### PR TITLE
Add test class for calculated functions

### DIFF
--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import unittest
+
+import numpy as np
+
+import data.calculated_parser.functions as funcs
+
+
+class TestDataFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.relative_tolerance: float = 1e-3
+
+    def test_max(self):
+        actual = funcs.max([[1, 2, 3], [4, 5, 6]])
+
+        self.assertEqual(actual, 6)
+
+    def test_min(self):
+        actual = funcs.min([[1, 2, 3], [4, 5, 6]])
+
+        self.assertEqual(actual, 1)
+
+    def test_magnitude(self):
+        actual = funcs.magnitude(np.array([3, 3, 3]), np.array([1, 1, 1]))
+        expected = np.array([3.162278, 3.162278, 3.162278])
+
+        np.testing.assert_allclose(
+            actual, expected, rtol=self.relative_tolerance)


### PR DESCRIPTION
## Background

The calculated functions in the `data/calculated_parser` folder at present have no tests. This gets the ball rolling with tests for `min`, `max`, and `magnitude`.


## Why did you take this approach?
Simplest approach. I also use the numpy test helpers: https://docs.scipy.org/doc/numpy/reference/routines.testing.html

## Anything in particular that should be highlighted?
I've defined a variable called `relative_tolerance` which controls how many decimal places are checked for floating-point equality. It's set to `1e-3` or 3 decimal places which should be sufficient for our needs. 

I feel this should be a "global" constant somewhere for behavioral consistency.

## Screenshot(s)

Not needed here.

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
