### PR TITLE
Increase Max Zoom

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -56,7 +56,7 @@ const MIN_ZOOM = {
 };
 
 const MAX_ZOOM = {
-  "EPSG:3857": 13,
+  "EPSG:3857": 16,
   "EPSG:32661": 5,
   "EPSG:3031": 5,
 };

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -914,7 +914,7 @@ def mbt(projection: str, tiletype: str, zoom: int, x: int, y: int):
     if (zoom < 7) or (projection != "EPSG:3857"):
         return send_file(shape_file_dir + "/blank.mbt")
 
-    if (zoom > 12) and (tiletype == "bath"):
+    if (zoom > 11) and (tiletype == "bath"):
         return send_file(shape_file_dir + "/blank.mbt")
 
     # Send file if cached or select data in SQLite file

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -914,6 +914,9 @@ def mbt(projection: str, tiletype: str, zoom: int, x: int, y: int):
     if (zoom < 7) or (projection != "EPSG:3857"):
         return send_file(shape_file_dir + "/blank.mbt")
 
+    if (zoom > 12) and (tiletype == "bath"):
+        return send_file(shape_file_dir + "/blank.mbt")
+
     # Send file if cached or select data in SQLite file
     if os.path.isfile(requestf):
         return send_file(requestf)


### PR DESCRIPTION
## Background
A new set of Mapbox tiles were created to increase the max zoom level. This PR changes some of the boundaries to allow users to zoom in further and use the new tiles.

## Why did you take this approach?
only way

## Anything in particular that should be highlighted?


## Screenshot(s)
Halifax harbor at second to highest zoom level
![z15](https://user-images.githubusercontent.com/36578069/75358495-8d270880-588d-11ea-9260-b1f21a7ba98a.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
