### PR TITLE
Front-end: display hours in UTC

### DIFF
--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -255,14 +255,14 @@ export default class TimePicker extends React.Component {
     if (this.props.quantum === "hour") {
       var times = [];
       d = $(this.refs.picker).datepicker("getDate");
-      const isodatestr = dateFormat(d, "yyyy-mm-dd");
+      const isodatestr = dateFormat(d, "yyyy-mm-dd", true);
 
       for (let i = 0; i < this.state.data.length; ++i) {
         if (this.state.data[i].value.indexOf(isodatestr) === 0) {
           if (this.state.data[i].id <= max && this.state.data[i].id >= min) {
             times.unshift({
               id: this.state.data[i].id,
-              value: dateFormat(this.state.data[i].value, "HH:MM")
+              value: dateFormat(this.state.data[i].value, "HH:MM", true)
             });
           }
         }


### PR DESCRIPTION
## Background
The hour selector in the front-end was automatically converting UTC to the client browsers time zone. This caused some confusion since the datasets we display are in UTC. Also, the time label says UTC.

Tweak `Timepicker.jsx` to format the hours/minutes in UTC and not the client time zone.

Two line change.

cc @nsoontie 

## Why did you take this approach?
It's the only way.

## Anything in particular that should be highlighted?

The signature for `dateFormat` is:
```ts
dateFormat(
    date?: Date | string | number,
    mask?: string,
    utc?: boolean,
    gmt?: boolean
)
```

## Screenshot(s)
![image](https://user-images.githubusercontent.com/5572045/75361314-b184e400-5891-11ea-8f83-7d1f445ae12c.png)

![image](https://user-images.githubusercontent.com/5572045/75361619-2a843b80-5892-11ea-8875-dfb99c3173c5.png)

## Checks
- [x] I ran unit tests (not that we have any front-end tests to run lol).
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
