### PR TITLE
Fix virtual mooring

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -135,11 +135,11 @@ class Data(object, metaclass=abc.ABCMeta):
     def get_timeseries_point(self, latitude, longitude, depth, starttime,
                              endtime, variable, return_depth=False):
         return self.get_point(latitude, longitude, depth,
-                              list(range(starttime, endtime + 1)),
+                              [starttime, endtime],
                               variable, return_depth=return_depth)
 
     def get_timeseries_profile(self, latitude, longitude, starttime,
                                endtime, variable):
         return self.get_profile(latitude, longitude,
-                                list(range(starttime, endtime + 1)),
+                                [starttime, endtime],
                                 variable)

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -43,7 +43,7 @@ class NetCDFData(Data):
         self._dataset_open: bool = False
         self._dataset_key: str = kwargs.get('dataset_key')
         self._dataset_config: DatasetConfig = DatasetConfig(
-            self._dataset_key)
+            self._dataset_key) if self._dataset_key else None
 
         super(NetCDFData, self).__init__(url)
 

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -556,7 +556,6 @@ export default class PointWindow extends React.Component {
             disabled={this.props.point[0][2] === undefined}
           >{_("Observation")}</NavItem>
           <NavItem
-            disabled
             eventKey={TabEnum.MOORING}>{_("Virtual Mooring")}</NavItem>
         </Nav>
         <Row>


### PR DESCRIPTION
The sqlite backend migration changed how datasets are "opened", so most of the plotting classes were broken. The initial merge had fixes for most plot types except for virtual mooring and stick plots.

I've also fixed the timeseries functions in data.py so that we don't construct a range from the timestamp values, and instead have a list of [start, end] from where we find the corresponding indices in the dataset's time dimension.

Given the small amount of test data I have, the results are identical to the same time range on the public site. I'll consider this good to go.

![image](https://user-images.githubusercontent.com/5572045/67855445-6df1b780-faf5-11e9-9984-8a325c56bf6a.png)
![image](https://user-images.githubusercontent.com/5572045/67855514-85c93b80-faf5-11e9-85c7-3c232d0e441a.png)
