### PR TITLE
Fix vector_variables property in DatasetConfig class.

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -154,7 +154,7 @@ class DatasetConfig():
         variables = {}
         for key,data in self._get_attribute("variables").items():
             is_hidden = data.get("hide")
-            is_vector = ',' in key
+            is_vector = 'mag' in key
 
             if (is_hidden is False or \
                     is_hidden is None or \

--- a/tests/test_dataset_config.py
+++ b/tests/test_dataset_config.py
@@ -32,7 +32,7 @@ class TestUtil(unittest.TestCase):
                         "name": "my_variable",
                     }
                 }
-            },
+            }
         }
 
         self.assertEqual(len(DatasetConfig.get_datasets()), 1)
@@ -60,16 +60,19 @@ class TestUtil(unittest.TestCase):
             "key": {
                 "enabled": True,
                 "variables": {
-                    "var,var2": {
+                    "magmyvar": {
+                        "name": "my_variable",
+                    },
+                    "magnitudemyvar": {
                         "name": "my_variable",
                     }
                 }
             },
         }
 
-        self.assertEqual(len(DatasetConfig("key").variables), 0)
-        self.assertEqual(len(DatasetConfig("key").vector_variables), 1)
-        result = DatasetConfig("key").variable["var,var2"]
+        self.assertEqual(len(DatasetConfig("key").variables), 2)
+        self.assertEqual(len(DatasetConfig("key").vector_variables), 2)
+        result = DatasetConfig("key").variable["magmyvar"]
         self.assertEqual(result.name, "my_variable")
         self.assertEqual(result.unit, "Unknown")
 


### PR DESCRIPTION
## Background
Once upon a time we constructed "vector variables" using two variables keys connected by a comma (e.g. "vomecrty,vozocrtx") to indicate a magnitude calculation. Now that we have a magnitude function defined in the calculation layer, this composite stuff can be removed. There are lots of places in the code where we do checks for composite keys, however the changes here specifically update the `DatasetConfig` class to check for `mag` substring in the dataset key instead of a comma.

This should fix the Navigator being unable to display vector variables in the Transect window.

## Why did you take this approach?
Most flexible way

## Anything in particular that should be highlighted?

NOTE: This will result in duplicate magnitude variables being displayed in the front-end because of some deprecated logic in the api. That will be removed in a new PR.

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
