### PR TITLE
Extend calculation layer to support full-depth slicing

### DIFF
--- a/data/calculated.py
+++ b/data/calculated.py
@@ -128,26 +128,10 @@ class CalculatedArray():
             pass
 
     def __getitem__(self, key):
-        """This is where the magic happens.
-        The dimensions of the key are determined by looking at the dimensions
-        of all the underlying variables used in the calculation, this is then
-        passed along to the parser where the calculation is performed.
-        """
-        key_dims = ()
-        for v in self._parser.lexer.variables:
-            if v not in self._parent.variables:
-                continue
-
-            d = self.__get_parent_variable_dims(v)
-
-            if len(d) > len(key_dims):
-                key_dims = d
-            elif len(d) == len(key_dims):
-                if d != key_dims:
-                    return np.nan
+        # This is where the magic happens.
 
         data = self._parser.parse(
-            self._expression, self._parent, key, key_dims)
+            self._expression, self._parent, key, self._dims)
 
         return xr.DataArray(data)
 

--- a/data/calculated_parser/lexer.py
+++ b/data/calculated_parser/lexer.py
@@ -1,7 +1,14 @@
-import ply.lex as lex
-import numpy as np
+#!/usr/bin/env python
+
 import re
+
+import numpy as np
+import ply.lex as lex
+
 import data.calculated_parser.functions as functions
+
+# Intro to PLY: https://www.dabeaz.com/ply/PLYTalk.pdf
+
 
 class Lexer:
     """This is the Lexer (or tokenizer) part of the domain specific language.
@@ -11,18 +18,20 @@ class Lexer:
     def __init__(self, **kwargs):
         # a list of the tokens that are used in this language
         self.tokens = [
-                'NUMBER',
-                'PLUS',
-                'MINUS',
-                'TIMES',
-                'DIVIDE',
-                'POWER',
-                'LPAREN',
-                'RPAREN',
-                'ID',
-                'COMMA',
-                'CONST'
-                ]
+            'NUMBER',
+            'PLUS',
+            'MINUS',
+            'TIMES',
+            'DIVIDE',
+            'POWER',
+            'LPAREN',
+            'RPAREN',
+            'ID', # variable key OR function name (see below t_ID)
+            'COMMA',
+            'CONST', # math constant (see below t_CONST)
+            'LBRKT',
+            'RBRKT'
+        ]
 
         # These tokens don't require any additional processing
         self.t_PLUS = '\\+'
@@ -33,6 +42,8 @@ class Lexer:
         self.t_LPAREN = '\\('
         self.t_RPAREN = '\\)'
         self.t_COMMA = ','
+        self.t_LBRKT = '\\['
+        self.t_RBRKT = '\\]'
 
         # Ignore tabs and spaces
         self.t_ignore = ' \t'

--- a/data/calculated_parser/parser.py
+++ b/data/calculated_parser/parser.py
@@ -76,6 +76,20 @@ class Parser:
 
         return tuple(key)
 
+    def get_key_for_variable_full_depth(self, variable_key):
+        variable = self.data.variables[variable_key]
+
+        if 'depth' in variable_key:
+            depth_levels = variable.shape[0]  # Expecting (depth shape)
+            return (slice(0, depth_levels), )
+
+        key = list(self.key)
+        # Expecting (time, depth, lat, lon) shape
+        depth_levels = variable.shape[1]
+        key.insert(1, slice(0, depth_levels))
+
+        return tuple(key)
+
     # Similar to the Lexer, these p_*, methods cannot have proper python
     # docstrings, because it's used for the parsing specification.
     def p_statement_expr(self, t):
@@ -88,6 +102,13 @@ class Parser:
             self.get_key_for_variable(
                 self.data.variables[t[1]]
             )
+        ]
+
+    def p_expression_variable_full_depth(self, t):
+        '''expression : LBRKT ID RBRKT'''
+
+        t[0] = self.data.variables[t[2]][
+            self.get_key_for_variable_full_depth(t[2])
         ]
 
     def p_expression_uop(self, t):

--- a/tests/test_calculated_data.py
+++ b/tests/test_calculated_data.py
@@ -110,14 +110,14 @@ class TestCalculatedArray(unittest.TestCase):
 
     def test_passthrough(self):
         dataset = xr.Dataset({'var': ('x', [1, 2, 3, 4, 5])})
-        array = CalculatedArray(dataset, "var", [])
+        array = CalculatedArray(dataset, "var", ['x'])
         self.assertEqual(array[0], 1)
         self.assertEqual(array[2], 3)
         self.assertEqual(array[4], 5)
 
     def test_single_expression(self):
         dataset = xr.Dataset({'var': ('x', [1, 2, 3, 4, 5])})
-        array = CalculatedArray(dataset, "var * 5", [])
+        array = CalculatedArray(dataset, "var * 5", ['x'])
         self.assertEqual(array[0], 5)
         self.assertEqual(array[2], 15)
         self.assertEqual(array[4], 25)
@@ -127,7 +127,7 @@ class TestCalculatedArray(unittest.TestCase):
             'var': ('x', [1, 2, 3, 4, 5]),
             'var2': ('x', [5, 4, 3, 2, 1]),
         })
-        array = CalculatedArray(dataset, "var + var2", [])
+        array = CalculatedArray(dataset, "var + var2", ['x'])
         self.assertEqual(array[0], 6)
         self.assertEqual(array[2], 6)
         self.assertEqual(array[4], 6)
@@ -139,11 +139,11 @@ class TestCalculatedArray(unittest.TestCase):
             'var3': (('x', 'y'), [[5, 6], [7, 8]]),
             'var4': (('y', 'x'), [[9, 10], [11, 12]]),
         })
-        array = CalculatedArray(dataset, "var + var2", [])
+        array = CalculatedArray(dataset, "var + var2", ['x'])
         self.assertIsNan(array[0])
-        array = CalculatedArray(dataset, "var3 + var4", [])
+        array = CalculatedArray(dataset, "var3 + var4", ['x'])
         self.assertIsNan(array[0, 0])
-        array = CalculatedArray(dataset, "var + var3", [])
+        array = CalculatedArray(dataset, "var + var3", ['x', 'y'])
         self.assertEqual(array[0, 0], 6)
         self.assertEqual(array[0, 1], 7)
         self.assertEqual(array[1, 0], 9)


### PR DESCRIPTION
## Background
The requested acoustic calculations required the "compression" of 3D data variables into 2D (i.e. full-depth temperature + full-depth salinity would yield a 2D deep sound channel product). The parser grammar didn't support this kind of slicing so we needed to add new tokens ("[" and "]"). 

To request a variable be sliced with full-depth, use the following syntax in the dataset config: `[ my-variable-key ]`. The square brackets tell the parser to grab the full depth dimension when slicing the requested lat/lon coords.

## Why did you take this approach?
Simplest way I could think of to minimize the amount of code changed, while keeping present functionality. The square brackets were borrowed from math, where they refer to inclusive ranges; where we want the full depth range.

## Anything in particular that should be highlighted?
The `dims` attribute for calculated variables in the dataset config remain required courtesy of #630. This partly allows the full-depth slicing implemented here.

I've also specifically tested the subsetting code with no issue.

## Screenshot(s)
I jumped a little ahead and implemented the deep sound channel variable for testing; not in this pr:
![image](https://user-images.githubusercontent.com/5572045/74175677-dda53180-4c10-11ea-9ff1-6f001a396e48.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
