### PR TITLE
Implement sonic layer depth calculated variable

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -66,8 +66,40 @@ def __calc_pressure(depth, latitude):
     return np.array(pressure)
 
 
+def __validate_depth_lat_temp_sal(depth, latitude, temperature, salinity):
+
+    if type(depth) is not np.ndarray:
+        depth = np.array(depth)
+
+    if type(latitude) is not np.ndarray:
+        latitude = np.array(latitude)
+
+    if type(temperature) is not np.ndarray:
+        temperature = np.array(temperature)
+
+    if type(salinity) is not np.ndarray:
+        salinity = np.array(salinity)
+
+    return depth, latitude, temperature, salinity
+
+
+def __find_depth_index_of_min_value(data: np.ndarray, depth_axis=0) -> np.ndarray:
+
+    # Mask out NaN values to prevent an exception blow-up.
+    masked = np.ma.masked_array(data, np.isnan(data))
+
+    return np.argmin(masked, axis=depth_axis)
+
+
+def __find_depth_index_of_max_value(data: np.ndarray, depth_axis=0) -> np.ndarray:
+    # Mask out NaN values to prevent an exception blow-up.
+    masked = np.ma.masked_array(data, np.isnan(data))
+
+    return np.argmax(masked, axis=depth_axis)
+
+
 def oxygensaturation(temperature: np.ndarray,
-                     salinity: np.ndarray):
+                     salinity: np.ndarray) -> np.ndarray:
     """
     Calculate the solubility (saturation) of 
     Oxygen (O2) in seawater.
@@ -82,7 +114,7 @@ def oxygensaturation(temperature: np.ndarray,
 
 
 def nitrogensaturation(temperature: np.ndarray,
-                       salinity: np.ndarray):
+                       salinity: np.ndarray) -> np.ndarray:
     """
     Calculate the solubility (saturation) of 
     Nitrogen (N2) in seawater.
@@ -99,7 +131,7 @@ def nitrogensaturation(temperature: np.ndarray,
 def sspeed(depth: Union[np.ndarray, xr.Variable],
            latitude: np.ndarray,
            temperature: np.ndarray,
-           salinity: np.ndarray):
+           salinity: np.ndarray) -> np.ndarray:
     """
     Calculates the speed of sound.
 
@@ -111,16 +143,10 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
     * salinity: The salinity (unitless)
     """
 
-    if type(latitude) is not np.ndarray:
-        latitude = np.array(latitude)
+    depth, latitude, temperature, salinity = __validate_depth_lat_temp_sal(
+        depth, latitude, temperature, salinity)
 
     press = __calc_pressure(depth, latitude)
-
-    if type(temperature) is not np.ndarray:
-        temperature = np.array(temperature)
-
-    if type(salinity) is not np.ndarray:
-        salinity = np.array(salinity)
 
     if salinity.shape != press.shape:
         # pad array shape to match otherwise seawater freaks out
@@ -130,7 +156,7 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
     return np.array(speed)
 
 
-def density(depth, latitude, temperature, salinity):
+def density(depth, latitude, temperature, salinity) -> np.ndarray:
     """
     Calculates the density of sea water.
 
@@ -147,7 +173,7 @@ def density(depth, latitude, temperature, salinity):
     return np.array(density)
 
 
-def heatcap(depth, latitude, temperature, salinity):
+def heatcap(depth, latitude, temperature, salinity) -> np.ndarray:
     """
     Calculates the heat capacity of sea water.
 
@@ -164,16 +190,19 @@ def heatcap(depth, latitude, temperature, salinity):
     return np.array(heatcap)
 
 
-def tempgradient(depth, latitude, temperature, salinity):
+def tempgradient(depth, latitude, temperature, salinity) -> np.ndarray:
     """
     Calculates the adiabatic temp gradient of sea water.
 
-    Parameters:
-    depth: The depth(s) in meters
-    latitude: The latitude(s) in degrees North
-    temperature: The temperatures(s) in Celsius
-    salinity: The salinity (unitless)
+    Required Arguments:
+        * depth: Depth in meters
+        * latitude: Latitude in degrees North
+        * temperature: Temperatures in Celsius
+        * salinity: Salinity
     """
+
+    depth, latitude, temperature, salinity = __validate_depth_lat_temp_sal(
+        depth, latitude, temperature, salinity)
 
     press = __calc_pressure(depth, latitude)
 
@@ -181,45 +210,60 @@ def tempgradient(depth, latitude, temperature, salinity):
     return np.array(tempgradient)
 
 
-def deepsoundchannel(depth: Union[np.ndarray, xr.Variable],
-                     latitude: np.ndarray,
-                     temperature: np.ndarray,
-                     salinity: np.ndarray) -> np.ndarray:
+def soniclayerdepth(depth, latitude, temperature, salinity) -> np.ndarray:
+    """
+    Find and return the depth of the maximum value of the speed
+    of sound ABOVE the deep sound channel.
+
+    Required Arguments:
+        * depth: Depth in meters
+        * latitude: Latitude in degrees North
+        * temperature: Temperatures in Celsius
+        * salinity: Salinity
+    """
+
+    depth, latitude, temperature, salinity = __validate_depth_lat_temp_sal(
+        depth, latitude, temperature, salinity)
+
+    sound_speed = sspeed(depth, latitude, temperature, salinity)
+
+    min_indices = __find_depth_index_of_min_value(sound_speed)
+
+    # Mask out values below deep sound channel
+    mask = min_indices.ravel()[..., np.newaxis] < np.arange(
+        sound_speed.shape[0])
+    mask = mask.T.reshape(sound_speed.shape)
+
+    sound_speed[mask] = np.nan
+
+    # Find sonic layer depth indices
+    max_indices = __find_depth_index_of_max_value(sound_speed)
+
+    return depth[max_indices]
+
+
+def deepsoundchannel(depth, latitude, temperature, salinity) -> np.ndarray:
     """
     Find and return the depth of the minimum value of the
     speed of sound.
 
     https://en.wikipedia.org/wiki/SOFAR_channel
 
-    Required Arguments:
-        * depth: The depth(s) in meters
-        * lat: The latitude(s) in degrees North
-        * temperature: The temperatures(s) (at all depths) in Celsius
-        * salinity: The salinity (at all depths)
+     Required Arguments:
+        * depth: Depth in meters
+        * latitude: Latitude in degrees North
+        * temperature: Temperatures in Celsius
+        * salinity: Salinity
     """
 
-    if type(latitude) is not np.ndarray:
-        latitude = np.array(latitude)
-
-    if type(temperature) is not np.ndarray:
-        temperature = np.array(temperature)
-
-    if type(salinity) is not np.ndarray:
-        salinity = np.array(salinity)
+    depth, latitude, temperature, salinity = __validate_depth_lat_temp_sal(
+        depth, latitude, temperature, salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
 
-    # Mask out NaN values to prevent an exception blow-up.
-    masked_sound_speed = np.ma.masked_array(sound_speed, np.isnan(sound_speed))
+    min_indices = __find_depth_index_of_min_value(sound_speed)
 
-    # The resulting shape of sound_speed is (full_depth, lat_slice, lon_slice)
-    # So we simply need to find the minimum sound speed along each lat/lon index
-    # Using numpy axis magic, we want the minimum along the full_depth axis = 0.
-    # https://stackoverflow.com/a/52468964/2231969
-
-    min_indices = np.argmin(masked_sound_speed, axis=0)
-
-    return depth.values[min_indices]
+    return depth[min_indices]
 
 
 def _metpy(func, data, lat, lon, dim):

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -172,7 +172,8 @@
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "giops_10day": {
@@ -197,7 +198,8 @@
             "votemper": { "name": "Temperature", "envtype": "ocean", "unit": "Celsius", "scale": [-5, 30], "equation": "votemper - 273.15", "dims": ["time", "depth", "latitude", "longitude"] },
             "vosaline": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [30, 40] },
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "latitude", "longitude"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "latitude", "longitude"] }
         }
     },
     "giops_fc_2dps": {
@@ -292,7 +294,8 @@
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "giops_fc_10day_3dps": {
@@ -320,7 +323,8 @@
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1030], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "riops_fc_2dll": {
@@ -408,7 +412,8 @@
             "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
             "oxygensaturation": { "name": "Oxygen Saturation", "scale": [4, 11], "unit": "ml/l", "equation": "oxygensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "nitrogensaturation": { "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "nitrogensaturation": { "name": "Nitrogen Saturation", "scale": [8, 20], "unit": "ml/l", "equation": "nitrogensaturation(votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "ecc_datamart_riops_fc_3dps": {
@@ -434,7 +439,9 @@
             "sspeed": { "name": "Speed of Sound", "envtype": "ocean", "scale": [1400, 1600], "scale_factor": 1, "unit": "m/s", "equation": "sspeed(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "density": { "name": "Water Density", "envtype": "ocean", "scale": [1000, 1050], "scale_factor": 1, "unit": "kg/m^3", "equation": "density(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
             "heatcapacity": { "name": "Heat Capacity", "envtype": "ocean", "scale": [3950, 4220], "scale_factor": 1, "unit": "J/(kg*K)", "equation": "heatcap(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
-            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] }
+            "tempgradient": { "name": "Adiabatic Temp Gradient", "envtype": "ocean", "scale": [-2.9e-5, 1.5e-4], "scale_factor": 1, "unit": "Celsius/db", "equation": "tempgradient(depth, latitude, votemper - 273.15, vosaline)", "dims": ["time", "depth", "yc", "xc"] },
+            "deepsoundchannel": { "name": "Deep Sound Channel", "unit": "m", "scale": [0, 1700], "equation": "deepsoundchannel([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] },
+            "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
     "glorys3": {

--- a/tests/test_data_functions.py
+++ b/tests/test_data_functions.py
@@ -45,3 +45,7 @@ class TestDataFunctions(unittest.TestCase):
     def test_deepsoundchannel(self):
         self.assertEqual(funcs.deepsoundchannel(xr.Variable(
             data=[0], dims=['depth']), [45], [0.5], [32]), 0)
+
+    def test_soniclayerdepth(self):
+        self.assertEqual(funcs.soniclayerdepth(xr.Variable(
+            data=[0], dims=['depth']), [45], [0.5], [32]), 0)


### PR DESCRIPTION
## Background

New variable has been added to all giops/riops 3D datasets.

## Why did you take this approach?
Vectorized and as memory-efficient as I can make it.

## Anything in particular that should be highlighted?
Nope.

## Screenshot(s)
![Screenshot from 2020-02-27 12-36-41](https://user-images.githubusercontent.com/5572045/75461406-53bdce00-595d-11ea-85d6-4144cc7813da.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
