### PR TITLE
Fix deprecated uses of @abc.abstractproperty

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -41,19 +41,23 @@ class Data(object, metaclass=abc.ABCMeta):
     def timestamp_to_iso_8601(self, timestamp):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def timestamps(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def depths(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def variables(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def depth_dimensions(self):
         pass
 


### PR DESCRIPTION
## Background
See https://docs.python.org/3.6/library/abc.html#abc.abstractproperty

> Deprecated since version 3.3: It is now possible to use property, ...
> with abstractmethod(), making this decorator redundant.

## Why did you take this approach?
Keeping code up to date is A Good Thing™.
Python 3.2 that required `@abc.abtractproperty` was EOL-ed in March 2016.

## Anything in particular that should be highlighted?
Noticed this as I started to work on ioc/factory refactoring.

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
