### PR TITLE
GPSC modifications

### DIFF
--- a/launch-web-service.sh
+++ b/launch-web-service.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
+HOST_IP=`ip addr show | egrep "e(th|np)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//'`
+
+PORT=5000
+
+nc -zv 0.0.0.0 $PORT > /dev/null
+RES=$?
+
+while  [ $((RES)) -eq 0 ] ; do
+	PORT=$((PORT+1))
+	nc -zv 0.0.0.0 $PORT > /dev/null
+	RES=$?
+done
+
+echo "Use the following IP in your URL ${HOST_IP}:$((PORT))"
 echo "This will log information from the application to the screen and the logfile."
-exec bash runserver.sh &> >(tee -a /home/buildadm/launch-web-service.log)
+exec bash runserver.sh $PORT &> >(tee -a ${HOME}/launch-on-web-service.log)

--- a/launch-web-service.sh
+++ b/launch-web-service.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-HOST_IP=`ip addr show | egrep "e(th|np)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//'`
+HOST_IP=$(ip addr show | grep -E "e(th|np)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//')
 
 PORT=5000
 
@@ -12,6 +12,8 @@ while  [ $((RES)) -eq 0 ] ; do
 	RES=$?
 done
 
+echo " "
 echo "Use the following IP in your URL ${HOST_IP}:$((PORT))"
+echo " "
 echo "This will log information from the application to the screen and the logfile."
 exec bash runserver.sh $PORT &> >(tee -a ${HOME}/launch-on-web-service.log)

--- a/launch-web-service.sh
+++ b/launch-web-service.sh
@@ -3,12 +3,12 @@ HOST_IP=`ip addr show | egrep "e(th|np)" | grep inet | awk '{print $2}' | sed -e
 
 PORT=5000
 
-nc -zv 0.0.0.0 $PORT > /dev/null
+nc -zv 0.0.0.0 $PORT > /dev/null 2>&1
 RES=$?
 
 while  [ $((RES)) -eq 0 ] ; do
 	PORT=$((PORT+1))
-	nc -zv 0.0.0.0 $PORT > /dev/null
+	nc -zv 0.0.0.0 $PORT > /dev/null 2>&1
 	RES=$?
 done
 

--- a/runserver.sh
+++ b/runserver.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Usage: ./runserver.sh <optional_dataset_config_file.json>
+# Usage: ./runserver.sh <port> <optional_dataset_config_file.json>
 # <optional_dataset_config_file.json>:  Specify a non-default dataset config file to load the Navigator with.
 #                                       Argument not required.
 
-gunicorn -w 12 -t 90 --graceful-timeout 90 --preload -b 0.0.0.0:5000 --reload "oceannavigator:create_app()" $1
+[[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
+gunicorn -w 4 -t 90 --graceful-timeout 90 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2


### PR DESCRIPTION
## Background
Need to come up with a way such that researchers are able to launch their own Navigator instance. The script will check to see if a network port is free. If it is not it increments by one and checks again. If the port is not  in use it will proceed with launching the Navigator on the available port.

## Why did you take this approach?
In order to allow multiple users to be able to launch their own instance or possibly multiple instances of the Navigator on various machines.

## Anything in particular that should be highlighted?
There is no exponential backoff. The script will just keep going from 5000 by 1 until a free port is found. Also, the user is given the URL which is the <IP Address>:<PORT> where the instance is running.

## Screenshot(s)
![Screen Shot 2020-03-02 at 5 36 24 PM](https://user-images.githubusercontent.com/44408505/75717780-606b5a80-5cac-11ea-8a55-68b3fa5582b3.png)


## Checks
N/A
