### PR TITLE
Make link customization panel expanded by default

### DIFF
--- a/oceannavigator/frontend/src/components/Permalink.jsx
+++ b/oceannavigator/frontend/src/components/Permalink.jsx
@@ -13,12 +13,12 @@ export default class Permalink extends React.Component {
     this.state = {
       center: true,
       projection: true,
-      basemap: true,
+      basemap: false,
       bathymetry: false,
-      dataset_compare: true,
+      dataset_compare: false,
       zoom: true,
       dataset: true,
-      dataset_1: true,
+      dataset_1: false,
       variable: true,
       depth: true,
       vectortype: true,
@@ -70,6 +70,7 @@ export default class Permalink extends React.Component {
         <br />
         <Panel
           collapsible
+          defaultExpanded
           header={_("Advanced")}
           bsStyle="warning"
         >


### PR DESCRIPTION
Our permalinks can get a little...large, so here's a workaround:

![image](https://user-images.githubusercontent.com/5572045/60176662-8f623000-97f1-11e9-90a8-a66844650fa3.png)
