### PR TITLE
Cast time dim values to int when calculating corresponding time index

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -108,7 +108,7 @@ class NetCDFData(Data):
             [int or list] -- Time index(es).
         """
 
-        time_var = self.time_variable
+        time_var = self.time_variable.astype(np.int)
 
         result = np.nonzero(np.isin(time_var, timestamp))[0]
 


### PR DESCRIPTION
## Background
Some datasets have floating-point values in their time dimensions, even though the sqlite databases store them as integers (see below for reasoning) which causes the `timestamp_to_time_index` method to not find a corresponding time index since int -> float comparisons don't work.

I've opted to simple bring forward the database logic and do a quick cast to integer in order to account for this case.

## Why did you take this approach?
Least painful way.

## Anything in particular that should be highlighted?
It's worth emphasizing that it's ok to cast these float values to integers since our datasets do not require millisecond-or-higher time resolution. All datasets are either "hours since" or "seconds since...". The sqlite databases also make this assumption, hence the timestamp column is marked as INTEGER.

This method works for now, however if we get a dataset down the road where millisecond resolution is required (which is highly unlikely), we'll have to re-think this approach.

## Screenshot(s)
Glorys v4 Climatology is now working:
![Screenshot from 2020-02-18 12-16-52](https://user-images.githubusercontent.com/5572045/74751630-1c0da280-5248-11ea-8abe-070194109cd8.png)

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
