### PR TITLE
Added missing import

### DIFF
--- a/utils/misc.py
+++ b/utils/misc.py
@@ -16,6 +16,7 @@ from shapely.geometry.polygon import LinearRing
 
 from data import open_dataset
 from oceannavigator import DatasetConfig
+from thredds_crawler.crawl import Crawl
 
 
 def list_kml_files(subdir):


### PR DESCRIPTION
## Background
`misc.py` has been missing this import for a while and has been messing with the drifters. This PR replaces the import.

## Why did you take this approach?
It seemed most effective.

## Anything in particular that should be highlighted?
The new import on line 19.

## Screenshot(s)
None

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
