### PR TITLE
Improve performance of array creation used in finding indices.

### DIFF
--- a/data/fvcom.py
+++ b/data/fvcom.py
@@ -106,9 +106,8 @@ class Fvcom(netcdf_data.NetCDFData):
             lonvals = lonvar[:] * RAD_FACTOR
             clat, clon = np.cos(latvals), np.cos(lonvals)
             slat, slon = np.sin(latvals), np.sin(lonvals)
-            triples = np.array(list(zip(np.ravel(clat * clon),
-                                        np.ravel(clat * slon),
-                                        np.ravel(slat))))
+            triples = np.array([np.ravel(clat * clon), np.ravel(clat * slon),
+                                np.ravel(slat)]).transpose()
             self._kdt[index] = KDTree(triples)
             del clat, clon
             del slat, slon

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -71,9 +71,8 @@ class Nemo(NetCDFData):
             lonvals = lonvar[:] * RAD_FACTOR
             clat, clon = np.cos(latvals), np.cos(lonvals)
             slat, slon = np.sin(latvals), np.sin(lonvals)
-            triples = np.array(list(zip(np.ravel(clat * clon),
-                                        np.ravel(clat * slon),
-                                        np.ravel(slat))))
+            triples = np.array([np.ravel(clat * clon), np.ravel(clat * slon),
+                                np.ravel(slat)]).transpose()
             self._kdt[latvar.name] = KDTree(triples)
             del clat, clon
             del slat, slon

--- a/oceannavigator/nearest_grid_point.py
+++ b/oceannavigator/nearest_grid_point.py
@@ -42,9 +42,8 @@ def find_nearest_grid_point(
     lonvals = lonvar[:] * rad_factor
     clat, clon = np.cos(latvals), np.cos(lonvals)
     slat, slon = np.sin(latvals), np.sin(lonvals)
-    triples = np.array(list(zip(np.ravel(clat * clon),
-                                np.ravel(clat * slon),
-                                np.ravel(slat))))
+    triples = np.array([np.ravel(clat * clon), np.ravel(clat * slon),
+                        np.ravel(slat)]).transpose()
     kdt = KDTree(triples)
     shape = latvar.shape
     dist_sq, iy, ix = find_index(lat, lon, kdt, shape, n)

--- a/plotting/grid.py
+++ b/plotting/grid.py
@@ -37,9 +37,8 @@ class Grid(object):
             lonvals = self.lonvar[:] * rad_factor
             clat, clon = np.cos(latvals), np.cos(lonvals)
             slat, slon = np.sin(latvals), np.sin(lonvals)
-            triples = np.array(list(zip(np.ravel(clat * clon),
-                                        np.ravel(clat * slon),
-                                        np.ravel(slat))))
+            triples = np.array([np.ravel(clat * clon), np.ravel(clat * slon),
+                                np.ravel(slat)]).transpose()
 
             self.kdt = KDTree(triples)
             _data_cache[ncfile.filepath()] = self.kdt


### PR DESCRIPTION
In my drift verification work, I profiled the Python code to check for performance bottlenecks. In the function where the k-d tree is set up (which is code borrowed from Ocean Navigator), approximately 80% of the time was spent in constructing the `triples` array. The offending statement was:
```
    triples = np.array(list(zip(np.ravel(clat * clon),
                                np.ravel(clat * slon),
                                np.ravel(slat))))
```
I rewrote that one statement as:
```
    triples = np.array([np.ravel(clat * clon), np.ravel(clat * slon),
                        np.ravel(slat)]).transpose()
```
Some quick tests showed that this resulted in a reduction of the time to construct the `triples` array by more than a factor of 40.