### PR TITLE
Deprecate vectors api argument

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -413,7 +413,7 @@ export default class AreaWindow extends React.Component {
           state={this.state.output_variables}
           def={"defaults.dataset"}
           onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}
-          url={"/api/v1.0/variables/?vectors&dataset=" + this.state.dataset_0.dataset
+          url={"/api/v1.0/variables/?dataset=" + this.state.dataset_0.dataset
           }
           title={_("Variables")}
         />

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -151,7 +151,7 @@ export default class DatasetSelector extends React.Component {
           state={this.props.state.variable}
           def={"defaults.dataset"}
           onUpdate={this.variableUpdate}
-          url={"/api/v1.0/variables/?vectors&dataset=" + this.props.state.dataset + variables
+          url={"/api/v1.0/variables/?dataset=" + this.props.state.dataset + variables
           }
           title={_("Variable")}
         ><h1>{_("Variable")}</h1></ComboBox>

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -331,7 +331,7 @@ export default class PointWindow extends React.Component {
         state={this.props.variable}
         def=''
         onUpdate={this.props.onUpdate}
-        url={"/api/v1.0/variables/?vectors&dataset="+this.props.dataset}
+        url={"/api/v1.0/variables/?dataset="+this.props.dataset}
         title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
 
       <Range

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -114,9 +114,15 @@ def variables_query_v1_0():
 
     data = []
 
-    if 'vectors_only' not in args:
+    if 'vectors_only' in args:
+        for variable in config.vector_variables:
+            data.append({
+                'id': variable,
+                'value': config.variable[variable].name,
+                'scale': config.variable[variable].scale,
+            })
+    else:
         with open_dataset(config, meta_only=True) as ds:
-
             for v in ds.variables:
                 if ('3d_only' in args) and v.is_surface_only():
                     continue
@@ -127,14 +133,6 @@ def variables_query_v1_0():
                                 'value': config.variable[v].name,
                                 'scale': config.variable[v].scale
                                 })
-
-    if 'vectors' in args or 'vectors_only' in args:
-        for variable in config.vector_variables:
-            data.append({
-                'id': variable,
-                'value': config.variable[variable].name,
-                'scale': config.variable[variable].scale,
-            })
 
     data = sorted(data, key=lambda k: k['value'])
 
@@ -376,7 +374,7 @@ def timestamps():
     vals = []
     with SQLiteDatabase(config.url) as db:
         if variable in config.calculated_variables:
-            data_vars = get_data_vars_from_equation(config.calculated_variables[variable]['equation'], 
+            data_vars = get_data_vars_from_equation(config.calculated_variables[variable]['equation'],
                                                     [v.key for v in db.get_data_variables()])
             vals = db.get_timestamps(data_vars[0])
         else:
@@ -424,6 +422,7 @@ def bathymetry_v1_0(projection: str, zoom: int, x: int, y: int):
 @bp_v1_0.route('/api/v1.0/mbt/<string:projection>/<string:tiletype>/<int:zoom>/<int:x>/<int:y>')
 def mbt(projection: str, tiletype: str, zoom: int, x: int, y: int):
     return routes.routes_impl.mbt_impl(projection, tiletype, zoom, x, y)
+
 
 @bp_v1_0.after_request
 def after_request(response):

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -60,7 +60,7 @@ class TestAPIv1(unittest.TestCase):
         self.assertEqual(resp_data[0]['scale'], [-5, 30])
         self.assertEqual(resp_data[0]['value'], 'Temperature')
 
-        res = self.app.get('/api/v1.0/variables/?dataset=giops&vectors')
+        res = self.app.get('/api/v1.0/variables/?dataset=giops')
 
         self.assertEqual(res.status_code, 200)
 


### PR DESCRIPTION
## Background
Extension of #647 where I removed the need for the `vectors` option in the API since we calculate the magnitude properly through the calculation layer.

This resolves the duplicate magnitude variables in the front-end introduced by #647 

Did a search of the code and removed all references of `vectors`.

## Why did you take this approach?
It's the only way.

## Anything in particular that should be highlighted?
Nope

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
