### PR TITLE
Ui scroll fix

### DIFF
--- a/oceannavigator/frontend/src/stylesheets/components/_Map.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_Map.scss
@@ -312,7 +312,7 @@
             transform: rotate(-90deg);
             
             position: relative;
-            display: inline-block;
+            display: block;
 
             width: 30px;
             left: -28px;
@@ -342,7 +342,7 @@
             transform: rotate(-90deg);
             
             position: relative;
-            display: inline-block;
+            display: block;
 
             width: 31px;
             left: 82px;

--- a/oceannavigator/frontend/src/stylesheets/components/_Map.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_Map.scss
@@ -323,11 +323,11 @@
         }
         .monthContainer {
             overflow: auto;
-            overflow-x: hidden;
+            //overflow-x: hidden;
             transform: rotate(-90deg);
             
             position: relative;
-            display: inline-block;
+            display: block;
 
             width: 30px;
             left: 30px;


### PR DESCRIPTION
Resolves #579 
Fixes the odd page scrolling when changing time.

Changed inline block to inline. Because it is technically a horizontal piece flipped sideways inline block was preserving the width or something.