### PR TITLE
Fix loading of Mercator datasets

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -30,10 +30,11 @@ class Mercator(CalculatedData):
     def __enter__(self):
         super(Mercator, self).__enter__()
 
-        if self.latvar is None:
-            self.latvar, self.lonvar = self.latlon_variables
-            self.__latsort = np.argsort(self.latvar[:])
-            self.__lonsort = np.argsort(np.mod(self.lonvar[:] + 360, 360))
+        if not self._meta_only:
+            if self.latvar is None:
+                self.latvar, self.lonvar = self.latlon_variables
+                self.__latsort = np.argsort(self.latvar[:])
+                self.__lonsort = np.argsort(np.mod(self.lonvar[:] + 360, 360))
 
         return self
 

--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -72,6 +72,24 @@ class SQLiteDatabase:
         # funky way to remove duplicates from the list: https://stackoverflow.com/a/7961390/2231969
         return list(set(self.__flatten_list(file_list)))
 
+    def get_all_dimensions(self) -> List[str]:
+        """Returns a list of all the dimensions in the Dimensions table.
+        
+        Returns:
+            List[str] -- List of strings of all dimension names (e.g. time_counter, depth, x, latitude, etc.)
+        """
+        
+        self.c.execute(
+            """
+            SELECT 
+                name 
+            FROM 
+                Dimensions;
+            """ 
+        )
+
+        return self.__flatten_list(self.c.fetchall())
+
     def get_variable_dims(self, variable: str) -> List[str]:
         """Retrieves the given variables dimensions.
 

--- a/tests/test_sqlite_database.py
+++ b/tests/test_sqlite_database.py
@@ -41,6 +41,17 @@ class TestSqliteDatabase(TestCase):
 
             self.assertEqual(len(rng), 4)
 
+    def test_get_all_dimensions_returns_dims(self):
+
+        expected_dims = sorted(
+            ['axis_nbounds', 'depthv', 'time_counter', 'x', 'y'])
+
+        with SQLiteDatabase(self.historical_db) as db:
+
+            dims = sorted(db.get_all_dimensions())
+
+            self.assertTrue(expected_dims == dims)
+
     def test_get_variable_dims_returns_correct_dims(self):
 
         expected_dims = sorted(["depthv", "time_counter", "x", "y"])

--- a/tests/test_sqlite_database.py
+++ b/tests/test_sqlite_database.py
@@ -101,7 +101,7 @@ class TestSqliteDatabase(TestCase):
         with SQLiteDatabase(self.historical_db) as db:
 
             nc_files = sorted(db.get_netcdf_files(
-                self.historical_timestamps, "vo"))
+                self.historical_timestamps, ["vo"]))
 
             self.assertTrue(expected_nc_files == nc_files)
 


### PR DESCRIPTION
## Intro
This issue came up when datasets using the Mercator grid were being requested in the Navigator. The following error was occuring: 
```sh
File "/home/nabil/Ocean-Data-Map-Project/data/nemo.py", line 78, in __bounding_box
    minx, maxx = fix_limits(x, latvar.shape[1])
IndexError: tuple index out of range
```
The error being thrown from `nemo.py` was the obvious giveaway. Why was a mercator-gridded dataset using a nemo file? Turns out the bounding box function had nothing to do with this. The problem had to be in the `open_dataset` logic, so that's where the fixes are.

## Fix
Instead of looking at the dataset variables like we used to be, we now look at the dimensions since they're more consistent across datasets.

The primary observation was that Mercator and Nemo dimension names are always different and more-or-less follow a naming scheme:
Nemo:
![image](https://user-images.githubusercontent.com/5572045/69240990-492eb400-0b78-11ea-90f8-7c3a6c0ee69b.png)
Mercator:
![image](https://user-images.githubusercontent.com/5572045/69241020-5b105700-0b78-11ea-94e9-e124e6cb6186.png)

Nemo can vary a bit ('x' or 'xc') but it still has a distinguishable pattern.

## Tests
I've written, fixed, and ran the relevant tests and they pass.

## Result
Here's a screenshot of the fix in action with the Mercator global reanalysis dataset selected:
![image](https://user-images.githubusercontent.com/5572045/69242926-7c734200-0b7c-11ea-9de3-0de54899d12d.png)

The tiling is messed up for some reason but that's outside the scope of these changes:
![Screenshot at 2019-11-20 10-04-26](https://user-images.githubusercontent.com/5572045/69243054-c0664700-0b7c-11ea-829d-f9ffe1765523.png)

NOTE: there are also issues with the Timepicker.jsx component that causes the front-end to crash. I've checked the api call results for a few other plots and they're returning 200. Again, fixing the front-end is outside the scope of these changes.