### PR TITLE
Fix crash in timestamps api endpoint

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -9,7 +9,7 @@ from data.fvcom import Fvcom
 from data.mercator import Mercator
 from data.nemo import Nemo
 from data.sqlite_database import SQLiteDatabase
-from data.utils import find_le, roll_time
+from data.utils import find_le, roll_time, get_data_vars_from_equation
 
 # We cannot cache by URL anymore since with the sqlite approach it points to a database
 # and the original cache system wasn't aware which individual NC files were opened.
@@ -95,10 +95,10 @@ def __get_nc_file_list(url: str, datasetconfig, **kwargs) -> List[str]:
 
         calculated_variables = datasetconfig.calculated_variables
         if variable[0] in calculated_variables:
-            regex = re.compile(r'[a-zA-Z][a-zA-Z_0-9]*')
             equation = calculated_variables[variable[0]]['equation']
-            variable = list(set(re.findall(regex, equation)) &
-                            set([v.key for v in db.get_data_variables()]))
+            
+            variable = get_data_vars_from_equation(
+                equation, [v.key for v in db.get_data_variables()])
 
         timestamp = __get_requested_timestamps(
             db, variable[0], kwargs['timestamp'], kwargs.get('endtime'), kwargs.get('nearest_timestamp', False))

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -596,7 +596,11 @@ class NetCDFData(Data):
     @property
     def timestamps(self):
         """
-        Loads, caches, and returns the time dimension from a dataset.
+            Loads, caches, and returns the values of the
+            time dimension for the open netcdf files.
+
+            Note: to get all timestamp values from a dataset,
+            you must query the SQLiteDatabase.
         """
         # If the timestamp cache is empty
         if self.__timestamp_cache.get("timestamps") is None:

--- a/data/utils.py
+++ b/data/utils.py
@@ -3,7 +3,9 @@
 import datetime
 import itertools
 import json
+import re
 from bisect import bisect_left, bisect_right
+from typing import List
 
 import cftime
 import numpy as np
@@ -38,6 +40,15 @@ def find_ge(a, x):
     if i != len(a):
         return a[i]
     return a[-1]
+
+
+def get_data_vars_from_equation(equation: str, data_variables: List[str]) -> List[str]:
+    regex = re.compile(r'[a-zA-Z][a-zA-Z_0-9]*')
+
+    variables = set(re.findall(regex, equation))
+    data_vars = set(data_variables)
+
+    return list(variables & data_vars)
 
 
 def datetime_to_timestamp(datetime: datetime.datetime, time_units: str):

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -29,7 +29,7 @@ class TestAPIv1(unittest.TestCase):
                 "help": "help",
                 "attribution": "attrib",
                 "variables": {
-                    "votemper": {"name": "Temperature", "scale": [-5, 30], "units": "Kelvins"},
+                    "votemper": {"name": "Temperature", "scale": [-5, 30], "units": "Kelvins", "equation": "votemper - 273.15"},
                 }
             }
         }
@@ -92,11 +92,13 @@ class TestAPIv1(unittest.TestCase):
         self.assertEqual(res_data[0]['value'], 'Bottom')
 
     @patch.object(DatasetConfig, "_get_dataset_config")
+    @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
     @patch('data.sqlite_database.SQLiteDatabase.get_timestamps')
-    def test_timestamps_endpoint(self, patch_get_all_timestamps, patch_get_dataset_config):
+    def test_timestamps_endpoint(self, patch_get_all_timestamps, patch_get_data_variables, patch_get_dataset_config):
 
         patch_get_all_timestamps.return_value = sorted(
             [2031436800, 2034072000])
+        patch_get_data_variables.return_value = self.patch_data_vars_ret_val
         patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
 
         res = self.app.get(

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -6,7 +6,8 @@ import unittest
 import numpy as np
 import pytz
 
-from data.utils import (datetime_to_timestamp, find_ge, find_le, roll_time,
+from data.utils import (datetime_to_timestamp, find_ge, find_le,
+                        get_data_vars_from_equation, roll_time,
                         time_index_to_datetime)
 
 
@@ -65,3 +66,11 @@ class TestDataUtils(unittest.TestCase):
         self.assertEqual(2145484800, find_ge(
             self.raw_timestamps, 2222222222))
         self.assertEqual(2144966400, find_ge(self.raw_timestamps, 0))
+
+    def test_get_data_vars_from_equation(self):
+        expected = sorted(["vosaline", "votemper"])
+
+        result = sorted(get_data_vars_from_equation(
+            "sspeed(depth, nav_lat, vosaline, votemper - 273.15)", ["vosaline", "votemper", "vozocrtx", "vomecrty"]))
+
+        self.assertEqual(expected, result)


### PR DESCRIPTION
### Problem
* Crashed when timestamps for a calculated variable were requested.

### Cause
* The key of the calculated variables was used in the timestamps sql query. Since the indexing tool only considers variables inside netcdf files, the resulting list was empty.

### Fix
* The API now checks against the `DatasetConfig.calculated_variables` property, and performs additional parsing of the calculated variable's equation to extract the data variables, and then performs the original sql query.

* Added a new helper function in the `data.utils` package called `get_data_vars_from_equation` to prevent code duplication in `__init__.py`.


`tests/test_data_utils.py` and `tests/test_api_v_1_0.py` pass so I'm considering this good to go.
