### PR TITLE
Update to the runserver.sh script

### DIFF
--- a/runserver.sh
+++ b/runserver.sh
@@ -6,6 +6,6 @@
 
 [[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
 
-NUMBER_PROCS=$(cat /proc/cpuinfo | awk /processor/'{processor++} END {print processor}')
+NUMBER_PROCS=$(awk /processor/'{processor++} END {print processor}' < /proc/cpuinfo)
 
 gunicorn -w $((NUMBER_PROCS)) -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2

--- a/runserver.sh
+++ b/runserver.sh
@@ -5,4 +5,7 @@
 #                                       Argument not required.
 
 [[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
-gunicorn -w 4 -t 90 --graceful-timeout 90 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2
+
+NUMBER_PROCS=$(cat /proc/cpuinfo | awk /processor/'{processor++} END {print processor}')
+
+gunicorn -w $((NUMBER_PROCS)) -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2


### PR DESCRIPTION
Launch as many gunicorn processes as their are processors. The timeout was increased for both the silent works terminated and restated. And again for the graceful restart of workers.

## Background
Previously we set the number of gunicorn processes to some value. Depending on the instance resources there were either to many or to few gunicorn services running. This will launch the number of gunicorn processes as their are processors. 

Also, the timeout values were increased from 90s to 300s. Depending on what datasets were selected and if there was a large time range requested. The stalled gunicorn processes were terminated.

## Checks
- [ N/A] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
