### PR TITLE
fixed colourmap url

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -570,7 +570,7 @@ export default class AreaWindow extends React.Component {
           state={this.state.leftColormap} 
           def='default' 
           onUpdate={this.onLocalUpdate} 
-          url='/api/v1,0/colormaps/' 
+          url='/api/v1.0/colormaps/' 
           title={_("Colourmap")}
         >
           {_("colourmap_help")}


### PR DESCRIPTION
Fixed the area map colour selection. The selection box was not previously showing.

There was a comma instead of a period in the colourmaps request.