### PR TITLE
Clean up attrs access among NetCDFData and Model-derived classes

### DIFF
--- a/data/fvcom.py
+++ b/data/fvcom.py
@@ -30,7 +30,6 @@ class Fvcom(Model):
         super().__init__(nc_data)
         self.nc_data = nc_data
         self.variables = nc_data.variables
-        self.time_variable = None
         self._kdt: KDTree = [None, None]
         self.__timestamp_cache: TTLCache = TTLCache(1, 3600)
 
@@ -63,7 +62,7 @@ class Fvcom(Model):
             [int] -- Time index.
         """
 
-        time_var = self.time_variable
+        time_var = self.nc_data.time_variable
 
         # https: // stackoverflow.com/a/41022847/2231969
         # We use 1.e-7 since the default 1.e-5 doesn't provide enough precision

--- a/data/fvcom.py
+++ b/data/fvcom.py
@@ -274,7 +274,7 @@ class Fvcom(Model):
             longitude = np.array([longitude])
 
         var = self.nc_data.get_dataset_variable(variable)
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
         latvar, lonvar = self.__latlon_vars(variable)
 
         if depth == 'bottom':
@@ -294,7 +294,7 @@ class Fvcom(Model):
     def get_point(self, latitude, longitude, depth, timestamp, variable,
                   return_depth=False):
         var = self.nc_data.get_dataset_variable(variable)
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
         latvar, lonvar = self.__latlon_vars(variable)
 
         min_i, max_i, radius = self.__bounding_box(
@@ -344,7 +344,7 @@ class Fvcom(Model):
 
     def __get_depths(self, variable, timestamp, min_i, max_i):
         var = self.nc_data.get_dataset_variable(variable)
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         if 'nele' in var.dimensions:
             # First, find indicies to cover the nodes
@@ -410,7 +410,7 @@ class Fvcom(Model):
 
     def get_profile(self, latitude, longitude, timestamp, variable):
         latvar, lonvar = self.__latlon_vars(variable)
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         min_i, max_i, radius = self.__bounding_box(
             latitude, longitude,

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -20,13 +20,11 @@ class Mercator(Model):
         self.latvar = None
         self.lonvar = None
         self.nc_data = nc_data
-        self._dataset = nc_data.dataset
         self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
 
     def __enter__(self):
         self.nc_data.__enter__()
-        self._dataset = self.nc_data.dataset
 
         if not self._meta_only:
             if self.latvar is None:
@@ -45,7 +43,7 @@ class Mercator(Model):
             var = None
             for v in self.nc_data.depth_dimensions:
                 # Depth is usually a "coordinate" variable
-                if v in self._dataset.coords.keys():
+                if v in self.nc_data.dataset.coords:
                     # Get DataArray for depth
                     var = self.nc_data.get_dataset_variable(v)
                     break
@@ -63,7 +61,7 @@ class Mercator(Model):
 
     def __bounding_box(self, lat, lon, n=10):
 
-        y, x, _ = find_nearest_grid_point(lat, lon, self._dataset, self.latvar, self.lonvar, n)
+        y, x, _ = find_nearest_grid_point(lat, lon, self.nc_data.dataset, self.latvar, self.lonvar, n)
 
         def fix_limits(data, limit):
             mx = np.amax(data)

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -24,7 +24,6 @@ class Mercator(Model):
         self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
         self.timestamp_to_time_index = nc_data.timestamp_to_time_index
-        self.time_variable = None
         self.timestamps = None
 
     def __enter__(self):
@@ -32,7 +31,6 @@ class Mercator(Model):
         self._dataset = self.nc_data.dataset
 
         if not self._meta_only:
-            self.time_variable = self.nc_data.time_variable
             self.timestamps = self.nc_data.timestamps
             if self.latvar is None:
                 self.latvar, self.lonvar = self.nc_data.latlon_variables

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -61,7 +61,7 @@ class Mercator(Model):
 
     def __bounding_box(self, lat, lon, n=10):
 
-        y, x, _ = find_nearest_grid_point(lat, lon, self.nc_data.dataset, self.latvar, self.lonvar, n)
+        y, x, _ = find_nearest_grid_point(lat, lon, self.latvar, self.lonvar, n)
 
         def fix_limits(data, limit):
             mx = np.amax(data)

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -23,7 +23,6 @@ class Mercator(Model):
         self._dataset = nc_data.dataset
         self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
-        self.timestamp_to_time_index = nc_data.timestamp_to_time_index
 
     def __enter__(self):
         self.nc_data.__enter__()
@@ -167,7 +166,7 @@ class Mercator(Model):
 
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         if depth == 'bottom':
             if hasattr(time, "__len__"):
@@ -222,7 +221,7 @@ class Mercator(Model):
 
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         if depth == 'bottom':
             if hasattr(time, "__len__"):
@@ -312,7 +311,7 @@ class Mercator(Model):
         if len(var.shape) != 4:
             raise APIError("This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
 
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         miny, maxy, minx, maxx, radius = self.__bounding_box(
             latitude, longitude, 10)

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -24,14 +24,12 @@ class Mercator(Model):
         self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
         self.timestamp_to_time_index = nc_data.timestamp_to_time_index
-        self.timestamps = None
 
     def __enter__(self):
         self.nc_data.__enter__()
         self._dataset = self.nc_data.dataset
 
         if not self._meta_only:
-            self.timestamps = self.nc_data.timestamps
             if self.latvar is None:
                 self.latvar, self.lonvar = self.nc_data.latlon_variables
 

--- a/data/nearest_grid_point.py
+++ b/data/nearest_grid_point.py
@@ -15,9 +15,7 @@ import numpy as np
 from pykdtree.kdtree import KDTree
 
 
-def find_nearest_grid_point(
-        lat, lon, dataset, latvar, lonvar, n=1
-):
+def find_nearest_grid_point(lat, lon, latvar, lonvar, n=1):
     """Find the nearest grid point to a given lat/lon pair.
 
     Parameters

--- a/data/nearest_grid_point.py
+++ b/data/nearest_grid_point.py
@@ -24,8 +24,6 @@ def find_nearest_grid_point(lat, lon, latvar, lonvar, n=1):
         Latitude value at which to find the nearest grid point.
     lon : float
         Longitude value at which to find the nearest grid point.
-    dataset : xarray.Dataset
-        An xarray Dataset containing the mesh variables.
     latvar : xarray.DataArray
         DataArray corresponding to latitude variable.
     lonVar : xarray.DataArray

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -26,16 +26,12 @@ class Nemo(Model):
         self.__lonsort = None
         self.nc_data = nc_data
         self._dataset = nc_data.dataset
-        self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
         self.timestamp_to_time_index = nc_data.timestamp_to_time_index
-        self.timestamps = None
 
     def __enter__(self):
         self.nc_data.__enter__()
         self._dataset = self.nc_data.dataset
-        if not self._meta_only:
-            self.timestamps = self.nc_data.timestamps
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -20,10 +20,6 @@ class Nemo(Model):
 
     def __init__(self, nc_data: Union[CalculatedData, NetCDFData]) -> None:
         super().__init__(nc_data)
-        self.latvar = None
-        self.lonvar = None
-        self.__latsort = None
-        self.__lonsort = None
         self.nc_data = nc_data
         self.variables = nc_data.variables
 

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -25,12 +25,10 @@ class Nemo(Model):
         self.__latsort = None
         self.__lonsort = None
         self.nc_data = nc_data
-        self._dataset = nc_data.dataset
         self.variables = nc_data.variables
 
     def __enter__(self):
         self.nc_data.__enter__()
-        self._dataset = self.nc_data.dataset
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -45,7 +43,7 @@ class Nemo(Model):
             # Look through possible dimension names
             for v in self.nc_data.depth_dimensions:
                 # Depth is usually a "coordinate" variable
-                if v in self._dataset.coords.keys():
+                if v in self.nc_data.dataset.coords:
                     # Get DataArray for depth
                     var = self.nc_data.get_dataset_variable(v)
                     break
@@ -64,7 +62,7 @@ class Nemo(Model):
     def __bounding_box(self, lat, lon, latvar, lonvar, n=10):
         """Computes and returns points bounding lat, lon.
         """
-        y, x, d = find_nearest_grid_point(lat, lon, self._dataset, latvar, lonvar, n)
+        y, x, d = find_nearest_grid_point(lat, lon, self.nc_data.dataset, latvar, lonvar, n)
 
         def fix_limits(data, limit):
             mx = np.amax(data)
@@ -171,11 +169,11 @@ class Nemo(Model):
                 if p[0] in coordinates:
                     return (
                         self.nc_data.get_dataset_variable(p[0]),
-                        self.nc_data.get_dataset_variable(p[1]) # Check this
+                        self.nc_data.get_dataset_variable(p[1])  # Check this
                     )
         else:
             for p in pairs:
-                if p[0] in self._dataset.variables:
+                if p[0] in self.nc_data.dataset.variables:
                     return (
                         self.nc_data.get_dataset_variable(p[0]),
                         self.nc_data.get_dataset_variable(p[1])

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -27,7 +27,6 @@ class Nemo(Model):
         self.nc_data = nc_data
         self._dataset = nc_data.dataset
         self.variables = nc_data.variables
-        self.timestamp_to_time_index = nc_data.timestamp_to_time_index
 
     def __enter__(self):
         self.nc_data.__enter__()
@@ -213,7 +212,7 @@ class Nemo(Model):
 
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
         if depth == 'bottom':
             if hasattr(time, "__len__"):
@@ -268,7 +267,7 @@ class Nemo(Model):
         # Get xarray.Variable
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.timestamp_to_time_index(timestamp)
+        time = self.nc_data.timestamp_to_time_index(timestamp)
 
 
         if depth == 'bottom':
@@ -354,7 +353,7 @@ class Nemo(Model):
             raise APIError(
                 "This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
 
-        time_index = self.timestamp_to_time_index(timestamp)
+        time_index = self.nc_data.timestamp_to_time_index(timestamp)
 
         latvar, lonvar = self.__latlon_vars(variable)
 

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -58,7 +58,7 @@ class Nemo(Model):
     def __bounding_box(self, lat, lon, latvar, lonvar, n=10):
         """Computes and returns points bounding lat, lon.
         """
-        y, x, d = find_nearest_grid_point(lat, lon, self.nc_data.dataset, latvar, lonvar, n)
+        y, x, d = find_nearest_grid_point(lat, lon, latvar, lonvar, n)
 
         def fix_limits(data, limit):
             mx = np.amax(data)

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -29,14 +29,12 @@ class Nemo(Model):
         self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
         self.timestamp_to_time_index = nc_data.timestamp_to_time_index
-        self.time_variable = None
         self.timestamps = None
 
     def __enter__(self):
         self.nc_data.__enter__()
         self._dataset = self.nc_data.dataset
         if not self._meta_only:
-            self.time_variable = self.nc_data.time_variable
             self.timestamps = self.nc_data.timestamps
         return self
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -237,12 +237,11 @@ class NetCDFData(Data):
         if not entire_globe:
             # Find closest indices in dataset corresponding to each calculated point
             ymin_index, xmin_index, _ = find_nearest_grid_point(
-                bottom_left[0], bottom_left[1], self.dataset,
-                self.get_dataset_variable(
+                bottom_left[0], bottom_left[1], self.get_dataset_variable(
                     lat_var), self.get_dataset_variable(lon_var)
             )
             ymax_index, xmax_index, _ = find_nearest_grid_point(
-                top_right[0], top_right[1], self.dataset, self.get_dataset_variable(
+                top_right[0], top_right[1], self.get_dataset_variable(
                     lat_var), self.get_dataset_variable(lon_var)
             )
 

--- a/plotting/drifter.py
+++ b/plotting/drifter.py
@@ -119,30 +119,30 @@ class DrifterPlotter(Plotter):
 
             try:
                 model_start = np.where(
-                    dataset.timestamps <= self.times[self.start]
+                    dataset.nc_data.timestamps <= self.times[self.start]
                 )[0][-1]
             except IndexError:
                 model_start = 0
 
             model_start -= 1
-            model_start = np.clip(model_start, 0, len(dataset.timestamps) - 1)
+            model_start = np.clip(model_start, 0, len(dataset.nc_data.timestamps) - 1)
 
             try:
                 model_end = np.where(
-                    dataset.timestamps >= self.times[self.end]
+                    dataset.nc_data.timestamps >= self.times[self.end]
                 )[0][0]
             except IndexError:
-                model_end = len(dataset.timestamps) - 1
+                model_end = len(dataset.nc_data.timestamps) - 1
 
             model_end += 1
             model_end = np.clip(
                 model_end,
                 model_start,
-                len(dataset.timestamps) - 1
+                len(dataset.nc_data.timestamps) - 1
             )
 
             model_times = [time.mktime(
-                t.timetuple()) for t in dataset.timestamps[model_start:model_end + 1]]
+                t.timetuple()) for t in dataset.nc_data.timestamps[model_start:model_end + 1]]
             output_times = [time.mktime(t.timetuple())
                             for t in self.times[self.start:self.end + 1]]
             d = []

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -63,10 +63,10 @@ class HovmollerPlotter(LinePlotter):
 
             time_var = dataset.nc_data.time_variable
             if self.starttime > 0:
-                self.starttime = dataset.timestamp_to_time_index(
+                self.starttime = dataset.nc_data.timestamp_to_time_index(
                     self.starttime)
             if self.endtime > 0:
-                self.endtime = dataset.timestamp_to_time_index(self.endtime)
+                self.endtime = dataset.nc_data.timestamp_to_time_index(self.endtime)
 
             time = time_var[slice(min(self.starttime, self.endtime), max(
                 self.starttime, self.endtime) + 1)].values

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -61,7 +61,7 @@ class HovmollerPlotter(LinePlotter):
             self.depth, self.depth_value, self.depth_unit = find_depth(
                 self.depth, len(dataset.depths) - 1, dataset)
 
-            time_var = dataset.time_variable
+            time_var = dataset.nc_data.time_variable
             if self.starttime > 0:
                 self.starttime = dataset.timestamp_to_time_index(
                     self.starttime)

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -162,7 +162,7 @@ class HovmollerPlotter(LinePlotter):
 
                 self.compare['variable_unit'] = variable_units[0]
                 self.compare['data'] = value
-                self.compare['times'] = dataset.timestamps[self.compare['starttime']                                                           : self.compare['endtime'] + 1]
+                self.compare['times'] = dataset.nc_data.timestamps[self.compare['starttime']: self.compare['endtime'] + 1]
                 self.compare['data'] = np.multiply(
                     self.compare['data'], scale_factors[0])
                 self.compare['data'] = self.compare['data'].transpose()

--- a/plotting/observation.py
+++ b/plotting/observation.py
@@ -67,7 +67,7 @@ class ObservationPlotter(PointPlotter):
                                for o in self.observation]
 
         with open_dataset(self.dataset_config, variable=self.variables) as dataset:
-            ts = dataset.timestamps
+            ts = dataset.nc_data.timestamps
 
             observation_times = []
             timestamps = []

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -426,8 +426,8 @@ class Plotter(metaclass=ABCMeta):
         return output
 
     def fix_startend_times(self, dataset, starttime, endtime):
-        starttime = np.clip(starttime, 0, len(dataset.timestamps) - 1)
-        endtime = np.clip(endtime, 0, len(dataset.timestamps) - 1)
+        starttime = np.clip(starttime, 0, len(dataset.nc_data.timestamps) - 1)
+        endtime = np.clip(endtime, 0, len(dataset.nc_data.timestamps) - 1)
 
         if starttime > endtime:
             starttime = endtime - 1

--- a/plotting/scriptGenerator.py
+++ b/plotting/scriptGenerator.py
@@ -20,7 +20,7 @@ def time_query_conversion(dataset, index):
     config = DatasetConfig(dataset)
     with open_dataset(config) as ds:
         try:
-            date = ds.timestamps[index]
+            date = ds.nc_data.timestamps[index]
             return date.replace(tzinfo=pytz.UTC).isoformat()
         except IndexError:
             return ClientError("Timestamp does not exist")

--- a/plotting/stats.py
+++ b/plotting/stats.py
@@ -75,8 +75,8 @@ class Stats:
                 time = int(self.time)
 
             if time < 0:
-                time += len(dataset.timestamps)
-            time = np.clip(time, 0, len(dataset.timestamps) - 1)
+                time += len(dataset.nc_data.timestamps)
+            time = np.clip(time, 0, len(dataset.nc_data.timestamps) - 1)
 
             depth = 0
             depthm = 0

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -111,7 +111,7 @@ class TimeseriesPlotter(PointPlotter):
 
             starttime_idx = dataset.timestamp_to_time_index(self.starttime)
             endtime_idx = dataset.timestamp_to_time_index(self.endtime)
-            times = dataset.timestamps[starttime_idx : endtime_idx + 1]
+            times = dataset.nc_data.timestamps[starttime_idx: endtime_idx + 1]
             if self.query.get('dataset_quantum') == 'month':
                 times = [datetime.date(x.year, x.month, 1) for x in times]
 

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -109,8 +109,8 @@ class TimeseriesPlotter(PointPlotter):
                 if factor != 1.0:
                     point_data[idx] = np.multiply(point_data[idx], factor)
 
-            starttime_idx = dataset.timestamp_to_time_index(self.starttime)
-            endtime_idx = dataset.timestamp_to_time_index(self.endtime)
+            starttime_idx = dataset.nc_data.timestamp_to_time_index(self.starttime)
+            endtime_idx = dataset.nc_data.timestamp_to_time_index(self.endtime)
             times = dataset.nc_data.timestamps[starttime_idx: endtime_idx + 1]
             if self.query.get('dataset_quantum') == 'month':
                 times = [datetime.date(x.year, x.month, 1) for x in times]

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -808,10 +808,10 @@ def timestamp_for_date_v1_0(old_dataset: str, date: int, new_dataset: str):
     old_config = DatasetConfig(old_dataset)
     new_config = DatasetConfig(new_dataset)
     with open_dataset(old_config) as ds:
-        timestamp = ds.timestamps[date]
+        timestamp = ds.nc_data.timestamps[date]
 
     with open_dataset(new_config) as ds:
-        timestamps = ds.timestamps
+        timestamps = ds.nc_data.timestamps
 
     diffs = np.vectorize(lambda x: x.total_seconds())(timestamps - timestamp)
     idx = np.where(diffs <= 0)[0]

--- a/tests/disabled/test_fvcom.py
+++ b/tests/disabled/test_fvcom.py
@@ -38,18 +38,6 @@ class TestFvcom(unittest.TestCase):
             self.assertEqual(variables['h'].unit, 'm')
             self.assertEqual(variables['h'].dimensions, ["node"])
 
-    def test_timestamp_to_time_index(self):
-        with Fvcom('tests/testdata/fvcom_test.nc') as n:
-            idx = n.timestamp_to_time_index(57209.043)
-
-            self.assertEqual(idx, 1)
-
-    def test_timestamp_to_time_index(self):
-        with Fvcom('tests/testdata/fvcom_test.nc') as n:
-            idx = n.timestamp_to_time_index(57209.043)
-
-            self.assertEqual(idx, 1)
-
     def test_get_point(self):
         with Fvcom('tests/testdata/fvcom_test.nc') as n:
             data, depth = n.get_point(45.3, -64.0, 0, 0, 'temp',

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -28,7 +28,6 @@ class TestMercator(unittest.TestCase):
         self.assertIs(ds._dataset, nc_data.dataset)
         self.assertIs(ds._meta_only, nc_data.meta_only)
         self.assertEqual(ds.variables, nc_data.variables)
-        self.assertEqual(ds.timestamp_to_time_index, nc_data.timestamp_to_time_index)
 
     def test_open_meta_only(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc', **{"meta_only": True})
@@ -79,13 +78,6 @@ class TestMercator(unittest.TestCase):
             self.assertEqual(variables['votemper'].unit, 'Kelvin')
             self.assertEqual(sorted(variables['votemper'].dimensions), sorted(
                 ['time', 'depth', 'latitude', 'longitude']))
-
-    def test_timestamp_to_time_index(self):
-        nc_data = NetCDFData('tests/testdata/mercator_test.nc')
-        with Mercator(nc_data) as ds:
-            idx = ds.timestamp_to_time_index(2119651200)
-
-            self.assertEqual(idx, 0)
 
     def test_get_point(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -38,7 +38,6 @@ class TestMercator(unittest.TestCase):
     def test_open_not_meta_only(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
-            self.assertIsNotNone(ds.timestamps)
             self.assertIsNotNone(ds.latvar)
             self.assertIsNotNone(ds.lonvar)
 
@@ -132,17 +131,6 @@ class TestMercator(unittest.TestCase):
                 ds.get_point(13.01, -149.0, 'bottom', 2119651200, 'votemper'),
                 273.95, places=2
             )
-
-    def test_timestamps(self):
-        nc_data = NetCDFData('tests/testdata/mercator_test.nc')
-        with Mercator(nc_data) as ds:
-            self.assertEqual(len(ds.timestamps), 1)
-            self.assertEqual(ds.timestamps[0],
-                             datetime.datetime(2017, 3, 3, 0, 0, 0, 0,
-                                               pytz.UTC))
-            # List is immutable
-            with self.assertRaises(ValueError):
-                ds.timestamps[0] = 0
 
     def test_get_area(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -38,7 +38,6 @@ class TestMercator(unittest.TestCase):
     def test_open_not_meta_only(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
-            self.assertIsNotNone(ds.time_variable)
             self.assertIsNotNone(ds.timestamps)
             self.assertIsNotNone(ds.latvar)
             self.assertIsNotNone(ds.lonvar)
@@ -88,14 +87,6 @@ class TestMercator(unittest.TestCase):
             idx = ds.timestamp_to_time_index(2119651200)
 
             self.assertEqual(idx, 0)
-
-    def test_time_variable(self):
-        nc_data = NetCDFData('tests/testdata/mercator_test.nc')
-        with Mercator(nc_data) as ds:
-            time_var = ds.time_variable
-
-            self.assertEqual(time_var.attrs["standard_name"], "time")
-            self.assertEqual(time_var.attrs["long_name"], "Validity time")
 
     def test_get_point(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -25,16 +25,10 @@ class TestMercator(unittest.TestCase):
         self.assertIsNone(ds.latvar)
         self.assertIsNone(ds.lonvar)
         self.assertIs(ds.nc_data, nc_data)
-        self.assertIs(ds._dataset, nc_data.dataset)
         self.assertIs(ds._meta_only, nc_data.meta_only)
         self.assertEqual(ds.variables, nc_data.variables)
 
-    def test_open_meta_only(self):
-        nc_data = NetCDFData('tests/testdata/mercator_test.nc', **{"meta_only": True})
-        with Mercator(nc_data) as ds:
-            self.assertIs(ds._dataset, nc_data.dataset)
-
-    def test_open_not_meta_only(self):
+    def test_enter_not_meta_only(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
             self.assertIsNotNone(ds.latvar)

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -25,13 +25,7 @@ class TestNemo(unittest.TestCase):
         self.assertIsNone(ds.latvar)
         self.assertIsNone(ds.lonvar)
         self.assertIs(ds.nc_data, nc_data)
-        self.assertIs(ds._dataset, nc_data.dataset)
         self.assertEqual(ds.variables, nc_data.variables)
-
-    def test_enter(self):
-        nc_data = NetCDFData('tests/testdata/nemo_test.nc')
-        with Nemo(nc_data) as ds:
-            self.assertIs(ds._dataset, nc_data.dataset)
 
     def test_depths(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -26,19 +26,13 @@ class TestNemo(unittest.TestCase):
         self.assertIsNone(ds.lonvar)
         self.assertIs(ds.nc_data, nc_data)
         self.assertIs(ds._dataset, nc_data.dataset)
-        self.assertIs(ds._meta_only, nc_data.meta_only)
         self.assertEqual(ds.variables, nc_data.variables)
         self.assertEqual(ds.timestamp_to_time_index, nc_data.timestamp_to_time_index)
 
-    def test_open_meta_only(self):
-        nc_data = NetCDFData('tests/testdata/nemo_test.nc', **{"meta_only": True})
-        with Nemo(nc_data) as ds:
-            self.assertIs(ds._dataset, nc_data.dataset)
-
-    def test_open_not_meta_only(self):
+    def test_enter(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         with Nemo(nc_data) as ds:
-            self.assertIsNotNone(ds.timestamps)
+            self.assertIs(ds._dataset, nc_data.dataset)
 
     def test_depths(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
@@ -189,14 +183,3 @@ class TestNemo(unittest.TestCase):
 
             self.assertNotEqual(r[0, 0], r[1, 0])
             self.assertTrue(np.ma.is_masked(r[1, 49]))
-
-    def test_timestamps(self):
-        nc_data = NetCDFData('tests/testdata/nemo_test.nc')
-        with Nemo(nc_data) as ds:
-            self.assertEqual(len(ds.timestamps), 2)
-            self.assertEqual(ds.timestamps[0],
-                             datetime.datetime(2014, 5, 17, 0, 0, 0, 0,
-                                               pytz.UTC))
-            # List is immutable
-            with self.assertRaises(ValueError):
-                ds.timestamps[0] = 0

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -27,7 +27,6 @@ class TestNemo(unittest.TestCase):
         self.assertIs(ds.nc_data, nc_data)
         self.assertIs(ds._dataset, nc_data.dataset)
         self.assertEqual(ds.variables, nc_data.variables)
-        self.assertEqual(ds.timestamp_to_time_index, nc_data.timestamp_to_time_index)
 
     def test_enter(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
@@ -69,13 +68,6 @@ class TestNemo(unittest.TestCase):
             self.assertEqual(variables['votemper'].unit, 'Kelvins')
             self.assertEqual(sorted(variables['votemper'].dimensions), sorted(
                 ["deptht", "time_counter", "y", "x"]))
-
-    def test_timestamp_to_time_index(self):
-        nc_data = NetCDFData('tests/testdata/nemo_test.nc')
-        with Nemo(nc_data) as ds:
-            idx = ds.timestamp_to_time_index(2031436800)
-
-            self.assertEqual(idx, 0)
 
     def test_get_point(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -38,7 +38,6 @@ class TestNemo(unittest.TestCase):
     def test_open_not_meta_only(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         with Nemo(nc_data) as ds:
-            self.assertIsNotNone(ds.time_variable)
             self.assertIsNotNone(ds.timestamps)
 
     def test_depths(self):
@@ -83,13 +82,6 @@ class TestNemo(unittest.TestCase):
             idx = ds.timestamp_to_time_index(2031436800)
 
             self.assertEqual(idx, 0)
-
-    def test_time_variable(self):
-        nc_data = NetCDFData('tests/testdata/nemo_test.nc')
-        with Nemo(nc_data) as ds:
-            time_var = ds.time_variable
-
-            self.assertEqual(time_var.attrs["title"], "Time")
 
     def test_get_point(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -22,8 +22,6 @@ class TestNemo(unittest.TestCase):
     def test_init(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         ds = Nemo(nc_data)
-        self.assertIsNone(ds.latvar)
-        self.assertIsNone(ds.lonvar)
         self.assertIs(ds.nc_data, nc_data)
         self.assertEqual(ds.variables, nc_data.variables)
 

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -522,7 +522,6 @@ def get_point_data(dataset, variable, time, depth, location):
     units = []
     dsc = DatasetConfig(dataset)
     with open_dataset(dsc) as ds:
-        timestamp = ds.timestamps[time]
         for v in variables:
             d = ds.get_point(
                 location[0],
@@ -539,7 +538,7 @@ def get_point_data(dataset, variable, time, depth, location):
             units.append(variable_unit)
 
     result = {
-        'value': ['%s' % float('%.4g' % f) for f in data],
+        'value': [f'{float(f):.4g}' for f in data],
         'location': [round(f, 4) for f in location],
         'name': names,
         'units': units,


### PR DESCRIPTION
## Background
This comes out of a discussion with @htmlboss during his review of PR#614.

Drop `time_variable` attr from `Nemo`, `Mercator` and `Fvcom` classes in favour of accessing it as an attr on the `NetCDFData` instance that is used to construct instances of those classes. Access looks like `self.nc_data.time_variable` within instances of those classes, and like `dataset.nc_data.time_variable` or `ds.nc_data.time_variable` in code that uses `open_dataset()` as a context manager.

Likewise:

- drop `timestamps` attr in favour of accessing it like `dataset.nc_data.timestamps` or `ds.nc_data.timestamps` in code that uses `open_dataset()` as a context manager
- drop `timestamp_to_time_index()` method in favour of accessing it as `self.nc_data.timestamp_to_time_index()` within instances of `Model`-derived classes, and like `dataset.nc_data.timestamp_to_time_index()` in code that uses `open_dataset()` as a context manager
- drop `_dataset` attr in favour of accessing it as `self.nc_data.dataset` within instances of `Model`-derived classes

Get rid of unsed lat/lon attrs in `Nemo` that I noticed during the above refactoring.

Get rid of unused `dataset` arg in `nearest_grid_point.find_nearest_grid_point()` that I noticed during the above refactoring.


## Why did you take this approach?
Cleaner code!

## Anything in particular that should be highlighted?
I was hoping that I could make each of these commits a separate PR. Either that's not a GitHub thing, or my Git/GitHub foo is weak. Perhaps that would be going to far to the granular extreme with small PRs compared to the gorilla that was PR#641. But my goal was to make these easy to review and merge as we move toward the 6.2 release later this week.

If you can tell me how to make small PRs @htmlboss I can withdraw this one. I kept going with it because of the time difference so as not to slow down our progress toward 6.2 release too much.

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
