### PR TITLE
Add Unittests for Sound Channel Calculations and SSCP

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -334,8 +334,9 @@ def slopeofsomething(depth, lat, temperature, salinity):
     for x in range(speed.shape[-1]):
         for y in range(speed.shape[-2]):
             speed_point = speed[:,y,x]
-            if count_numerical_vals(speed_point) != 0:
-                slope = slopeofsomething_point(speed_point, depth)
+            num = count_numerical_vals(speed_point)
+            if num != 0:
+                slope = slopeofsomething_point(speed_point[:num], depth[:num])
                 result[y,x] = slope
 
     return result

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -244,7 +244,9 @@ def sscp_point(sspeed, max_idx):
     Ensures:
     Returns either np.nan or 1
     """
-    channels = []
+    
+    print(something)
+
     for d in range(sspeed.shape[0]):
         if d is not 0 and d is not sspeed.shape[0] -1:
             idx = __is_min(sspeed[d-1], sspeed[d], sspeed[d+1])

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -248,9 +248,10 @@ def sscp_point(sspeed, max_idx):
     
     mins = argrelextrema(sspeed, np.less)
     if len(mins) > 1:
+        print(something)
         return 1
     else:
-        return np.nan
+        return 0
 
             
 def sscp(depth, lat, temperature,salinity):
@@ -282,7 +283,7 @@ def sscp(depth, lat, temperature,salinity):
                 speed_point = speed_point[:num]
                 result[y,x] = sscp_point(speed_point, max_depth)
             else:
-                result[y,x] = np.nan
+                result[y,x] = 0
 
     return result
                 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -246,7 +246,11 @@ def sscp_point(sspeed, max_idx):
     Returns either np.nan or 1
     """
     
-    print(something)
+    mins = argrelextrema(sspeed, np.less)
+    if len(mins) > 1:
+        return 1
+    else:
+        return np.nan
 
             
 def sscp(depth, lat, temperature,salinity):

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -303,7 +303,7 @@ def slopeofsomething_point(sspeed, depth):
     if temp_sspeed.shape[0] == 2:
         return np.nan
 
-    while sspeed.shape[0] >= 2:
+    while temp_sspeed.shape[0] >= 2:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_depth[:temp_depth.shape[0]-1]

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -350,7 +350,6 @@ def slopeofsomething(depth, lat, temperature, salinity):
                         slope = slopeofsomething_point(speed_point[:num], depth[:num])
                         result[y,x] = slope
 
-    print(something)
     return result
 
 def soundchannelaxis(depth, lat, temperature, salinity):

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -335,12 +335,12 @@ def slopeofsomething(depth, lat, temperature, salinity):
     for x in range(speed.shape[-1]):
         for y in range(speed.shape[-2]):
             speed_point = speed[:,y,x]
-            
-            sca_idx = find_sca_idx(speed_point)
-            sld_idx = find_sld_idx(sca_idx, speed_point)
-            speed_point = speed_point[sld_idx:sca_idx]
             num = count_numerical_vals(speed_point)
             if num != 0:
+                sca_idx = find_sca_idx(speed_point)
+                sld_idx = find_sld_idx(sca_idx, speed_point)
+                speed_point = speed_point[sld_idx:sca_idx]
+                num = count_numerical_vals(speed_point)
                 slope = slopeofsomething_point(speed_point[:num], depth[:num])
                 result[y,x] = slope
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -185,7 +185,7 @@ def cd_interpolation(cd_idx, sld_idx, speed_point, depth):
     speed_point: np.array of sound speed for a water column
     depth: np.array of available depths
     """
-
+    print("DEPTH: ", depth)
     # Now that we have the nearest critical depth idx we must perform linear interpolation
     def linearInterp(x1, y1, x2, y2, x):
         """

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -9,6 +9,7 @@ import seawater
 import xarray as xr
 from metpy.units import units
 from pint import UnitRegistry
+from scipy.signal import argrelextrema
 
 _ureg = UnitRegistry()
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -9,7 +9,7 @@ import seawater
 import xarray as xr
 from metpy.units import units
 from pint import UnitRegistry
-from scipy.signal import argrelextrema
+from scipy.signal import argrelextrema, lineregress
 
 _ureg = UnitRegistry()
 
@@ -285,7 +285,55 @@ def sscp(depth, lat, temperature,salinity):
                 result[y,x] = 0
 
     return result
-                
+
+def slopeofsomething_point(sspeed, depth):
+    """
+    Finds the slope of the subset before the change in slope becomes too positvie
+    => Threshold must still be determined
+
+    Parameters:
+    sspeed: Speed of sound subsetted from Sonic Layer Depth to Sound Channel Axis of a sound channel
+    depth: Depth layers subsetted using the criteria as sspeed
+    """
+
+    temp_sspeed = sspeed
+    temp_depth = depth
+    previous_slope, intercept, r_value, p_value, std_err = linregress(x, y)
+
+    while True:
+
+        temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
+        temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
+
+        new_slope, intercept, r_value, p_value, std_err = linregress(x, y)
+
+        # Determine breaking condition
+        if previous_slope - new_slope < 0:
+            break
+
+        previous_slope = new_slope
+
+def slopeofsomething(depth, lat, temperature, salinity):
+    """
+    Find the slope of the change in sound speed after the sonic layer depth
+
+    Parameters:
+    depth: The depth(s) in meters
+    lat: The latitudes(s) in degrees North
+    temperature: The temperatures(s) (at all depths) in celsius
+    salinity: The salinity (at all depths) (unitless)
+    """
+
+    speed = sspeed(depth, lat, temperature, salinity)
+    result = np.empty((speed.shape[-2], speed.shape[-1]))
+
+    for x in range(speed.shape[-1]):
+        for y in range(speed.shape[-2]):
+            speed_point = speed[:,y,x]
+            if count_numerical_vals(speed_point) != 0:
+                # Do stuff here
+                pass
+
 def soundchannelaxis(depth, lat, temperature, salinity):
     """
     Finds the global minimum of the speed of sound

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -247,7 +247,7 @@ def sscp_point(sspeed, max_idx):
     """
     
     mins = argrelextrema(sspeed, np.less)
-    if len(mins) > 1:
+    if len(mins) > 0:
         print(something)
         return 1
     else:

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -335,6 +335,10 @@ def slopeofsomething(depth, lat, temperature, salinity):
     for x in range(speed.shape[-1]):
         for y in range(speed.shape[-2]):
             speed_point = speed[:,y,x]
+            
+            sca_idx = find_sca_idx(speed_point)
+            sld_idx = find_sld_idx(sca_idx, speed_point)
+            speed_point = speed_point[sld_idx:sca_idx]
             num = count_numerical_vals(speed_point)
             if num != 0:
                 slope = slopeofsomething_point(speed_point[:num], depth[:num])

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -246,6 +246,7 @@ def sscp_point(sspeed, max_idx):
     Returns either np.nan or 1
     """
     
+    # Finds all local minima in sspeed
     mins = argrelextrema(sspeed, np.less)
     if len(mins[0]) >= 2:
         return 1

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -310,7 +310,9 @@ def slopeofsomething_point(sspeed, depth):
         # Determine breaking condition
         if previous_slope - new_slope < 0:
             return previous_slope
-
+        elif temp_sspeed.shape[0] = 2:
+            return np.nan
+        
         previous_slope = new_slope
 
     return np.nan

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -304,11 +304,12 @@ def slopeofsomething_point(sspeed, depth):
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
-
+        if np.isnan(np.min(temp_sspeed)) or np.isnan(np.min(temp_depth)):
+            print(something)
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
 
         # Determine breaking condition
-        if previous_slope - new_slope < 0:
+        if previous_slope - new_slope < 0.5:
             return previous_slope
         elif temp_sspeed.shape[0] == 2:
             return np.nan

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -337,7 +337,6 @@ def slopeofsomething(depth, lat, temperature, salinity):
             speed_point = speed[:,y,x]
             num = count_numerical_vals(speed_point)
             if num != 0:
-                print(something)
                 sca_idx = find_sca_idx(speed_point)
                 if np.isnan(sca_idx):
                     return sca_idx

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -296,7 +296,6 @@ def slopeofsomething_point(sspeed, depth):
     depth: Depth layers subsetted using the criteria as sspeed
     """
 
-
     temp_sspeed = sspeed
     temp_depth = depth
     previous_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -338,17 +338,18 @@ def slopeofsomething(depth, lat, temperature, salinity):
             if num != 0:
                 sca_idx = find_sca_idx(speed_point)
                 if np.isnan(sca_idx):
-                    return sca_idx
+                    return np.nan
                 
                 sld_idx = find_sld_idx(sca_idx, speed_point)
                 if np.isnan(sld_idx):
-                    return sld_idx
+                    return np.nan
                 
                 speed_point = speed_point[sld_idx:sca_idx]
                 num = count_numerical_vals(speed_point)
                 slope = slopeofsomething_point(speed_point[:num], depth[:num])
                 result[y,x] = slope
 
+    print(something)
     return result
 
 def soundchannelaxis(depth, lat, temperature, salinity):

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -9,8 +9,8 @@ import seawater
 import xarray as xr
 from metpy.units import units
 from pint import UnitRegistry
-from scipy.signal import argrelextrema, linregress
-
+from scipy.signal import argrelextrema
+from scipy.stats import linregress
 _ureg = UnitRegistry()
 
 # All functions in this file (that do not start with an underscore) will be

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -301,13 +301,13 @@ def slopeofsomething_point(sspeed, depth):
     previous_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
     if temp_sspeed.shape[0] == 2:
         return np.nan
-        
+
     while True:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
-
+        print(something)
         # Determine breaking condition
         if previous_slope - new_slope < 0.5:
             return previous_slope

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -9,7 +9,7 @@ import seawater
 import xarray as xr
 from metpy.units import units
 from pint import UnitRegistry
-from scipy.signal import argrelextrema, lineregress
+from scipy.signal import argrelextrema, linregress
 
 _ureg = UnitRegistry()
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -309,7 +309,7 @@ def slopeofsomething_point(sspeed, depth):
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
         print(something)
         # Determine breaking condition
-        if previous_slope - new_slope < 0.5:
+        if previous_slope - new_slope > -0.1:
             return previous_slope
         elif temp_sspeed.shape[0] == 2:
             return np.nan

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -298,14 +298,14 @@ def slopeofsomething_point(sspeed, depth):
 
     temp_sspeed = sspeed
     temp_depth = depth
-    previous_slope, intercept, r_value, p_value, std_err = linregress(x, y)
+    previous_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
 
     while True:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
 
-        new_slope, intercept, r_value, p_value, std_err = linregress(x, y)
+        new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
 
         # Determine breaking condition
         if previous_slope - new_slope < 0:

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -305,7 +305,7 @@ def slopeofsomething_point(sspeed, depth):
     while True:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
-        temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
+        temp_depth = temp_depth[:temp_depth.shape[0]-1]
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
         print(something)
         # Determine breaking condition

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -339,7 +339,13 @@ def slopeofsomething(depth, lat, temperature, salinity):
             if num != 0:
                 print(something)
                 sca_idx = find_sca_idx(speed_point)
+                if np.isnan(sca_idx):
+                    return sca_idx
+                
                 sld_idx = find_sld_idx(sca_idx, speed_point)
+                if np.isnan(idx):
+                    return sld_idx
+                
                 speed_point = speed_point[sld_idx:sca_idx]
                 num = count_numerical_vals(speed_point)
                 slope = slopeofsomething_point(speed_point[:num], depth[:num])

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -248,7 +248,6 @@ def sscp_point(sspeed, max_idx):
     
     mins = argrelextrema(sspeed, np.less)
     if len(mins[0]) > 2:
-        print(something)
         return 1
     else:
         return 0

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -248,19 +248,6 @@ def sscp_point(sspeed, max_idx):
     
     print(something)
 
-    for d in range(sspeed.shape[0]):
-        if d is not 0 and d is not sspeed.shape[0] -1:
-            idx = __is_min(sspeed[d-1], sspeed[d], sspeed[d+1])
-            if not np.isnan(idx):
-                channels.append(idx)
-                if len(channels) > 1:
-                    break
-
-    if len(channels) > 1:
-        if channels[0] < max_idx:
-            return 1
-
-    return np.nan
             
 def sscp(depth, lat, temperature,salinity):
     """

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -342,7 +342,7 @@ def slopeofsomething(depth, lat, temperature, salinity):
                     return sca_idx
                 
                 sld_idx = find_sld_idx(sca_idx, speed_point)
-                if np.isnan(idx):
+                if np.isnan(sld_idx):
                     return sld_idx
                 
                 speed_point = speed_point[sld_idx:sca_idx]

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -337,6 +337,7 @@ def slopeofsomething(depth, lat, temperature, salinity):
             speed_point = speed[:,y,x]
             num = count_numerical_vals(speed_point)
             if num != 0:
+                print(something)
                 sca_idx = find_sca_idx(speed_point)
                 sld_idx = find_sld_idx(sca_idx, speed_point)
                 speed_point = speed_point[sld_idx:sca_idx]

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -310,7 +310,7 @@ def slopeofsomething_point(sspeed, depth):
         # Determine breaking condition
         if previous_slope - new_slope < 0:
             return previous_slope
-        elif temp_sspeed.shape[0] = 2:
+        elif temp_sspeed.shape[0] == 2:
             return np.nan
         
         previous_slope = new_slope

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -247,7 +247,7 @@ def sscp_point(sspeed, max_idx):
     """
     
     mins = argrelextrema(sspeed, np.less)
-    if len(mins[0]) > 2:
+    if len(mins[0]) >= 2:
         return 1
     else:
         return 0

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -333,7 +333,7 @@ def slopeofsomething(depth, lat, temperature, salinity):
         for y in range(speed.shape[-2]):
             speed_point = speed[:,y,x]
             if count_numerical_vals(speed_point) != 0:
-                slope = slopeofsomething_point(sspeed, depth)
+                slope = slopeofsomething_point(speed_point, depth)
                 result[y,x] = slope
 
     return result

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -185,7 +185,7 @@ def cd_interpolation(cd_idx, sld_idx, speed_point, depth):
     speed_point: np.array of sound speed for a water column
     depth: np.array of available depths
     """
-    print("DEPTH: ", depth)
+    
     # Now that we have the nearest critical depth idx we must perform linear interpolation
     def linearInterp(x1, y1, x2, y2, x):
         """

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -338,11 +338,11 @@ def slopeofsomething(depth, lat, temperature, salinity):
             if num != 0:
                 sca_idx = find_sca_idx(speed_point)
                 if np.isnan(sca_idx):
-                    return np.nan
+                    result[y,x] = np.nan
                 
                 sld_idx = find_sld_idx(sca_idx, speed_point)
                 if np.isnan(sld_idx):
-                    return np.nan
+                    result[y,x] = np.nan
                 
                 speed_point = speed_point[sld_idx:sca_idx]
                 num = count_numerical_vals(speed_point)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -296,13 +296,14 @@ def slopeofsomething_point(sspeed, depth):
     depth: Depth layers subsetted using the criteria as sspeed
     """
 
+
     temp_sspeed = sspeed
     temp_depth = depth
     previous_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
     if temp_sspeed.shape[0] == 2:
         return np.nan
 
-    while True:
+    while sspeed.shape[0] >= 2:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_depth[:temp_depth.shape[0]-1]
@@ -310,8 +311,8 @@ def slopeofsomething_point(sspeed, depth):
         # Determine breaking condition
         if previous_slope - new_slope > -0.1:
             return previous_slope
-        elif temp_sspeed.shape[0] == 2:
-            return np.nan
+        #elif temp_sspeed.shape[0] == 2:
+        #    return np.nan
         
         previous_slope = new_slope
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -309,9 +309,11 @@ def slopeofsomething_point(sspeed, depth):
 
         # Determine breaking condition
         if previous_slope - new_slope < 0:
-            break
+            return previous_slope
 
         previous_slope = new_slope
+
+    return np.nan
 
 def slopeofsomething(depth, lat, temperature, salinity):
     """
@@ -331,8 +333,10 @@ def slopeofsomething(depth, lat, temperature, salinity):
         for y in range(speed.shape[-2]):
             speed_point = speed[:,y,x]
             if count_numerical_vals(speed_point) != 0:
-                # Do stuff here
-                pass
+                slope = slopeofsomething_point(sspeed, depth)
+                result[y,x] = slope
+
+    return result
 
 def soundchannelaxis(depth, lat, temperature, salinity):
     """

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -299,13 +299,13 @@ def slopeofsomething_point(sspeed, depth):
     temp_sspeed = sspeed
     temp_depth = depth
     previous_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
-
+    if temp_sspeed.shape[0] == 2:
+        return np.nan
+        
     while True:
 
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_sspeed[:temp_depth.shape[0]-1]
-        if np.isnan(np.min(temp_sspeed)) or np.isnan(np.min(temp_depth)):
-            print(something)
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
 
         # Determine breaking condition

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -339,15 +339,15 @@ def slopeofsomething(depth, lat, temperature, salinity):
                 sca_idx = find_sca_idx(speed_point)
                 if np.isnan(sca_idx):
                     result[y,x] = np.nan
-                
-                sld_idx = find_sld_idx(sca_idx, speed_point)
-                if np.isnan(sld_idx):
-                    result[y,x] = np.nan
-                
-                speed_point = speed_point[sld_idx:sca_idx]
-                num = count_numerical_vals(speed_point)
-                slope = slopeofsomething_point(speed_point[:num], depth[:num])
-                result[y,x] = slope
+                else:
+                    sld_idx = find_sld_idx(sca_idx, speed_point)
+                    if np.isnan(sld_idx):
+                        result[y,x] = np.nan
+                    else:
+                        speed_point = speed_point[sld_idx:sca_idx]
+                        num = count_numerical_vals(speed_point)
+                        slope = slopeofsomething_point(speed_point[:num], depth[:num])
+                        result[y,x] = slope
 
     print(something)
     return result

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -307,7 +307,6 @@ def slopeofsomething_point(sspeed, depth):
         temp_sspeed = temp_sspeed[:temp_sspeed.shape[0]-1]
         temp_depth = temp_depth[:temp_depth.shape[0]-1]
         new_slope, intercept, r_value, p_value, std_err = linregress(temp_sspeed, temp_depth)
-        print(something)
         # Determine breaking condition
         if previous_slope - new_slope > -0.1:
             return previous_slope

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -247,7 +247,7 @@ def sscp_point(sspeed, max_idx):
     """
     
     mins = argrelextrema(sspeed, np.less)
-    if len(mins) > 0:
+    if len(mins[0]) > 2:
         print(something)
         return 1
     else:

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -269,7 +269,7 @@
             "soniclayerdepth": {"name": "Sonic Layer Depth (BETA)", "scale": [0,1000], "scale_factor": 1, "unit": "m", "equation": "soniclayerdepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
-            "sscp": {"name": "Secondary Sound Channel Potential (Above 1000m)", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
+            "sscp": {"name": "Secondary Sound Channel Potential", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "slope": {"name": "Slope (TEST)", "scale": [0,10], "scale_factor": 1, "unit": "Hz", "equation": "slopeofsomething(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "vorticity": { "name": "Water Vorticity", "scale": [-50, 50], "scale_factor": 1e6, "unit": "1/10^6 s", "equation": "vorticity(vozocrtx, vomecrty, nav_lat, nav_lon)", "zero_centered": "true" }
         }

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -270,6 +270,7 @@
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "sscp": {"name": "Secondary Sound Channel Potential (Above 1000m)", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
+            "slope": {"name": "Slope (TEST)", "scale": [0,10], "scale_factor": 1, "unit": "Hz", "equation": "slopeofsomething(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "vorticity": { "name": "Water Vorticity", "scale": [-50, 50], "scale_factor": 1e6, "unit": "1/10^6 s", "equation": "vorticity(vozocrtx, vomecrty, nav_lat, nav_lon)", "zero_centered": "true" }
         }
     },

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -270,7 +270,6 @@
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "sscp": {"name": "Secondary Sound Channel Potential", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
-            "slope": {"name": "Slope (TEST)", "scale": [0,10], "scale_factor": 1, "unit": "Hz", "equation": "slopeofsomething(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "vorticity": { "name": "Water Vorticity", "scale": [-50, 50], "scale_factor": 1e6, "unit": "1/10^6 s", "equation": "vorticity(vozocrtx, vomecrty, nav_lat, nav_lon)", "zero_centered": "true" }
         }
     },
@@ -297,6 +296,7 @@
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "soniclayerdepth": {"name": "Sonic Layer Depth (BETA)", "scale": [0,1000], "scale_factor": 1, "unit": "m", "equation": "soniclayerdepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},       
+            "sscp": {"name": "Secondary Sound Channel Potential", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "sossheig": { "name": "Sea Surface Height", "unit": "m", "scale": [-3, 3], "zero_centered": "true", "quantum": "hour" },
             "iiceconc": { "name": "Ice Concentration", "unit": "fraction", "scale": [0, 1], "quantum": "hour" },
             "iicevol": { "name": "Ice Volume",        "unit": "m", "scale": [0, 10], "quantum": "hour" },
@@ -679,6 +679,7 @@
             "soundchannelaxis": {"name": "Sound Channel Axis (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "soundchannelaxis(~depth, latitude, ~votemper - 273.15, ~vosaline)"},
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "soniclayerdepth": {"name": "Sonic Layer Depth (BETA)", "scale": [0,1000], "scale_factor": 1, "unit": "m", "equation": "soniclayerdepth(~depth, latitude, ~votemper - 273.15, ~vosaline)"},
+            "sscp": {"name": "Secondary Sound Channel Potential", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, latitude, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, latitude, ~votemper - 273.15, ~vosaline)"}        
         }
     },
@@ -917,6 +918,7 @@
             "soundchannelaxis": {"name": "Sound Channel Axis (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "soundchannelaxis(~depth, latitude, ~votemper - 273.15, ~vosaline)"},
             "soniclayerdepth": {"name": "Sonic Layer Depth (BETA)", "scale": [0,1000], "scale_factor": 1, "unit": "m", "equation": "soniclayerdepth(~depth, latitude, ~votemper - 273.15, ~vosaline)"},
             "criticaldepth": {"name": "Sound Channel Bottom", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "criticaldepth(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
+            "sscp": {"name": "Secondary Sound Channel Potential", "scale": [0, 1], "scale_factor": 1, "unit": "m", "equation": "sscp(~depth, nav_lat, ~votemper - 273.15, ~vosaline)"},
             "depthexcess": {"name": "Depth Excess (BETA)", "scale": [0, 1000], "scale_factor": 1, "unit": "m", "equation": "depthexcess(~depth, latitude, ~votemper - 273.15, ~vosaline)"}            
             }
     },

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -33,6 +33,15 @@ class TestFunctions(unittest.TestCase):
         test_result = find_sld_idx(sca_idx, test_array)
         self.assertEqual(test_result, 2)
 
+
+    def test_find_cd_idx(self):
+        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sca_idx = 6
+        sld_idx = 2
+
+        test_result = find_cd_idx(sca_idx, sld_idx, test_array)
+        self.assertEqual(test_result, 10)
+
     #def test_soundchannelaxis(self):
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,4 @@
-from data/calculated_parser/functions.py import *
+from data.calculated_parser/functions.py import *
 import numpy as np
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -42,7 +42,7 @@ class TestFunctions(unittest.TestCase):
         # Testing 2 sound channels, 2 critical depths
         sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         
-        test_result = find_sca_idx(sspeed_3)
+        test_result = find_sca_idx(sspeed_4)
         self.assertEqual(test_result, 6)
 
     def test_find_sld_idx(self):
@@ -72,7 +72,7 @@ class TestFunctions(unittest.TestCase):
         sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         sca_idx = 6
 
-        test_result = find_sld_idx(sca_idx, sspeed_3)
+        test_result = find_sld_idx(sca_idx, sspeed_4)
         self.assertEqual(test_result, 3)
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
-from .data.calculated_parser.function.py import *
+from data.calculated_parser.function.py import *
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -111,16 +111,16 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(test_result, 10)
         
 
-    def test_cd_interpolation(self):
+    #def test_cd_interpolation(self):
     
         # Testing Typical sspeed profile
-        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
-        cd_idx = 10
-        sld_idx = 2
-        depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
+        #sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        #cd_idx = 10
+        #sld_idx = 2
+        #depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
         
-        test_result = cd_interpolation(cd_idx, sld_idx, sspeed_1, depth)
-        self.assertEqual(test_result, 10)
+        #test_result = cd_interpolation(cd_idx, sld_idx, sspeed_1, depth)
+        #self.assertEqual(test_result, 10)
     
         # Testing immediately declining sspeed profile
         #sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
-from data.calculated_parser.function.py import *
+from data.calculated_parser.functions import *
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -30,7 +30,7 @@ class TestFunctions(unittest.TestCase):
         test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         sca_idx = 6
 
-        test_result = find_sld_idx(test_array, sca_idx)
+        test_result = find_sld_idx(sca_idx, test_array)
         self.assertEqual(test_result, 2)
 
     #def test_soundchannelaxis(self):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -138,15 +138,6 @@ class TestFunctions(unittest.TestCase):
         #sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         
 
-    def test_soundchannelaxis(self):
-        depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
-        lat = np.array([])
-        temperature = np.array([])
-        salinity = np.array([])
-
-        test_result = soundchannelaxis(depth, lat, temperature, salinity)
-        self.assertEqual()
-
     #def test_soniclayerdepth(self):
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,8 +1,11 @@
+#!/usr/bin/env python
+
 import numpy as np
+
 
 class TestFunctions(unittest.TestCase):
 
-    def test_sspeed(self):
+    #def test_sspeed(self):
         
     
     def test_sscp_point(self):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,32 @@
+from data/calculated_parser/functions.py import *
+import numpy as np
+
+class TestFunctions(unittest.TestCase):
+
+    def test_sspeed(self):
+        
+    
+    def test_sscp_point(self):
+        test_array = np.array[1434.08,1435.48,1436.10,1435.16,1433.01,1432.80,1432.54,1432.75,1433.20,1434.92,1435.81]
+        test_max = 11
+
+        test_result = sscp_point(test_array, test_max)
+        self.assertEqual(test_result, 0)
+
+    #def test_sscp(self):
+
+
+    #def test_soundchannelaxis(self):
+
+
+    #def test_soniclayerdepth(self):
+
+
+    #def test_criticaldepth(self):
+
+
+    #def test_depthexcess(self):
+
+
+    
+        

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -10,14 +10,28 @@ class TestFunctions(unittest.TestCase):
         
     
     def test_sscp_point(self):
-        test_array = np.array([1434.08,1435.48,1436.10,1435.16,1433.01,1432.80,1432.54,1432.75,1433.20,1434.92,1435.81])
-        test_max = 11
+        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        test_max = 13
 
         test_result = sscp_point(test_array, test_max)
         self.assertEqual(test_result, 0)
 
     #def test_sscp(self):
 
+
+    def test_find_sca_idx(self):
+        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        
+        test_result = find_sca_idx(test_array)
+        self.assertEqual(test_result, 6)
+
+
+    def test_find_sld_idx(self):
+        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sca_idx = 6
+
+        test_result = find_sld_idx(test_array, sca_idx)
+        self.assertEqual(test_result, 2)
 
     #def test_soundchannelaxis(self):
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -10,46 +10,101 @@ class TestFunctions(unittest.TestCase):
         
     
     def test_sscp_point(self):
-        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         test_max = 13
 
-        test_result = sscp_point(test_array, test_max)
+        test_result = sscp_point(sspeed_1, test_max)
         self.assertEqual(test_result, 0)
 
     #def test_sscp(self):
 
 
     def test_find_sca_idx(self):
-        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         
-        test_result = find_sca_idx(test_array)
+        test_result = find_sca_idx(sspeed_1)
         self.assertEqual(test_result, 6)
 
+        sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        test_result = find_sca_idx(sspeed_2)
+        self.assertEqual(test_result, 3)
 
     def test_find_sld_idx(self):
-        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         sca_idx = 6
 
-        test_result = find_sld_idx(sca_idx, test_array)
+        test_result = find_sld_idx(sca_idx, sspeed_1)
         self.assertEqual(test_result, 2)
+
+        sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        sca_idx = 3
+
+        test_result = find_sld_idx(sca_idx, sspeed_2)
+        self.assertEqual(test_result, 0)
 
 
     def test_find_cd_idx(self):
-        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+
+        # Testing Typical sspeed profile
+        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         sca_idx = 6
         sld_idx = 2
 
-        test_result = find_cd_idx(sca_idx, sld_idx, test_array)
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_1)
         self.assertEqual(test_result, 10)
+        
+        # Testing immediately declining sspeed profile
+        sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        sca_idx = 3
+        sld_idx = 0
+
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_2)
+        self.assertEqual(test_result, 10)
+
+        # Testing 2 sound channels, single critical depth
+        sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
+        sca_idx = 6
+        sld_idx = 3
+
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 11)
+        
+        # Testing 2 sound channels, 2 critical depths
+        sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
+        sca_idx = 7
+        sld_idx = 0
+
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 11)
+        
 
     def test_cd_interpolation(self):
-
-        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+    
+        # Testing Typical sspeed profile
+        sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         cd_idx = 10
         sld_idx = 2
-
-        test_result = cd_interpolation(cd_idx, sld_idx, test_array, depth)
+        depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
+        
+        test_result = cd_interpolation(cd_idx, sld_idx, sspeed_1, depth)
         self.assertEqual(test_result, 10)
+    
+        # Testing immediately declining sspeed profile
+        #Qsspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        #cd_idx = 10
+        #Wsld_idx = 0
+
+        #test_result = cd_interpolation(cd_idx, sld_idx, sspeed_2, depth)
+        #self.assertEqual(test_result, 10)
+
+        #sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
+        #sld_idx = 3
+        #cd_idx = 10
+
+        
+        #sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
+        
+
     #def test_soundchannelaxis(self):
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+from data/calculated_parser/function.py import *
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,3 @@
-from data.calculated_parser/functions.py import *
 import numpy as np
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -9,7 +9,7 @@ class TestFunctions(unittest.TestCase):
         
     
     def test_sscp_point(self):
-        test_array = np.array[1434.08,1435.48,1436.10,1435.16,1433.01,1432.80,1432.54,1432.75,1433.20,1434.92,1435.81]
+        test_array = np.array([1434.08,1435.48,1436.10,1435.16,1433.01,1432.80,1432.54,1432.75,1433.20,1434.92,1435.81])
         test_max = 11
 
         test_result = sscp_point(test_array, test_max)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -138,8 +138,14 @@ class TestFunctions(unittest.TestCase):
         #sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         
 
-    #def test_soundchannelaxis(self):
+    def test_soundchannelaxis(self):
+        depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
+        lat = 
+        temperature = np.array([])
+        salinity = np.array([])
 
+        test_result = soundchannelaxis(depth, lat, temperature, salinity)
+        self.assertEqual()
 
     #def test_soniclayerdepth(self):
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
-from data/calculated_parser/function.py import *
+from .data.calculated_parser.function.py import *
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -107,7 +107,7 @@ class TestFunctions(unittest.TestCase):
         sca_idx = 6
         sld_idx = 3
 
-        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_4)
         self.assertEqual(test_result, 10)
         
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -36,13 +36,13 @@ class TestFunctions(unittest.TestCase):
         # Testing 2 sound channels, single critical depth
         sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
         
-        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        test_result = find_sca_idx(sspeed_3)
         self.assertEqual(test_result, 7)
         
         # Testing 2 sound channels, 2 critical depths
         sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         
-        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        test_result = find_sca_idx(sspeed_3)
         self.assertEqual(test_result, 6)
 
     def test_find_sld_idx(self):
@@ -65,14 +65,14 @@ class TestFunctions(unittest.TestCase):
         sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
         sca_idx = 7
 
-        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        test_result = find_sld_idx(sca_idx, sspeed_3)
         self.assertEqual(test_result, 0)
         
         # Testing 2 sound channels, 2 critical depths
         sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
         sca_idx = 6
 
-        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        test_result = find_sld_idx(sca_idx, sspeed_3)
         self.assertEqual(test_result, 3)
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import unittest
 import numpy as np
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -140,7 +140,7 @@ class TestFunctions(unittest.TestCase):
 
     def test_soundchannelaxis(self):
         depth = np.array([0, 10, 30, 60, 100, 150, 210, 280, 360, 460, 560, 670, 790])
-        lat = 
+        lat = np.array([])
         temperature = np.array([])
         salinity = np.array([])
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -11,11 +11,22 @@ class TestFunctions(unittest.TestCase):
     
     def test_sscp_point(self):
         sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
+        sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
+        
         test_max = 13
 
-        test_result = sscp_point(sspeed_1, test_max)
-        self.assertEqual(test_result, 0)
-
+        result_1 = sscp_point(sspeed_1, test_max)
+        result_2 = sscp_point(sspeed_2, test_max)
+        result_3 = sscp_point(sspeed_3, test_max)
+        result_4 = sscp_point(sspeed_4, test_max)
+        
+        self.assertEqual(result_1, 0)
+        self.assertEqual(result_2, 0)
+        self.assertEqual(result_3, 1)
+        self.assertEqual(result_4, 1)
+        
     #def test_sscp(self):
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -42,6 +42,14 @@ class TestFunctions(unittest.TestCase):
         test_result = find_cd_idx(sca_idx, sld_idx, test_array)
         self.assertEqual(test_result, 10)
 
+    def test_cd_interpolation(self):
+
+        test_array = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
+        cd_idx = 10
+        sld_idx = 2
+
+        test_result = cd_interpolation(cd_idx, sld_idx, test_array, depth)
+        self.assertEqual(test_result, 10)
     #def test_soundchannelaxis(self):
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -20,27 +20,60 @@ class TestFunctions(unittest.TestCase):
 
 
     def test_find_sca_idx(self):
+
+        # Testing Typical sspeed profile
         sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         
         test_result = find_sca_idx(sspeed_1)
         self.assertEqual(test_result, 6)
 
+        # Testing immediately declining sspeed profile
         sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        
         test_result = find_sca_idx(sspeed_2)
         self.assertEqual(test_result, 3)
 
+        # Testing 2 sound channels, single critical depth
+        sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
+        
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 7)
+        
+        # Testing 2 sound channels, 2 critical depths
+        sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
+        
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 6)
+
     def test_find_sld_idx(self):
+        
+        # Testing Typical sspeed profile
         sspeed_1 = np.array([1434.08, 1435.48, 1436.10, 1435.16, 1433.01, 1432.80, 1432.54, 1432.75, 1433.20, 1434.92, 1435.81, 1436.80, 1437.91])
         sca_idx = 6
 
         test_result = find_sld_idx(sca_idx, sspeed_1)
         self.assertEqual(test_result, 2)
 
+        # Testing immediately declining sspeed profile
         sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
         sca_idx = 3
 
         test_result = find_sld_idx(sca_idx, sspeed_2)
         self.assertEqual(test_result, 0)
+
+        # Testing 2 sound channels, single critical depth
+        sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
+        sca_idx = 7
+
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 0)
+        
+        # Testing 2 sound channels, 2 critical depths
+        sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
+        sca_idx = 6
+
+        test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
+        self.assertEqual(test_result, 3)
 
 
     def test_find_cd_idx(self):
@@ -63,19 +96,19 @@ class TestFunctions(unittest.TestCase):
 
         # Testing 2 sound channels, single critical depth
         sspeed_3 = np.array([1437.32, 1436.70, 1435.45, 1433.97, 1436.16, 1435.27, 1433.81, 1433.11, 1433.79, 1434.98, 1436.29, 1437.16, 1438.12])
-        sca_idx = 6
-        sld_idx = 3
+        sca_idx = 7
+        sld_idx = 0
 
         test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
         self.assertEqual(test_result, 11)
         
         # Testing 2 sound channels, 2 critical depths
         sspeed_4 = np.array([1435.76, 1434.12, 1434.98, 1436.27, 1434.51, 1433.97, 1433.49, 1433.67, 1435.09, 1435.98, 1436.12, 1437.41, 1438.19])
-        sca_idx = 7
-        sld_idx = 0
+        sca_idx = 6
+        sld_idx = 3
 
         test_result = find_cd_idx(sca_idx, sld_idx, sspeed_3)
-        self.assertEqual(test_result, 11)
+        self.assertEqual(test_result, 10)
         
 
     def test_cd_interpolation(self):
@@ -90,7 +123,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(test_result, 10)
     
         # Testing immediately declining sspeed profile
-        #Qsspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
+        #sspeed_2 = np.array([1436.17, 1435.52, 1434.81, 1433.56, 1433.90, 1434.18, 1434.75, 1435.00, 1435.63, 1435.99, 1436.28, 1436.61, 1437.12])
         #cd_idx = 10
         #Wsld_idx = 0
 


### PR DESCRIPTION
Adds Unittests for the point functions for each of the sound speed calculations.
This means that it's testing that the correct value is being selected from the profile, but is not testing the looping through each profile.

This also adds sscp which is the possibility of a secondary sound channel at that point, and is either 0 if their isn't a possibility, or 1 if their is a possibility.
(This also has tests)