### PR TITLE
Makes the Cookie disclaimer smaller

### DIFF
--- a/oceannavigator/frontend/src/components/LayerSelection.jsx
+++ b/oceannavigator/frontend/src/components/LayerSelection.jsx
@@ -199,7 +199,7 @@ export default class LayerSelection extends React.Component {
                         />
                     </div>                        
                     <div className='settings'>
-                        <div className='analyticsDisclaimer' style={{width: '75%', float: 'left'}}>
+                        <div className='analyticsDisclaimer' style={{width: '75%', float: 'left', 'font-size': '12px'}}>
                             {_("This website uses Google Analytics. By continuing, you accept the usage of cookies.")}
                             <br />
                             <a href='https://www.wikihow.com/Disable-Cookies'>{_("How to disable Cookies")}</a>


### PR DESCRIPTION
The text was too large and causing the scrollbar to appear

![image](https://user-images.githubusercontent.com/34169751/71188306-1949fd80-2257-11ea-943a-ab18bbb61b14.png)
