### PR TITLE
Raise SyntaxError when p_error is called

### DIFF
--- a/tests/test_calculated_parser.py
+++ b/tests/test_calculated_parser.py
@@ -1,7 +1,11 @@
+#!/usr/bin/env python
+
 import unittest
-import data.calculated_parser.parser
-import data.calculated_parser.functions as cfn
+
 import numpy as np
+
+import data.calculated_parser.functions as cfn
+import data.calculated_parser.parser
 
 
 class TestCalculatedParser(unittest.TestCase):
@@ -22,8 +26,7 @@ class TestCalculatedParser(unittest.TestCase):
 
         for case in cases:
             self.assertEqual(parser.parse(case[0], None, None, None), case[1],
-                    msg="Equation: \"%s\"" % case[0])
-
+                             msg="Equation: \"%s\"" % case[0])
 
     def test_constants(self):
         parser = data.calculated_parser.parser.Parser()
@@ -34,7 +37,7 @@ class TestCalculatedParser(unittest.TestCase):
 
         for case in cases:
             self.assertEqual(parser.parse(case[0], None, None, None), case[1],
-                    msg="Equation: \"%s\"" % case[0])
+                             msg="Equation: \"%s\"" % case[0])
 
     def test_functions(self):
         parser = data.calculated_parser.parser.Parser()
@@ -50,12 +53,25 @@ class TestCalculatedParser(unittest.TestCase):
             ["log2(2)", 1],
             ["log2(256)", 8],
             ["ln(e)", 1],
-            ["atan2(0, 0)", 0],
+            ["atan2(0, 0)", 0]
         ]
 
         for case in cases:
             self.assertAlmostEqual(parser.parse(case[0], None, None, None), case[1],
-                    msg="Equation: \"%s\"" % case[0])
+                                   msg="Equation: \"%s\"" % case[0])
+
+    def test_syntax_error_in_expr_raises(self):
+        parser = data.calculated_parser.parser.Parser()
+
+        cases = [
+            "atan2(0,)",
+            "atan2()",
+            "atan2(,0)"
+        ]
+
+        for case in cases:
+            with self.assertRaises(SyntaxError):
+                parser.parse(case, None, None, None)
 
     def test_sspeed(self):
         self.assertAlmostEqual(cfn.sspeed(0, 45, 0.5, 32), 1447.4, 1)
@@ -64,6 +80,5 @@ class TestCalculatedParser(unittest.TestCase):
         lat = np.array([[45, 45], [45, 45]])
         temp = 0.5 * np.ones((10, 2, 2))
         sal = 32 * np.ones((10, 2, 2))
-        self.assertAlmostEqual(cfn.sspeed(dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)
-
-        
+        self.assertAlmostEqual(cfn.sspeed(
+            dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)


### PR DESCRIPTION
## Background
parser.py:
When a syntax error occurs in an equation string, part of the `t` parameter is attempted to be assigned to `None`. Unfortunately that results in another unrelated Python exception that confuses the caller. Instead we explicitly raise a `SyntaxError` exception, along with some useful debug info in the message (see below).

I threw in a new test case to check for the new raising behavior, along with some pylint formatting.

> In preparation for bringing back the derived variables.

## Why did you take this approach?
Easiest way.
PLY is built around error feedback so I opted to pass along a more sane exception message
to the console:

```
SyntaxError: Syntax error in equation: atan2(0,)...LexToken(RPAREN,')',1,8)
```

## Anything in particular that should be highlighted?

The new test is only hitting the built-in math functions since they don't need to be mocked. To enhance the coverage, we could mock some data and try some other stuff (e.g. try `votemper -` instead of the proper `votemper - 273.15`).

## Screenshot(s)

n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
