### PR TITLE
Add Density, Heat Capacity, Temp Gradient variables

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -55,6 +55,16 @@ def magnitude(a, b):
     return np.sqrt(a ** 2 + b ** 2)
 
 
+def __calc_pressure(depth, latitude):
+    pressure = []
+    try:
+        pressure = [seawater.pres(d, latitude) for d in depth]
+    except TypeError:
+        pressure = seawater.pres(depth, latitude)
+
+    return pressure
+
+
 def sspeed(depth, latitude, temperature, salinity):
     """
     Calculates the speed of sound.
@@ -65,13 +75,61 @@ def sspeed(depth, latitude, temperature, salinity):
     temperature: The temperatures(s) in Celsius
     salinity: The salinity (unitless)
     """
-    try:
-        press = [seawater.pres(d, latitude) for d in depth]
-    except TypeError:
-        press = seawater.pres(depth, latitude)
+    press = __calc_pressure(depth, latitude)
 
     speed = seawater.svel(salinity, temperature, press)
     return np.array(speed)
+
+
+def density(depth, latitude, temperature, salinity):
+    """
+    Calculates the density of sea water.
+
+    Parameters:
+    depth: The depth(s) in meters
+    latitude: The latitude(s) in degrees North
+    temperature: The temperatures(s) in Celsius
+    salinity: The salinity (unitless)
+    """
+
+    press = __calc_pressure(depth, latitude)
+
+    density = seawater.dens(salinity, temperature, press)
+    return np.array(density)
+
+
+def heatcap(depth, latitude, temperature, salinity):
+    """
+    Calculates the heat capacity of sea water.
+
+    Parameters:
+    depth: The depth(s) in meters
+    latitude: The latitude(s) in degrees North
+    temperature: The temperatures(s) in Celsius
+    salinity: The salinity (unitless)
+    """
+
+    press = __calc_pressure(depth, latitude)
+
+    heatcap = seawater.cp(salinity, temperature, press)
+    return np.array(heatcap)
+
+
+def tempgradient(depth, latitude, temperature, salinity):
+    """
+    Calculates the adiabatic temp gradient of sea water.
+
+    Parameters:
+    depth: The depth(s) in meters
+    latitude: The latitude(s) in degrees North
+    temperature: The temperatures(s) in Celsius
+    salinity: The salinity (unitless)
+    """
+
+    press = __calc_pressure(depth, latitude)
+
+    tempgradient = seawater.adtg(salinity, temperature, press)
+    return np.array(tempgradient)
 
 
 def _metpy(func, data, lat, lon, dim):

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -8,7 +8,7 @@
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "enabled": true,
         "cache": 6,
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
@@ -43,7 +43,7 @@
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "enabled": true,
         "cache": 6,
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
@@ -67,7 +67,7 @@
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "enabled": true,
         "cache": 6,
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "yc",
         "lon_var_key": "xc",
@@ -100,7 +100,7 @@
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "enabled": true,
         "cache": 6,
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
         "lat_var_key": "yc",
         "lon_var_key": "xc",
@@ -114,7 +114,7 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
         }
     },
     "riops_fc_2dll": {
@@ -144,7 +144,7 @@
         }
     },
     "riops_fc_2dps": {
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "envtype": ["ocean"],
         "enabled": true,
         "help": "",
@@ -176,7 +176,7 @@
         }
     },
     "riops_fc_3dps": {
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "envtype": ["ocean"],
         "enabled": true,
         "help": "",
@@ -197,12 +197,12 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
         }
     },
     "glorys3": {
         "attribution": "GLORYS2V3 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/glorys/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys/aggregated.ncml",
         "enabled": false,
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>                 <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2013)</li>                 <li>Variables Available:                     <ul>                         <li>Eastward Velocity</li>                         <li>Ice Concentration</li>                         <li>Northward Velocity</li>                         <li>Salinity</li>                         <li>Sea Ice Eastward Velocity</li>                         <li>Sea Ice Northward Velocity</li>                         <li>Sea Ice Thickness</li>                         <li>Sea Ice Velocity</li>                         <li>Sea Surface Height</li>                         <li>Sea Water Velocity</li>                         <li>Temperature</li>                     </ul>                 </li>             </ul>",
         "name": "GLORYS v3",
@@ -373,7 +373,7 @@
     },
     "glorys4": {
         "attribution": "GLORYS2V4 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
         "enabled": false,
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>             <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2014)</li>             </ul>",
         "name": "GLORYS v4",
@@ -575,13 +575,13 @@
     },
     "glorys4_climatology": {
         "envtype": ["ocean", "ice"],
-        "url": "http://10.0.3.56:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
+        "url": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
         "name": "GLORYS v4 Climatology",
         "quantum": "month",
         "type": "historical",       
         "enabled": false,
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
         "attribution": "GLORYS2V4 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>             <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2014)</li>             </ul>",
         "variables": {
@@ -608,7 +608,7 @@
     },
     "glorysv3_climatology": {
         "attribution": "GLORYS2V3 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/glorys/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys/aggregated.ncml",
         "enabled": false,
         "help": "Global Ocean Reanalysis and Simulation             <ul>             <li>Global Coverage</li>             <li>1/4° Mercator grid</li>             <li>75 vertical z-levels</li>             <li>Computed from the monthly averages January 1993&ndash;December 2013</li>             <li>Variables Available:                 <ul>                     <li>Eastward Velocity</li>                     <li>Ice Concentration</li>                     <li>Northward Velocity</li>                     <li>Salinity</li>                     <li>Sea Ice Eastward Velocity</li>                     <li>Sea Ice Northward Velocity</li>                     <li>Sea Ice Thickness</li>                     <li>Sea Ice Velocity</li>                     <li>Sea Surface Height</li>                     <li>Sea Water Velocity</li>                     <li>Temperature</li>                 </ul>             </li>             </ul>",
         "name": "GLORYSV3 Climatology",
@@ -731,14 +731,14 @@
     },
     "levitus98_phc21": {
         "attribution": "Unknown",
-        "climatology": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "enabled": false,
         "help": "Combination of Levitus98 and PHC 2.1             <ul>             <li>Global Coverage</li>             <li>Tri-polar ORCA grid 1/4° resolution (ORCA025), &lt; 15km in Arctic</li>             <li>50 vertical z-levels</li>             <li>Variables Available:                 <ul>                     <li>Salinity</li>                     <li>Water Temperature</li>                 </ul>             </li>             </ul>",
         "name": "World Ocean Atlas Climatology",
         "quantum": "month",
         "type": "historical",        
         "time_dim_units": "seconds since 1950-01-01 00: 00: 00",
-        "url": "http://10.0.3.56:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
+        "url": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "variables": {
             "vosaline": {
                 "hide": "false",

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -111,7 +111,10 @@
             "vomecrty": { "name": "Water Y Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "yc", "xc"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, yc, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] }
+            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
         }
     },
     "riops_fc_2dll": {
@@ -191,7 +194,10 @@
             "vomecrty": { "envtype": "ocean", "name": "Water Y Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "votemper": { "envtype": "ocean", "name": "Temperature", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "yc", "xc"] },
             "vosaline": { "envtype": "ocean", "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
         }
     },
     "glorys3": {

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -40,6 +40,8 @@ def find_colormap(name):
 _c = mcolors.ColorConverter().to_rgb
 data_dir = os.path.join(os.path.dirname(plotting.__file__), 'data')
 colormaps = {
+    'heat': cmocean.cm.thermal,
+    'density': cmocean.cm.dense,
     'curl': cmocean.cm.curl,
     'vorticity': cmocean.cm.curl,
     'divergence': cmocean.cm.curl,
@@ -170,6 +172,8 @@ gettext('NEO SST')
 gettext('Color Brewer Blue-Yellow-Red')
 gettext('Temperature (old)')
 gettext('Vorticity')
+gettext('Density')
+gettext('Thermal')
 
 colormap_names = {
     'anomaly': 'Anomaly',
@@ -197,6 +201,8 @@ colormap_names = {
     'BuYlRd': 'Color Brewer Blue-Yellow-Red',
     'temperature-old': 'Temperature (old)',
     'vorticity': 'Vorticity',
+    'density': 'Density',
+    'thermal': 'Thermal'
 }
 
 

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -40,12 +40,12 @@ def find_colormap(name):
 _c = mcolors.ColorConverter().to_rgb
 data_dir = os.path.join(os.path.dirname(plotting.__file__), 'data')
 colormaps = {
+    'temp gradient': cmocean.cm.thermal,
     'heat': cmocean.cm.thermal,
     'density': cmocean.cm.dense,
     'curl': cmocean.cm.curl,
     'vorticity': cmocean.cm.curl,
     'divergence': cmocean.cm.curl,
-    'gradient': cmocean.cm.curl,
     'bathymetry': cmocean.cm.deep,
     'salinity': cmocean.cm.haline,
     'speed': cmocean.cm.speed,
@@ -173,7 +173,6 @@ gettext('Color Brewer Blue-Yellow-Red')
 gettext('Temperature (old)')
 gettext('Vorticity')
 gettext('Density')
-gettext('Thermal')
 
 colormap_names = {
     'anomaly': 'Anomaly',
@@ -201,8 +200,7 @@ colormap_names = {
     'BuYlRd': 'Color Brewer Blue-Yellow-Red',
     'temperature-old': 'Temperature (old)',
     'vorticity': 'Vorticity',
-    'density': 'Density',
-    'thermal': 'Thermal'
+    'density': 'Density'
 }
 
 


### PR DESCRIPTION
## Background
Add Density, Heat Capacity, and Adiabatic Temperature Gradient to GIOPS/RIOPS 3D Polar Stereographic datasets.

We simply expose more functions in the `seawater` package to the calculation layer.

## Why did you take this approach?

Easiest way.

## Anything in particular that should be highlighted?

Deleted the generic "gradient" colour map since it didn't necessarily well represent gradient plots. 

## Screenshot(s)
![Screenshot from 2020-01-31 14-16-46](https://user-images.githubusercontent.com/5572045/73561622-dec9a800-4433-11ea-9e2d-b641daea062c.png)

![Screenshot from 2020-01-31 14-21-38](https://user-images.githubusercontent.com/5572045/73561902-86df7100-4434-11ea-93c0-b31c679166a5.png)

![Screenshot from 2020-01-31 14-22-58](https://user-images.githubusercontent.com/5572045/73561988-b7270f80-4434-11ea-9e0a-35f5a722ea20.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
