### PR TITLE
Fixed expected value in the 5th decimal place

### DIFF
--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -49,13 +49,6 @@ class TestNemo(unittest.TestCase):
 
             self.assertEqual(idx, 0)
 
-    def test_timestamp_to_time_index(self):
-        with Nemo('tests/testdata/nemo_test.nc') as n:
-
-            idx = n.timestamp_to_time_index(2031436800)
-
-            self.assertEqual(idx, 0)
-
     def test_time_variable(self):
         with Nemo('tests/testdata/nemo_test.nc') as n:
             time_var = n.time_variable

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -42,6 +42,7 @@ class TestNemo(unittest.TestCase):
             self.assertEqual(sorted(variables['votemper'].dimensions), sorted(
                 ["deptht", "time_counter", "y", "x"]))
 
+
     def test_timestamp_to_time_index(self):
         with Nemo('tests/testdata/nemo_test.nc') as n:
 
@@ -85,7 +86,7 @@ class TestNemo(unittest.TestCase):
             p, d = n.get_profile(13.0, -149.0, 2031436800, 'votemper')
             self.assertAlmostEqual(p[0], 299.17, places=2)
             self.assertAlmostEqual(p[10], 299.15, places=2)
-            self.assertAlmostEqual(p[20], 296.466766, places=6)
+            self.assertAlmostEqual(p[20], 296.466743, places=6)
             self.assertTrue(np.ma.is_masked(p[49]))
 
     def test_get_profile_depths(self):
@@ -154,7 +155,7 @@ class TestNemo(unittest.TestCase):
                 13.0, -149.0, 2031436800, 2034072000, 'votemper')
             self.assertAlmostEqual(r[0, 0], 299.17, places=2)
             self.assertAlmostEqual(r[0, 10], 299.15, places=2)
-            self.assertAlmostEqual(r[0, 20], 296.466766, places=6)
+            self.assertAlmostEqual(r[0, 20], 296.466743, places=6)
             self.assertTrue(np.ma.is_masked(r[0, 49]))
 
             self.assertNotEqual(r[0, 0], r[1, 0])


### PR DESCRIPTION
There was a 2.27e-5 difference in the expected compared to return value for the profile tests. Updated test to match returned value.