### PR TITLE
Implement `magnitude` calculation function

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -41,18 +41,18 @@ def min(arg):
 
 def magnitude(a, b):
     """
-    Calculates the magnitude of a and b using the following:
-    sqrt(a.dot(a) + b.dot(b))
+    Calculates the element-wise magnitude of a and b:
+    np.sqrt(a ** 2 + b ** 2). See:
+    https://en.wikipedia.org/wiki/Hadamard_product_(matrices)
 
     Paramters:
     a: ndarray
     b: ndarray
 
-    
     Returns:
         ndarray -- magnitude of a and b
     """
-    return np.sqrt(a.dot(a) + b.dot(b))
+    return np.sqrt(a ** 2 + b ** 2)
 
 
 def sspeed(depth, latitude, temperature, salinity):

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -134,17 +134,7 @@
                 "equation": "vozocrtx * sin_alpha + vomecrty * cos_alpha",
                 "zero_centered": "true"
             },
-            "vozocrte,vomecrtn": {
-                "hide": "false",
-                "name": "Water Velocity",
-                "scale": [
-                    0,
-                    3
-                ],
-                "scale_factor": 1,
-                "unit": "m/s",
-                "zero_centered": "true"
-            },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [-3, 3], "scale_factor": 1, "equation": "magnitude(vozocrtx * cos_alpha - vomecrty * sin_alpha, vozocrtx * sin_alpha + vomecrty * cos_alpha)" },
             "divergence": {
                 "hide": "false",
                 "name": "Water Divergence",
@@ -260,7 +250,7 @@
         "variables": {
             "vozocrtx": { "name": "Water X Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water Y Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "vozocrte,vomecrtn": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "scale_factor": 1 },
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [-3, 3], "scale_factor": 1, "equation": "magnitude(vozocrtx * cos_alpha - vomecrty * sin_alpha, vozocrtx * sin_alpha + vomecrty * cos_alpha)" },
             "votemper": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time_counter", "depth", "y", "x"] },
             "vosaline": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "sossheig": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3], "zero_centered": "true"  },

--- a/plotting/point.py
+++ b/plotting/point.py
@@ -1,12 +1,15 @@
+#!/usr/bin/env python
+
 import matplotlib.pyplot as plt
 import numpy as np
-import plotting.plotter as pl
-from netCDF4 import Dataset
-from oceannavigator import DatasetConfig
 import pint
+from netCDF4 import Dataset
+
+from plotting.plotter import Plotter
+from oceannavigator import DatasetConfig
 
 
-class PointPlotter(pl.Plotter):
+class PointPlotter(Plotter):
 
     def parse_query(self, query):
         super(PointPlotter, self).parse_query(query)

--- a/plotting/scale.py
+++ b/plotting/scale.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import re
 
 import numpy as np

--- a/plotting/stick.py
+++ b/plotting/stick.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python
+
 import matplotlib.pyplot as plt
 import numpy as np
 from flask_babel import gettext
 from matplotlib.dates import date2num
 
-from plotting.point import PointPlotter
 import plotting.utils as utils
 from data import open_dataset
+from plotting.point import PointPlotter
 
 
 class StickPlotter(PointPlotter):


### PR DESCRIPTION
* Creates a new `magnitude` function for the calculation layer. It computes the element-wise magnitude of two matrices (of equal shape). The magnitude function basically does the following:
https://en.wikipedia.org/wiki/Hadamard_product_(matrices)

* This will allow us to clean up the `if len(variables) == 2` checks throughout our code. Also, will be no need for comma-separated variable keys (i.e. instead of `vomecrty,vozocrtx`, we can have `magwatervel`).

* This PR enables the Water Velocity magnitude calculation for GIOPS Daily and Monthly only. If all goes well, RIOPS will be enabled shortly. Sea ice velocity will be enabled later too.

* OF NOTE: at this time, in order to computer the magnitude of two calculated variables, the equations of said variables must be used as arguments to the magnitude function. This is a limitation of the parser, where it doesn't recursively determine the equations or "root" variable keys. Use the `magwatervel` variables in `giops_day` or `giops_month`  `datasetconfig.json` as an example.

I've tested this on my local machine and it looks good:
![image](https://user-images.githubusercontent.com/5572045/66331431-1b194b80-e90d-11e9-93e1-aa09365c4160.png)

