### PR TITLE
Change shape of CalculatedArray to consider user-defined dims

### DIFF
--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -191,7 +191,7 @@
             "vomecrty": { "envtype": "ocean", "name": "Water Y Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "votemper": { "envtype": "ocean", "name": "Temperature", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "yc", "xc"] },
             "vosaline": { "envtype": "ocean", "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)" }
+            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
         }
     },
     "glorys3": {

--- a/tests/test_calculated_data.py
+++ b/tests/test_calculated_data.py
@@ -41,7 +41,7 @@ class TestCalculatedData(unittest.TestCase):
             'votemper_new': {
                 'equation': 'votemper * 2',
                 'long_name': 'Temperature',
-                'dims': ('time_counter', 'deptht', 'x', 'y'),
+                'dims': ('time', 'depth', 'latitude', 'longitude'),
                 'units': 'degree_C',
                 'valid_min': -273.15,
                 'valid_max': 999.0,
@@ -68,6 +68,7 @@ class TestCalculatedData(unittest.TestCase):
             'votemper': {
                 'equation': 'votemper -273.15',
                 'units': 'degree_C',
+                'dims': ('time', 'depth', 'latitude', 'longitude')
             }
         }
         with CalculatedImpl('tests/testdata/mercator_test.nc',
@@ -104,19 +105,19 @@ class TestCalculatedArray(unittest.TestCase):
 
     def test_static(self):
         dataset = xr.Dataset()
-        array = CalculatedArray(dataset, "3 * 5")
+        array = CalculatedArray(dataset, "3 * 5", [])
         self.assertEqual(array[0], 15)
 
     def test_passthrough(self):
         dataset = xr.Dataset({'var': ('x', [1, 2, 3, 4, 5])})
-        array = CalculatedArray(dataset, "var")
+        array = CalculatedArray(dataset, "var", [])
         self.assertEqual(array[0], 1)
         self.assertEqual(array[2], 3)
         self.assertEqual(array[4], 5)
 
     def test_single_expression(self):
         dataset = xr.Dataset({'var': ('x', [1, 2, 3, 4, 5])})
-        array = CalculatedArray(dataset, "var * 5")
+        array = CalculatedArray(dataset, "var * 5", [])
         self.assertEqual(array[0], 5)
         self.assertEqual(array[2], 15)
         self.assertEqual(array[4], 25)
@@ -126,7 +127,7 @@ class TestCalculatedArray(unittest.TestCase):
             'var': ('x', [1, 2, 3, 4, 5]),
             'var2': ('x', [5, 4, 3, 2, 1]),
         })
-        array = CalculatedArray(dataset, "var + var2")
+        array = CalculatedArray(dataset, "var + var2", [])
         self.assertEqual(array[0], 6)
         self.assertEqual(array[2], 6)
         self.assertEqual(array[4], 6)
@@ -138,11 +139,11 @@ class TestCalculatedArray(unittest.TestCase):
             'var3': (('x', 'y'), [[5, 6], [7, 8]]),
             'var4': (('y', 'x'), [[9, 10], [11, 12]]),
         })
-        array = CalculatedArray(dataset, "var + var2")
+        array = CalculatedArray(dataset, "var + var2", [])
         self.assertIsNan(array[0])
-        array = CalculatedArray(dataset, "var3 + var4")
+        array = CalculatedArray(dataset, "var3 + var4", [])
         self.assertIsNan(array[0, 0])
-        array = CalculatedArray(dataset, "var + var3")
+        array = CalculatedArray(dataset, "var + var3", [])
         self.assertEqual(array[0, 0], 6)
         self.assertEqual(array[0, 1], 7)
         self.assertEqual(array[1, 0], 9)


### PR DESCRIPTION
## Background

When the calculation layer was implemented, it only considered calculated variables to have the same dimensions as the underlying variables. So 3D calculated variables were only constructed from 3D underlying variables, and the same goes with 2D stuff. The `CalculatedArray` simply looked into the dimensions of the underlying variables and copied the maximum `.shape` values. This is just fine given the above consideration.

The issues arises when we consider 2D calculated variables with 3D underlying variables (e.g. Deep Sound Channel). We cannot simply copy the shapes of the 3D variables since we'll be pulling in depth, when there shouldn't be one. To work around this, I simply made the user-defined `dims` attribute in the dataset config file a requirement for all calculated variables. This allows the `CalculatedArray` to copy the shapes of the dims listed in said attribute. 

When a calculated variable is encountered with no `dims` attribute, an exception is thrown with a specific error message to easily track down the issue:
```
KeyError: 'This variable (sspeed) has no dims attribute defined in datasetconfig.json.'
```

* Unit tests were edited to reflect the change.
* Enabled datasets in datasetconfig.json were updated to reflect the new attribute requirement.

## Why did you take this approach?

This way involved the minimum amount of code changed, while preserving the behavior of the higher-level plotting functions.

In fact this simplifies the shape calculation considerably, while giving more flexibility.

## Anything in particular that should be highlighted?

The changes only affect the calculated variable code path.

**NOTE** The dims attribute is now required when declaring calculated variables in datasetconfig.json.

## Screenshot(s)
No changes in resulting plots with calculated variables, as expected:
![Screenshot from 2020-01-30 12-32-31](https://user-images.githubusercontent.com/5572045/73466219-2250e300-435c-11ea-8ea4-53aec12a70e9.png)

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
