### PR TITLE
Simplify quantum API endpoint

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -81,15 +81,8 @@ def quantum_query_v1_0():
     config = DatasetConfig(dataset)
 
     quantum = config.quantum
-    if quantum != 'split':
-        return jsonify(quantum)
-
-    if 'variable' not in args:
-        raise APIError(
-            "This dataset has multiple quantums, please specify a variable using &variable='...'")
-
-    variable = args.get('variable')
-    return jsonify(config.variable[variable].quantum)
+    
+    return jsonify(quantum)
 
 
 @bp_v1_0.route('/api/v1.0/variables/')

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -24,12 +24,12 @@ class TestAPIv1(unittest.TestCase):
                 "enabled": True,
                 "url": "tests/testdata/nemo_test.nc",
                 "time_dim_units": "seconds since 1950-01-01 00:00:00",
-                "quantum": "split",
+                "quantum": "day",
                 "name": "GIOPS",
                 "help": "help",
                 "attribution": "attrib",
                 "variables": {
-                    "votemper": {"name": "Temperature", "scale": [-5, 30], "units": "Kelvins", "quantum": "day"},
+                    "votemper": {"name": "Temperature", "scale": [-5, 30], "units": "Kelvins"},
                 }
             }
         }
@@ -151,15 +151,12 @@ class TestAPIv1(unittest.TestCase):
     def test_quantum_query(self, patch_get_dataset_config):
         patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
 
-        res = self.app.get('/api/v1.0/quantum/?dataset=giops&variable=votemper')
+        res = self.app.get('/api/v1.0/quantum/?dataset=giops')
 
         self.assertEqual(res.status_code, 200)
 
         res_data = self.__get_response_data(res)
         self.assertEqual(res_data, "day")
-
-        with self.assertRaises(APIError):
-            _ = self.app.get('/api/v1.0/quantum/?dataset=giops')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Remove logic for per-variable quantums.
* Fix test failure for quantum endpoint.

`tests/test_api_v_1_0.py` passes so I'm considering this good to go.