### PR TITLE
Lat / Lon variable fix for subsetting 

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -128,8 +128,8 @@ class NetCDFData(Data):
         variable_list = [v.key for v in self.variables]
 
         # Get lat/lon variable names from dataset (since they all differ >.>)
-        lat_var = find_variable("lat", variable_list)
-        lon_var = find_variable("lon", variable_list)
+        lat_var = find_variable("lat", list(self._dataset.variables.keys()))
+        lon_var = find_variable("lon", list(self._dataset.variables.keys()))
 
         depth_var = find_variable("depth", list(self._dataset.variables.keys()))
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -125,8 +125,6 @@ class NetCDFData(Data):
                     return key
             return None
 
-        variable_list = [v.key for v in self.variables]
-
         # Get lat/lon variable names from dataset (since they all differ >.>)
         lat_var = find_variable("lat", list(self._dataset.variables.keys()))
         lon_var = find_variable("lon", list(self._dataset.variables.keys()))


### PR DESCRIPTION
- Something with Geoff's code changes the list `variable_list` to not include the lat lon variables (I've no idea).

- This PR makes the subset function search through the superset of variable_list for the lat lon variables.