### PR TITLE
Fix virtual mooring crash

### DIFF
--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -109,7 +109,9 @@ class TimeseriesPlotter(PointPlotter):
                 if factor != 1.0:
                     point_data[idx] = np.multiply(point_data[idx], factor)
 
-            times = dataset.timestamps[self.starttime:self.endtime + 1]
+            starttime_idx = dataset.timestamp_to_time_index(self.starttime)
+            endtime_idx = dataset.timestamp_to_time_index(self.endtime)
+            times = dataset.timestamps[starttime_idx : endtime_idx + 1]
             if self.query.get('dataset_quantum') == 'month':
                 times = [datetime.date(x.year, x.month, 1) for x in times]
 


### PR DESCRIPTION
* The time indexing was wrong. Not sure how I missed that.

Resulting plot:
![image](https://user-images.githubusercontent.com/5572045/68303070-b2dd9700-007d-11ea-8f43-e03fbad55eb0.png)
