### PR TITLE
Add check for depth dimension in get_profile

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -14,6 +14,7 @@ from data.calculated import CalculatedData
 from data.nearest_grid_point import find_nearest_grid_point
 from data.variable import Variable
 from data.variable_list import VariableList
+from utils.errors import APIError
 
 
 class Mercator(CalculatedData):
@@ -301,15 +302,19 @@ class Mercator(CalculatedData):
             return res
 
     def get_profile(self, latitude, longitude, timestamp, variable):
+        var = self.get_dataset_variable(variable)
+        # We expect the following shape (time, depth, lat, lon)
+        if len(var.shape) != 4:
+            raise APIError("This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
+        
+        time = self.timestamp_to_time_index(timestamp)
+
         miny, maxy, minx, maxx, radius = self.__bounding_box(
             latitude, longitude, 10)
 
         if not hasattr(latitude, "__len__"):
             latitude = np.array([latitude])
             longitude = np.array([longitude])
-
-        var = self.get_dataset_variable(variable)
-        time = self.timestamp_to_time_index(timestamp)
 
         res = self.__resample(
             self.latvar[miny:maxy],

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -7,6 +7,7 @@ from pykdtree.kdtree import KDTree
 
 from data.calculated import CalculatedData
 from data.nearest_grid_point import find_nearest_grid_point
+from utils.errors import APIError
 
 
 class Nemo(CalculatedData):
@@ -318,6 +319,14 @@ class Nemo(CalculatedData):
             return res
 
     def get_profile(self, latitude, longitude, timestamp, variable):
+        var = self.get_dataset_variable(variable)
+        # We expect the following shape (time, depth, lat, lon)
+        if len(var.shape) != 4:
+            raise APIError(
+                "This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
+
+        time_index = self.timestamp_to_time_index(timestamp)
+
         latvar, lonvar = self.__latlon_vars(variable)
         
         miny, maxy, minx, maxx, radius = self.__bounding_box(
@@ -326,10 +335,6 @@ class Nemo(CalculatedData):
         if not hasattr(latitude, "__len__"):
             latitude = np.array([latitude])
             longitude = np.array([longitude])
-
-        var = self.get_dataset_variable(variable)
-
-        time_index = self.timestamp_to_time_index(timestamp)
 
         res = self.__resample(
             latvar[miny:maxy, minx:maxx],


### PR DESCRIPTION
## Intro
When sending API requests for depth-related plots with a variable that has no depth dimension, a rather cryptic `ValueError` is thrown in debug mode. On production we get generic 500 errors. The back end now does a quick check if the shape of the requested variable matches that of a 3D + time (4D), if the check fails, the api exception is thrown immediately so the user gets a super fast slap on the wrist. 

Note: There is some obvious code duplication that'll be addressed in the New Year.

## Change
* Throws an `APIError` if the requested dataset has no depth which gets passed through the API.

## Result
API result:
![image](https://user-images.githubusercontent.com/5572045/71181723-409ccc80-224f-11ea-9f19-41bc868b2b5c.png)

Example banner displayed:
![image](https://user-images.githubusercontent.com/5572045/71181277-6675a180-224e-11ea-9f24-723ac5309354.png)

Tested against other datasets with depth dimensions and no change in behaviour occurs as intended.