### PR TITLE
Fix duplicate timestamps returned from database

### DIFF
--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -167,7 +167,7 @@ class SQLiteDatabase:
 
         self.c.execute(
             """
-            SELECT
+            SELECT DISTINCT
                 timestamp
             FROM
                 TimestampVariableFilepath tvf


### PR DESCRIPTION
Just adds DISTINCT qualifier to SELECT

## Background
For some forecast datasets, the sql database driver returns duplicate timestamps from the database. These end up being passed up to the front-end via the API and causes end-user confusion. As a quick fix, I've opted to simply use the `DISTINCT` qualifier on the `SELECT` statement to quickly filter out duplicates. When time permits, we can do a proper investigation.

## Why did you take this approach?
Simplest method.

## Anything in particular that should be highlighted?
Nope

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
