### PR TITLE
Implement LRU cache for open_dataset

### DIFF
--- a/tests/test_data_open_dataset.py
+++ b/tests/test_data_open_dataset.py
@@ -1,14 +1,33 @@
 #!/usr/bin/env python
 
 import unittest
+from unittest.mock import patch
 
 from data import open_dataset
 from data.fvcom import Fvcom
 from data.mercator import Mercator
 from data.nemo import Nemo
+from oceannavigator import DatasetConfig
 
 
 class TestOpenDataset(unittest.TestCase):
+
+    def setUp(self):
+        self.patch_dataset_config_ret_val = {
+            "giops": {
+                "enabled": True,
+                "url": "tests/testdata/nemo_test.nc",
+                "grid_angle_file_url": "tests/testdata/nemo_grid_angle.nc",
+                "time_dim_units": "seconds since 1950-01-01 00:00:00",
+                "quantum": "day",
+                "name": "GIOPS",
+                "help": "help",
+                "attribution": "attrib",
+                "variables": {
+                    "votemper": {"name": "Temperature", "scale": [-5, 30], "units": "Kelvins", "equation": "votemper - 273.15"},
+                }
+            }
+        }
 
     def test_open_dataset_returns_nemo_object(self):
 
@@ -22,3 +41,31 @@ class TestOpenDataset(unittest.TestCase):
     def test_open_dataset_returns_fvcom_object(self):
         with open_dataset('tests/testdata/fvcom_test.nc') as ds:
             self.assertTrue(isinstance(ds, Fvcom))
+
+    def test_open_dataset_uses_lru_cache(self):
+        open_dataset.cache_clear() # clear the cache from other test runs
+
+        for i in range(0, 20):
+            with open_dataset('tests/testdata/nemo_test.nc') as ds:
+                pass
+
+        cache_info = open_dataset.cache_info()
+        self.assertEqual(cache_info.misses, 1)
+        self.assertEqual(cache_info.hits, 19)
+        self.assertEqual(cache_info.currsize, 1)
+
+    @patch.object(DatasetConfig, "_get_dataset_config")
+    def test_open_dataset_with_dataset_config_and_variable_list(self, patch_get_dataset_config):
+
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+        config = DatasetConfig('giops')
+        with open_dataset(config, variable=['votemper'], timestamp=2031436800) as ds:
+            pass
+
+    @patch.object(DatasetConfig, "_get_dataset_config")
+    def test_open_dataset_with_dataset_config_and_variable_str(self, patch_get_dataset_config):
+
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+        config = DatasetConfig('giops')
+        with open_dataset(config, variable='votemper', timestamp=2031436800) as ds:
+            pass

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import json
+from functools import lru_cache, wraps
+
+
+def freeze_args(func):
+    """Decorator to transform mutable dictionnary into immutable.
+    Useful to be compatible with cache.
+
+    Note: Does NOT work on kwargs containing non-hashable
+        types (e.g. list).
+
+    Usage:
+        @freeze_args
+        def my_function(arg1, arg2):
+            ...
+    """
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        args = tuple([frozendict(arg) if isinstance(
+            arg, dict) else arg for arg in args])
+        kwargs = {k: frozendict(v) if isinstance(
+            v, dict) else v for k, v in kwargs.items()}
+
+        return func(*args, **kwargs)
+
+    wrapped.cache_info = func.cache_info
+    wrapped.cache_clear = func.cache_clear
+
+    return wrapped
+
+
+def hashable_lru(func):
+    """Decorator to auto-magically cache the return
+    values of a function. It uses json serialisation
+    to account for un-hashable types (e.g. list); an
+    improvement over the default lru_cache decorator.
+
+    It uses an LRU cache internally with a maxsize of 16.
+
+    Robbed from: https://stackoverflow.com/a/46590069/2231969
+
+    Usage:
+        @hashable_lru
+        def my_expensive_function(arg1, arg2):
+            ...
+    """
+
+    cache = lru_cache(maxsize=16)
+
+    def deserialise(value):
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def func_with_serialized_params(*args, **kwargs):
+        _args = tuple([deserialise(arg) for arg in args])
+        _kwargs = {k: deserialise(v) for k, v in kwargs.items()}
+        return func(*_args, **_kwargs)
+
+    cached_function = cache(func_with_serialized_params)
+
+    @wraps(func)
+    def lru_decorator(*args, **kwargs):
+        _args = tuple([json.dumps(arg, sort_keys=True) if type(
+            arg) in (list, dict) else arg for arg in args])
+        _kwargs = {k: json.dumps(v, sort_keys=True) if type(
+            v) in (list, dict) else v for k, v in kwargs.items()}
+        return cached_function(*_args, **_kwargs)
+    
+    lru_decorator.cache_info = cached_function.cache_info
+    lru_decorator.cache_clear = cached_function.cache_clear
+    
+    return lru_decorator


### PR DESCRIPTION
## Intro
Simply re-implementing the LRU cache that was present before the sqlite backend refactor in the `open_dataset` function. The idea is to reduce the overhead of opening the same dataset in quick succession by caching the last 16 used dataset objects.

## Method
This implementation is more complicated than the original one because of the presence of un-hashable types (`list`) in the `**kwargs` of `open_dataset` (read the docstring). The json serialisation recursively handles that. There obviously is a performance cost, but it should be less than going through all the file opening logic (i.e. disk reads).

I've also added a helper decorator `freeze_args` that will non-recursively convert a function's arguments to a `frozendict`, which allows the use of python's built-in `@lru_cache` decorator.

The function decorator is a clean implementation that allows for other areas to make use of an LRU cache as well.

Docstrings have been written for both new decorators.

## Tests
I've written more tests with one specifically checking that the cache is being used, with everything passing.