### PR TITLE
Fix crash when in compare mode for Area plots

### DIFF
--- a/plotting/map.py
+++ b/plotting/map.py
@@ -345,7 +345,7 @@ class MapPlotter(Plotter):
         if self.compare:
             self.variable_name += " Difference"
             compare_config = DatasetConfig(self.compare['dataset'])
-            with open_dataset(compare_config) as dataset:
+            with open_dataset(compare_config, variable=self.compare['variables'], timestamp=self.compare['time']) as dataset:
                 data = []
                 for v in self.compare['variables']:
                     var = dataset.variables[v]


### PR DESCRIPTION
Fixes #496

Tested on my local machine for GIOPS Daily:
![Screenshot at 2019-09-28 14-49-32](https://user-images.githubusercontent.com/5572045/65820065-32ff1a00-e1ff-11e9-836a-38c01dc3f3bc.png)

The colour scale is messed up, and there's no way to change it, but that's a separate issue.
