### PR TITLE
Remove unused attributes in mercator.py

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -23,8 +23,6 @@ class Mercator(CalculatedData):
     def __init__(self, url, **kwargs):
         self.latvar = None
         self.lonvar = None
-        self.__latsort = None
-        self.__lonsort = None
 
         super(Mercator, self).__init__(url, **kwargs)
 
@@ -34,8 +32,6 @@ class Mercator(CalculatedData):
         if not self._meta_only:
             if self.latvar is None:
                 self.latvar, self.lonvar = self.latlon_variables
-                self.__latsort = np.argsort(self.latvar[:])
-                self.__lonsort = np.argsort(np.mod(self.lonvar[:] + 360, 360))
 
         return self
 


### PR DESCRIPTION
## Background
Resolves #653 

Looked back in the git blame and the last commit related to this code was by me two years ago. Seems like this code path hasn't been used for a very long time. Doing a search for `self.__latsort` and `self.__lonsort` yielded these two locations.

## Why did you take this approach?
It's the only way

## Anything in particular that should be highlighted?
nope

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
