### PR TITLE
Add Deep Sound Channel calculated variable

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import functools
+from typing import Union
 
 import metpy.calc
 import numpy as np
@@ -132,7 +133,10 @@ def tempgradient(depth, latitude, temperature, salinity):
     return np.array(tempgradient)
 
 
-def deepsoundchannel(depth, latitude, temperature, salinity):
+def deepsoundchannel(depth: Union[np.ndarray, xr.Variable],
+                     latitude: np.ndarray,
+                     temperature: np.ndarray,
+                     salinity: np.ndarray) -> np.ndarray:
     """
     Find and return the depth of the minimum value of the
     speed of sound.
@@ -148,17 +152,17 @@ def deepsoundchannel(depth, latitude, temperature, salinity):
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
 
-        # Mask out NaN values to prevent a exception blow-up.
+    # Mask out NaN values to prevent an exception blow-up.
     masked_sound_speed = np.ma.masked_array(sound_speed, np.isnan(sound_speed))
 
     # The resulting shape of sound_speed is (full_depth, lat_slice, lon_slice)
     # So we simply need to find the minimum sound speed along each lat/lon index
     # Using numpy axis magic, we want the minimum along the full_depth axis = 0.
     # https://stackoverflow.com/a/52468964/2231969
-    
+
     min_indices = np.argmin(masked_sound_speed, axis=0)
 
-    return depth.values[min_indices]
+    return depth[:][min_indices]
 
 
 def _metpy(func, data, lat, lon, dim):

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -63,7 +63,7 @@ def __calc_pressure(depth, latitude):
     except TypeError:
         pressure = seawater.pres(depth, latitude)
 
-    return pressure
+    return np.array(pressure)
 
 
 def sspeed(depth, latitude, temperature, salinity):
@@ -77,6 +77,10 @@ def sspeed(depth, latitude, temperature, salinity):
     salinity: The salinity (unitless)
     """
     press = __calc_pressure(depth, latitude)
+
+    if salinity.shape != press.shape:
+        # pad array shape to match otherwise seawater freaks out
+        press = press[..., np.newaxis]
 
     speed = seawater.svel(salinity, temperature, press)
     return np.array(speed)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -132,6 +132,29 @@ def tempgradient(depth, latitude, temperature, salinity):
     return np.array(tempgradient)
 
 
+def deepsoundchannel(depth, latitude, temperature, salinity):
+    """
+    Finds the minimum of the speed of sound.
+
+    # https://en.wikipedia.org/wiki/SOFAR_channel
+
+    Required Arguments:
+        * depth: The depth(s) in meters
+        * lat: The latitude(s) in degrees North
+        * temperature: The temperatures(s) (at all depths) in Celsius
+        * salinity: The salinity (at all depths)
+    """
+
+    sound_speed = sspeed(depth, latitude, temperature, salinity)
+
+    # The resulting shape of sound_speed is (full_depth, lat_slice, lon_slice)
+    # So we simply need to find the minimum sound speed along each lat/lon index
+    # Using numpy axis magic, we want the minimum along the full_depth axis = 0.
+    # https://stackoverflow.com/a/52468964/2231969
+
+    return np.nanmin(sound_speed, axis=0)
+
+
 def _metpy(func, data, lat, lon, dim):
     """Wrapper for MetPy functions
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -66,7 +66,10 @@ def __calc_pressure(depth, latitude):
     return np.array(pressure)
 
 
-def sspeed(depth, latitude, temperature, salinity):
+def sspeed(depth: Union[np.ndarray, xr.Variable],
+           latitude: np.ndarray,
+           temperature: np.ndarray,
+           salinity: np.ndarray):
     """
     Calculates the speed of sound.
 
@@ -76,7 +79,17 @@ def sspeed(depth, latitude, temperature, salinity):
     temperature: The temperatures(s) in Celsius
     salinity: The salinity (unitless)
     """
+
+    if type(latitude) is not np.ndarray:
+        latitude = np.array(latitude)
+
     press = __calc_pressure(depth, latitude)
+
+    if type(temperature) is not np.ndarray:
+        temperature = np.array(temperature)
+
+    if type(salinity) is not np.ndarray:
+        salinity = np.array(salinity)
 
     if salinity.shape != press.shape:
         # pad array shape to match otherwise seawater freaks out
@@ -153,6 +166,15 @@ def deepsoundchannel(depth: Union[np.ndarray, xr.Variable],
         * temperature: The temperatures(s) (at all depths) in Celsius
         * salinity: The salinity (at all depths)
     """
+    
+    if type(latitude) is not np.ndarray:
+        latitude = np.array(latitude)
+
+    if type(temperature) is not np.ndarray:
+        temperature = np.array(temperature)
+
+    if type(salinity) is not np.ndarray:
+        salinity = np.array(salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -348,7 +348,7 @@ def geostrophic_x(h, lat, lon):
         if dim_order == "yx":
             dy, dx = kwargs['deltas']
         else:
-            dx, dy = kwgard['deltas']
+            dx, dy = kwargs['deltas']
 
         return metpy.calc.geostrophic_wind(xr.DataArray(heights), c, dx, dy,
                                            dim_order=kwargs['dim_order'])

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -134,7 +134,8 @@ def tempgradient(depth, latitude, temperature, salinity):
 
 def deepsoundchannel(depth, latitude, temperature, salinity):
     """
-    Finds the minimum of the speed of sound.
+    Find and return the depth of the minimum value of the
+    speed of sound.
 
     # https://en.wikipedia.org/wiki/SOFAR_channel
 
@@ -147,12 +148,17 @@ def deepsoundchannel(depth, latitude, temperature, salinity):
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
 
+        # Mask out NaN values to prevent a exception blow-up.
+    masked_sound_speed = np.ma.masked_array(sound_speed, np.isnan(sound_speed))
+
     # The resulting shape of sound_speed is (full_depth, lat_slice, lon_slice)
     # So we simply need to find the minimum sound speed along each lat/lon index
     # Using numpy axis magic, we want the minimum along the full_depth axis = 0.
     # https://stackoverflow.com/a/52468964/2231969
+    
+    min_indices = np.argmin(masked_sound_speed, axis=0)
 
-    return np.nanmin(sound_speed, axis=0)
+    return depth.values[min_indices]
 
 
 def _metpy(func, data, lat, lon, dim):

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -141,7 +141,7 @@ def deepsoundchannel(depth: Union[np.ndarray, xr.Variable],
     Find and return the depth of the minimum value of the
     speed of sound.
 
-    # https://en.wikipedia.org/wiki/SOFAR_channel
+    https://en.wikipedia.org/wiki/SOFAR_channel
 
     Required Arguments:
         * depth: The depth(s) in meters
@@ -162,7 +162,7 @@ def deepsoundchannel(depth: Union[np.ndarray, xr.Variable],
 
     min_indices = np.argmin(masked_sound_speed, axis=0)
 
-    return depth[:][min_indices]
+    return depth.values[min_indices]
 
 
 def _metpy(func, data, lat, lon, dim):

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -115,7 +115,7 @@
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [1400, 1550], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "riops_fc_2dll": {
@@ -199,7 +199,7 @@
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [1400, 1550], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "glorys3": {

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -55,7 +55,8 @@
             "magwatervel": { "name": "Water Velocity", "envtype": "ocean", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"] },
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
-            "sspeed": { "name": "Speed of Sound", "hide": true, "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] }
+            "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "giops_fc_2dps": {

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -114,7 +114,8 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [1400, 1550], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "riops_fc_2dll": {
@@ -197,7 +198,8 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [1400, 1550], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "glorys3": {

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -40,6 +40,8 @@ def find_colormap(name):
 _c = mcolors.ColorConverter().to_rgb
 data_dir = os.path.join(os.path.dirname(plotting.__file__), 'data')
 colormaps = {
+    'depth': cmocean.cm.deep,
+    'deep': cmocean.cm.deep,
     'partial pressure': cmocean.cm.matter,
     'primary production': cmocean.cm.algae,
     'temp gradient': cmocean.cm.thermal,
@@ -188,6 +190,7 @@ gettext('Color Brewer Blue-Yellow-Red')
 gettext('Temperature (old)')
 gettext('Vorticity')
 gettext('Density')
+gettext('Deep')
 
 colormap_names = {
     'anomaly': 'Anomaly',
@@ -215,7 +218,8 @@ colormap_names = {
     'BuYlRd': 'Color Brewer Blue-Yellow-Red',
     'temperature-old': 'Temperature (old)',
     'vorticity': 'Vorticity',
-    'density': 'Density'
+    'density': 'Density',
+    'deep': 'Deep'
 }
 
 

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import xarray as xr
 
 import data.calculated_parser.functions as funcs
 
@@ -40,4 +41,5 @@ class TestDataFunctions(unittest.TestCase):
             dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)
 
     def test_deepsoundchannel(self):
-        self.assertEqual(funcs.deepsoundchannel([0], [45], [0.5], [32]), 0)
+        self.assertEqual(funcs.deepsoundchannel(xr.Variable(
+            data=[0], dims=['depth']), [45], [0.5], [32]), 0)

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -38,3 +38,6 @@ class TestDataFunctions(unittest.TestCase):
         sal = 32 * np.ones((10, 2, 2))
         self.assertAlmostEqual(funcs.sspeed(
             dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)
+
+    def test_deepsoundchannel(self):
+        self.assertEqual(funcs.deepsoundchannel([0], [45], [0.5], [32]), 0)

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -28,3 +28,13 @@ class TestDataFunctions(unittest.TestCase):
 
         np.testing.assert_allclose(
             actual, expected, rtol=self.relative_tolerance)
+
+    def test_sspeed(self):
+        self.assertAlmostEqual(funcs.sspeed(0, 45, 0.5, 32), 1447.4, 1)
+
+        dep = range(0, 10)
+        lat = np.array([[45, 45], [45, 45]])
+        temp = 0.5 * np.ones((10, 2, 2))
+        sal = 32 * np.ones((10, 2, 2))
+        self.assertAlmostEqual(funcs.sspeed(
+            dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -31,9 +31,10 @@ class TestDataFunctions(unittest.TestCase):
             actual, expected, rtol=self.relative_tolerance)
 
     def test_sspeed(self):
-        self.assertAlmostEqual(funcs.sspeed(0, 45, 0.5, 32), 1447.4, 1)
+        np.testing.assert_allclose(funcs.sspeed(xr.Variable(
+            data=[0], dims=['depth']), [45], [0.5], [32]), 1447.4, rtol=self.relative_tolerance)
 
-        dep = range(0, 10)
+        dep = np.array(range(0, 10))
         lat = np.array([[45, 45], [45, 45]])
         temp = 0.5 * np.ones((10, 2, 2))
         sal = 32 * np.ones((10, 2, 2))

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -38,8 +38,9 @@ class TestDataFunctions(unittest.TestCase):
         lat = np.array([[45, 45], [45, 45]])
         temp = 0.5 * np.ones((10, 2, 2))
         sal = 32 * np.ones((10, 2, 2))
-        self.assertAlmostEqual(funcs.sspeed(
-            dep, lat, temp, sal)[0, 0, 0], 1447.4, 1)
+
+        np.testing.assert_allclose(funcs.sspeed(
+            dep, lat, temp, sal)[0, 0, 0], 1447.4, rtol=self.relative_tolerance)
 
     def test_deepsoundchannel(self):
         self.assertEqual(funcs.deepsoundchannel(xr.Variable(


### PR DESCRIPTION
## Background
tldr: Someone wanted sound channel calculations, and so we deliver.

Available in:
* GIOPS Forecast 3D (Lat/Lon)
* GIOPS Forecast 3D PS
* RIOPS Forecast 3D PS

Deep Sound Channel is defined as the depth where the minimum sound speed occurs in a given vertical column.

I also added a basic test for the new `deepsoundchannel` function.

## Why did you take this approach?
Fastest performing implementation since it's vectorized.

## Anything in particular that should be highlighted?
Not really. Vectorized code sometimes isn't the most intuitive to understand so I've added some comments to hopefully clarify things.

## Screenshot(s)
![Screenshot from 2020-02-11 10-16-39](https://user-images.githubusercontent.com/5572045/74241707-2283a380-4cb7-11ea-8fb7-23b1329898b8.png)

![Screenshot from 2020-02-11 11-17-30](https://user-images.githubusercontent.com/5572045/74246777-a2157080-4cbf-11ea-8320-63cfe5f72579.png)

## Bonus
Fixed a crash when calculating pressure with GIOPS Forecast 3D (Lat/Lon) so speed of sound is now available there too.

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
