### PR TITLE
Flesh out support for timeseries data.

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -153,7 +153,7 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
         press = press[..., np.newaxis]
 
     speed = seawater.svel(salinity, temperature, press)
-    return np.array(speed)
+    return np.squeeze(speed)
 
 
 def density(depth, latitude, temperature, salinity) -> np.ndarray:

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -80,7 +80,7 @@ def __validate_depth_lat_temp_sal(depth, latitude, temperature, salinity):
     if type(salinity) is not np.ndarray:
         salinity = np.array(salinity)
 
-    return depth, latitude, temperature, salinity
+    return depth, latitude, np.squeeze(temperature), np.squeeze(salinity)
 
 
 def __find_depth_index_of_min_value(data: np.ndarray, depth_axis=0) -> np.ndarray:

--- a/data/fvcom.py
+++ b/data/fvcom.py
@@ -9,7 +9,6 @@ import pytz
 from cachetools import TTLCache
 from pykdtree.kdtree import KDTree
 
-import data.geo as geo
 from data.calculated import CalculatedData
 from data.model import Model
 from data.netcdf_data import NetCDFData
@@ -246,24 +245,6 @@ class Fvcom(Model):
             output = output.reshape(origshape[1:])
 
         return np.squeeze(output)
-
-    def get_path(self, path, depth, time, variable, numpoints=100, times=None, return_depth=False):
-        if times is None:
-            if hasattr(time, "__len__"):
-                times = self.nc_data.timestamp_to_iso_8601(time)
-            else:
-                times = None
-        distances, times, lat, lon, bearings = \
-            geo.path_to_points(path, numpoints, times=times)
-
-        if return_depth:
-            result, dep = self.get_point(lat, lon, depth, time, variable,
-                                         return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result, dep
-        else:
-            result = self.get_point(lat, lon, depth, time, variable,
-                                    return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result
 
     def get_raw_point(self, latitude, longitude, depth, timestamp, variable):
         min_i, max_i, radius = self.__bounding_box(

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -4,7 +4,6 @@ import numpy as np
 import pyresample
 from pint import UnitRegistry
 
-import data.geo as geo
 from data.calculated import CalculatedData
 from data.model import Model
 from data.nearest_grid_point import find_nearest_grid_point
@@ -81,22 +80,15 @@ class Mercator(Model):
         return np.int64(miny), np.int64(maxy), np.int64(minx), np.int64(maxx), np.amax(50000)
 
     def __resample(self, lat_in, lon_in, lat_out, lon_out, var, radius=50000):
-        if len(var.shape) == 3:
-            var = np.rollaxis(var, 0, 3)
-
+        var = np.squeeze(var)
+        
         origshape = var.shape
 
-        data = np.ma.masked_invalid(var[:])
-
-        lon_in, lat_in = pyresample.utils.check_and_wrap(lon_in, lat_in)
-
-        masked_lon_in = np.ma.array(lon_in)
-        masked_lat_in = np.ma.array(lat_in)
-
-        output_def = pyresample.geometry.SwathDefinition(
-            lons=np.ma.array(lon_out),
-            lats=np.ma.array(lat_out)
-        )
+        data, masked_lat_in, masked_lon_in, output_def = super()._make_resample_data(lat_in,
+                                                                                     lon_in,
+                                                                                     lat_out,
+                                                                                     lon_out,
+                                                                                     var)
 
         if len(data.shape) == 3:
             output = []
@@ -132,27 +124,16 @@ class Mercator(Model):
             output = self.nc_data.interpolate(input_def, output_def, data.transpose())
 
         if len(origshape) == 4:
-            output = output.reshape(origshape[2:])
+            # un-collapse time and depth axes and
+            # move axes back to original positions.
+            output = output.reshape((
+                origshape[0], # time
+                origshape[1], # depth
+                output.shape[0], # lat
+                output.shape[1] # lon
+            ))
 
         return np.squeeze(output)
-
-    def get_path(self, path, depth, time, variable, numpoints=100, times=None, return_depth=False):
-        if times is None:
-            if hasattr(time, "__len__"):
-                times = self.nc_data.timestamp_to_iso_8601(time)
-            else:
-                times = None
-        distances, times, lat, lon, bearings = \
-            geo.path_to_points(path, numpoints, times=times)
-
-        if return_depth:
-            result, dep = self.get_point(lat, lon, depth, time, variable,
-                                         return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result, dep
-        else:
-            result = self.get_point(lat, lon, depth, time, variable,
-                                    return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result
 
     def get_raw_point(self, latitude, longitude, depth, timestamp, variable):
         miny, maxy, minx, maxx, radius = self.__bounding_box(
@@ -208,7 +189,8 @@ class Mercator(Model):
             data
         )
 
-    def get_point(self, latitude, longitude, depth, timestamp, variable, return_depth=False):
+    def get_point(self, latitude, longitude, depth, variable, starttime,
+                    endtime=None, return_depth=False):
 
         miny, maxy, minx, maxx, radius = self.__bounding_box(
             latitude, longitude, 10)
@@ -219,43 +201,59 @@ class Mercator(Model):
 
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.nc_data.timestamp_to_time_index(timestamp)
+        starttime_idx = self.nc_data.timestamp_to_time_index(starttime)
+        time_slice = slice(starttime_idx, starttime_idx + 1) # slice only 1 element
+        if endtime is not None: # we have a range of times
+            endtime_idx = self.nc_data.timestamp_to_time_index(endtime)
+            time_slice = slice(starttime_idx, endtime_idx + 1)
 
+            time_duration = endtime_idx - starttime_idx # how many time values we have
+
+        depth_value = None
+        res = None
         if depth == 'bottom':
-            if hasattr(time, "__len__"):
-                d = var[time[0], :, miny:maxy, minx:maxx]
-            else:
-                d = var[time, :, miny:maxy, minx:maxx]
+            d = var[time_slice, :, miny:maxy, minx:maxx].values
 
-            reshaped = np.ma.masked_invalid(d.values.reshape([d.shape[0], -1]))
+            d = np.rollaxis(d, 0, 4) # roll time to back
+            # compress lat, lon, time along depth axis
+            reshaped = np.ma.masked_invalid(d.reshape([d.shape[0], -1]))
 
+            # Find the bottom data values along depth axis.
             edges = np.array(np.ma.notmasked_edges(reshaped, axis=0))
             depths = edges[1, 0, :]
             indices = edges[1, 1, :]
 
-            if hasattr(time, "__len__"):
-                data_in = var[time, :, miny:maxy, minx:maxx].values
+            if endtime is not None:
+                data_in = d
+                # Compress lat and lon across time and depth axes
                 data_in = data_in.reshape(
                     [data_in.shape[0], data_in.shape[1], -1])
                 data = []
-                for i, t in enumerate(time):
+                for i in range(starttime_idx, endtime_idx + 1):
                     di = np.ma.MaskedArray(np.zeros(data_in.shape[-1]),
                                            mask=True,
                                            dtype=data_in.dtype)
                     di[indices] = data_in[i, depths, indices]
                     data.append(di)
-                data = np.ma.array(data).reshape([len(time), d.shape[-2],
-                                                  d.shape[-1]])
+                
+                data = np.ma.array(data).reshape((
+                    d.shape[0], # time
+                    d.shape[2], # lat
+                    d.shape[3]  # lon
+                ))
             else:
-                data = np.ma.MaskedArray(np.zeros(d.shape[1:]),
+                data = np.ma.MaskedArray(np.zeros(d.shape[1:]), # copy lat lon and time axis shapes
                                          mask=True,
                                          dtype=d.dtype)
                 data[np.unravel_index(indices, data.shape)] = \
                     reshaped[depths, indices]
 
+                # Roll time axis back to the front
+                data = np.rollaxis(data, 2, 0)
+
             res = self.__resample(
                 self.latvar[miny:maxy],
-                np.mod(self.lonvar[minx:maxx] + 360, 360),
+                self.lonvar[minx:maxx],
                 [latitude], [longitude],
                 data,
                 radius
@@ -268,8 +266,8 @@ class Mercator(Model):
 
                 d[np.unravel_index(indices, d.shape)] = self.depths[depths]
 
-                if hasattr(time, "__len__"):
-                    d = [d] * len(time)
+                if endtime:
+                    d = [d] * time_duration
 
                 dep = self.__resample(
                     self.latvar[miny:maxy],
@@ -281,9 +279,9 @@ class Mercator(Model):
 
         else:
             if len(var.shape) == 4:
-                data = var[time, int(depth), miny:maxy, minx:maxx]
+                data = var[time_slice, int(depth), miny:maxy, minx:maxx]
             else:
-                data = var[time, miny:maxy, minx:maxx]
+                data = var[time_slice, miny:maxy, minx:maxx]
 
             res = self.__resample(
                 self.latvar[miny:maxy],
@@ -294,22 +292,22 @@ class Mercator(Model):
             )
 
             if return_depth:
-                dep = self.depths[depth]
-                dep = np.tile(dep, len(latitude))
-                if hasattr(time, "__len__"):
-                    dep = np.array([dep] * len(time))
+                depth_value = self.depths[int(depth)]
+                depth_value = np.tile(depth_value, len(latitude))
+                if endtime is not None:
+                    depth_value = np.array([depth_value] * time_duration)
 
         if return_depth:
-            return res, dep
+            return res, depth_value
         return res
 
-    def get_profile(self, latitude, longitude, timestamp, variable):
+    def get_profile(self, latitude, longitude, variable, starttime, endtime=None):
         var = self.nc_data.get_dataset_variable(variable)
         # We expect the following shape (time, depth, lat, lon)
         if len(var.shape) != 4:
             raise APIError("This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
 
-        time = self.nc_data.timestamp_to_time_index(timestamp)
+        time_slice = self.nc_data.make_time_slice(starttime, endtime)
 
         miny, maxy, minx, maxx, radius = self.__bounding_box(
             latitude, longitude, 10)
@@ -322,7 +320,7 @@ class Mercator(Model):
             self.latvar[miny:maxy],
             self.lonvar[minx:maxx],
             [latitude], [longitude],
-            var[time, :, miny:maxy, minx:maxx].values,
+            var[time_slice, :, miny:maxy, minx:maxx].values,
             radius
         )
 

--- a/data/model.py
+++ b/data/model.py
@@ -2,6 +2,7 @@ import abc
 
 import numpy
 from scipy.interpolate import interp1d
+import pyresample
 
 import data.geo as geo
 
@@ -18,23 +19,81 @@ class Model(metaclass=abc.ABCMeta):
     def depths(self) -> numpy.ndarray:
         pass
 
-    @abc.abstractmethod
     def get_path(
-        self, path, depth, time, variable, numpoints=100, times=None, return_depth=False
+        self,
+        path,
+        depth,
+        variable,
+        starttime,
+        endtime=None,
+        numpoints=100,
+        times=None,
+        return_depth=False,
+        tile_time=True
     ):
+        if times is None and endtime is not None:
+            time_slice = self.nc_data.make_time_slice(starttime, endtime)
+            times = self.nc_data.timestamps[time_slice]
+        
+        distances, t, lat, lon, bearings = \
+            geo.path_to_points(path, numpoints, times=times)
+        if tile_time:
+            times = t
+
+        if return_depth:
+            result, dep = self.get_point(lat, lon, depth, variable, starttime, endtime,
+                                         return_depth=return_depth)
+            return numpy.array([lat, lon]), distances, times, result, dep
+        else:
+            result = self.get_point(lat, lon, depth, variable, starttime, endtime,
+                                    return_depth=return_depth)
+            return numpy.array([lat, lon]), distances, times, result
+
+    @abc.abstractmethod
+    def get_point(self, latitude, longitude, depth, variable, starttime, endtime=None, return_depth=False):
         pass
 
     @abc.abstractmethod
-    def get_point(self, latitude, longitude, depth, time, variable, return_depth=False):
-        pass
-
-    @abc.abstractmethod
-    def get_profile(self, latitude, longitude, time, variable):
+    def get_profile(self, latitude, longitude, variable, starttime, endtime=None):
         pass
 
     @abc.abstractmethod
     def get_raw_point(self, latitude, longitude, depth, time, variable):
         pass
+
+    def _make_resample_data(self, lat_in, lon_in, lat_out, lon_out, data):
+        """
+        Note: `data` must be of shape (time, lat, lon) OR (time, depth, lat, lon).
+        """
+
+        if len(data.shape) == 4:
+            origshape = data.shape
+            # collapse time and depth axes (positions 0 and 1)
+            data = data.reshape((
+                origshape[0] * origshape[1],# combine time + depth
+                origshape[2],               # lat
+                origshape[3],               # lon
+            ))
+        if len(data.shape) == 3:
+            # move lat and lon axes (normally the last two axes)
+            # into the first and second axis positions.
+            # Before: (..., lat, lon)
+            # After: (lat, lon, ...)
+            data = numpy.rollaxis(data, 0, 3)
+
+        data = numpy.ma.masked_invalid(data[:])
+
+        lon_in, lat_in = pyresample.utils.check_and_wrap(lon_in, lat_in)
+
+        masked_lon_in = numpy.ma.array(lon_in)
+        masked_lat_in = numpy.ma.array(lat_in)
+
+        output_def = pyresample.geometry.SwathDefinition(
+            lons=numpy.ma.array(lon_out),
+            lats=numpy.ma.array(lat_out)
+        )
+
+        return data, masked_lat_in, masked_lon_in, output_def
 
     def get_area(
         self,
@@ -56,23 +115,23 @@ class Model(metaclass=abc.ABCMeta):
 
         if return_depth:
             a, d = self.get_point(
-                latitude, longitude, depth, time, variable, return_depth=return_depth
+                latitude, longitude, depth, variable, time, return_depth=return_depth
             )
             return numpy.reshape(a, area.shape[1:]), numpy.reshape(d, area.shape[1:])
         a = self.get_point(
-            latitude, longitude, depth, time, variable, return_depth=return_depth
+            latitude, longitude, depth, variable, time, return_depth=return_depth
         )
         return numpy.reshape(a, area.shape[1:])
 
     def get_path_profile(self, path, time, variable, numpoints=100):
         distances, times, lat, lon, bearings = geo.path_to_points(path, numpoints)
 
-        result, depth = self.get_profile(lat, lon, time, variable)
+        result, depth = self.get_profile(lat, lon, variable, time)
 
         return numpy.array([lat, lon]), distances, result.transpose(), depth
 
     def get_profile_depths(self, latitude, longitude, time, variable, depths):
-        profile, orig_dep = self.get_profile(latitude, longitude, time, variable)
+        profile, orig_dep = self.get_profile(latitude, longitude, variable, time)
 
         if not hasattr(latitude, "__len__"):
             latitude = [latitude]
@@ -106,10 +165,11 @@ class Model(metaclass=abc.ABCMeta):
             latitude,
             longitude,
             depth,
-            [starttime, endtime],
             variable,
+            starttime,
+            endtime,
             return_depth=return_depth,
         )
 
     def get_timeseries_profile(self, latitude, longitude, starttime, endtime, variable):
-        return self.get_profile(latitude, longitude, [starttime, endtime], variable)
+        return self.get_profile(latitude, longitude, variable, starttime, endtime)

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -4,7 +4,6 @@ import numpy as np
 import pyresample
 from pint import UnitRegistry
 
-import data.geo as geo
 from data.calculated import CalculatedData
 from data.model import Model
 from data.nearest_grid_point import find_nearest_grid_point
@@ -85,26 +84,15 @@ class Nemo(Model):
     def __resample(self, lat_in, lon_in, lat_out, lon_out, var):
         """ Resamples data given lat/lon inputs and outputs
         """
-        if len(var.shape) == 3:
-            var = np.rollaxis(var, 0, 3)
-        elif len(var.shape) == 4:
-            var = np.rollaxis(var, 0, 4)
-            var = np.rollaxis(var, 0, 4)
-
+        var = np.squeeze(var)
+        
         origshape = var.shape
-        var = var.reshape([var.shape[0], var.shape[1], -1])
 
-        data = np.ma.masked_invalid(var[:])
-
-        lon_in, lat_in = pyresample.utils.check_and_wrap(lon_in, lat_in)
-
-        masked_lon_in = np.ma.array(lon_in)
-        masked_lat_in = np.ma.array(lat_in)
-
-        output_def = pyresample.geometry.SwathDefinition(
-            lons=np.ma.array(lon_out),
-            lats=np.ma.array(lat_out)
-        )
+        data, masked_lat_in, masked_lon_in, output_def = super()._make_resample_data(lat_in,
+                                                                                     lon_in,
+                                                                                     lat_out,
+                                                                                     lon_out,
+                                                                                     var)
 
         if len(data.shape) == 3:
             output = []
@@ -137,7 +125,14 @@ class Nemo(Model):
 
 
         if len(origshape) == 4:
-            output = output.reshape(origshape[2:])
+            # un-collapse time and depth axes and
+            # move axes back to original positions.
+            output = output.reshape((
+                origshape[0], # time
+                origshape[1], # depth
+                output.shape[0], # lat
+                output.shape[1] # lon
+            ))
 
         return np.squeeze(output)
 
@@ -176,24 +171,6 @@ class Nemo(Model):
                     )
 
         raise LookupError("Cannot find latitude & longitude variables")
-
-    def get_path(self, path, depth, time, variable, numpoints=100, times=None, return_depth=False):
-        if times is None:
-            if hasattr(time, "__len__"):
-                times = self.nc_data.timestamp_to_iso_8601(time)
-            else:
-                times = None
-        distances, times, lat, lon, bearings = \
-            geo.path_to_points(path, numpoints, times=times)
-
-        if return_depth:
-            result, dep = self.get_point(lat, lon, depth, time, variable,
-                                         return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result, dep
-        else:
-            result = self.get_point(lat, lon, depth, time, variable,
-                                    return_depth=return_depth)
-            return np.array([lat, lon]), distances, times, result
 
     def get_raw_point(self, latitude, longitude, depth, timestamp, variable):
         latvar, lonvar = self.__latlon_vars(variable)
@@ -247,8 +224,9 @@ class Nemo(Model):
             data
         )
 
-    def get_point(self, latitude, longitude, depth, timestamp, variable,
-                  return_depth=False):
+    def get_point(self, latitude, longitude, depth, variable, starttime,
+                  endtime=None, return_depth=False):
+
         latvar, lonvar = self.__latlon_vars(variable)
 
         miny, maxy, minx, maxx, radius = self.__bounding_box(
@@ -261,23 +239,29 @@ class Nemo(Model):
         # Get xarray.Variable
         var = self.nc_data.get_dataset_variable(variable)
 
-        time = self.nc_data.timestamp_to_time_index(timestamp)
+        starttime_idx = self.nc_data.timestamp_to_time_index(starttime)
+        time_slice = slice(starttime_idx, starttime_idx + 1) # slice only 1 element
+        if endtime is not None: # we have a range of times
+            endtime_idx = self.nc_data.timestamp_to_time_index(endtime)
+            time_slice = slice(starttime_idx, endtime_idx + 1)
 
+            time_duration = endtime_idx - starttime_idx # how many time values we have
 
+        depth_value = None
+        res = None
         if depth == 'bottom':
+            d = var[time_slice, :, miny:maxy, minx:maxx].values
 
-            if hasattr(time, "__len__"):
-                d = var[time[0], :, miny:maxy, minx:maxx]
-            else:
-                d = var[time, :, miny:maxy, minx:maxx]
+            d = np.rollaxis(d, 0, 4) # roll time to back
+            # compress lat, lon, time along depth axis
+            reshaped = np.ma.masked_invalid(d.reshape([d.shape[0], -1]))
 
-            reshaped = np.ma.masked_invalid(d.values.reshape([d.shape[0], -1]))
-
+            # Find the bottom data values along depth axis.
             edges = np.array(np.ma.notmasked_edges(reshaped, axis=0))
             depths = edges[1, 0, :]
             indices = edges[1, 1, :]
 
-            if hasattr(time, "__len__"):
+            if endtime is not None:
                 data_in = var[time, :, miny:maxy, minx:maxx]
                 data_in = data_in.values.reshape(
                     [data_in.shape[0], data_in.shape[1], -1])
@@ -291,9 +275,9 @@ class Nemo(Model):
                 data = np.ma.array(data).reshape([len(time), d.shape[-2],
                                                   d.shape[-1]])
             else:
-                data = np.ma.MaskedArray(np.zeros(d.values.shape[1:]),
+                data = np.ma.MaskedArray(np.zeros(d.shape[1:]),
                                          mask=True,
-                                         dtype=d.values.dtype)
+                                         dtype=d.dtype)
 
                 data[np.unravel_index(indices, data.shape)] = \
                     reshaped[depths, indices]
@@ -319,9 +303,9 @@ class Nemo(Model):
 
         else:
             if len(var.shape) == 4:
-                data = var[time, int(depth), miny:maxy, minx:maxx]
+                data = var[time_slice, int(depth), miny:maxy, minx:maxx]
             else:
-                data = var[time, miny:maxy, minx:maxx]
+                data = var[time_slice, miny:maxy, minx:maxx]
 
             res = self.__resample(
                 latvar[miny:maxy, minx:maxx],
@@ -331,23 +315,23 @@ class Nemo(Model):
             )
 
             if return_depth:
-                dep = self.depths[depth]
-                dep = np.tile(dep, len(latitude))
-                if hasattr(time, "__len__"):
-                    dep = np.array([dep] * len(time))
+                depth_value = self.depths[int(depth)]
+                depth_value = np.tile(depth_value, len(latitude))
+                if endtime is not None:
+                    depth_value = np.array([depth_value] * time_duration)
 
         if return_depth:
-            return res, dep
+            return res, depth_value
         return res
 
-    def get_profile(self, latitude, longitude, timestamp, variable):
+    def get_profile(self, latitude, longitude, variable, starttime, endtime=None):
         var = self.nc_data.get_dataset_variable(variable)
         # We expect the following shape (time, depth, lat, lon)
         if len(var.shape) != 4:
             raise APIError(
                 "This plot requires a depth dimension. This dataset doesn't have a depth dimension.")
 
-        time_index = self.nc_data.timestamp_to_time_index(timestamp)
+        time_slice = self.nc_data.make_time_slice(starttime, endtime)
 
         latvar, lonvar = self.__latlon_vars(variable)
 
@@ -362,7 +346,7 @@ class Nemo(Model):
             latvar[miny:maxy, minx:maxx],
             lonvar[miny:maxy, minx:maxx],
             [latitude], [longitude],
-            var[time_index, :, miny:maxy, minx:maxx].values,
+            var[time_slice, :, miny:maxy, minx:maxx].values,
         )
 
         return res, np.squeeze([self.depths] * len(latitude))

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -115,6 +115,33 @@ class NetCDFData(Data):
                 continue
         raise KeyError(f"None of {candidates} were found in {self.dataset}")
 
+    def make_time_slice(self, starttime: int, endtime: Union[int, None] = None) -> slice:
+        """Converts given start and/or end timestamp values (e.g. 60442857)
+        into a slice object that captures the corresponding time
+        indices such that [starttime, starttime] OR [starttime, endtime].
+
+        Required Arguments:
+
+            * starttime {int} -- The starting timestamp.
+        
+        Optional Arguments:    
+
+            * endtime {int or None} -- The ending timestamp to create
+                an inclusive range. Default is None.
+
+        Returns:
+        
+            * slice instance representing the requested time range.
+        """
+        
+        starttime_idx = self.timestamp_to_time_index(starttime)
+
+        if endtime is not None:
+            endtime_idx = self.timestamp_to_time_index(endtime)
+            return slice(starttime_idx, endtime_idx + 1)
+
+        return slice(starttime_idx, starttime_idx + 1)
+    
     def timestamp_to_time_index(self, timestamp: Union[int, List]):
         """Converts a given timestamp (e.g. 2031436800) or list of timestamps
         into the corresponding time index(es) for the time dimension.
@@ -126,7 +153,7 @@ class NetCDFData(Data):
             [int or ndarray] -- Time index(es).
         """
 
-        time_var = self.time_variable.astype(np.int)
+        time_var = np.sort(self.time_variable.astype(np.int))
 
         result = np.nonzero(np.isin(time_var, timestamp))[0]
 
@@ -707,7 +734,7 @@ class NetCDFData(Data):
             var = self.time_variable
 
             # Convert timestamps to UTC
-            time_list = data.utils.time_index_to_datetime(var.values, var.attrs['units'])
+            time_list = data.utils.time_index_to_datetime(np.sort(var), var.attrs['units'])
             timestamps = np.array(time_list)
             timestamps.setflags(write=False)  # Make immutable
             self.__timestamp_cache["timestamps"] = timestamps

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -1,5 +1,3 @@
-# vim: set fileencoding=utf-8 :
-
 import re
 
 import matplotlib.gridspec as gridspec
@@ -61,50 +59,24 @@ class HovmollerPlotter(LinePlotter):
             self.depth, self.depth_value, self.depth_unit = find_depth(
                 self.depth, len(dataset.depths) - 1, dataset)
 
-            time_var = dataset.nc_data.time_variable
-            if self.starttime > 0:
-                self.starttime = dataset.nc_data.timestamp_to_time_index(
-                    self.starttime)
-            if self.endtime > 0:
-                self.endtime = dataset.nc_data.timestamp_to_time_index(self.endtime)
-
-            time = time_var[slice(min(self.starttime, self.endtime), max(
-                self.starttime, self.endtime) + 1)].values
-
-            if len(self.variables) > 1:
-                v = []
-                for name in self.variables:
-                    self.path_points, self.distance, t, value = dataset.get_path(
-                        self.points,
-                        self.depth,
-                        time,
-                        name
-                    )
-                    v.append(value ** 2)
-
-                value = np.sqrt(np.ma.sum(v, axis=0))
-
-                self.variable_name = self.get_vector_variable_name(dataset,
-                                                                   self.variables)
-            else:
-                self.path_points, self.distance, t, value = dataset.get_path(
-                    self.points,
-                    self.depth,
-                    time,
-                    self.variables[0]
-                )
-                self.variable_name = self.get_variable_names(
-                    dataset, self.variables)[0]
+            self.path_points, self.distance, times, data = dataset.get_path(
+                self.points,
+                self.depth,
+                self.variables[0],
+                self.starttime,
+                self.endtime,
+                tile_time=False
+            )
+            self.variable_name = self.get_variable_names(
+                dataset, self.variables)[0]
 
             variable_units = self.get_variable_units(dataset, self.variables)
             scale_factors = self.get_variable_scale_factors(
                 dataset, self.variables)
 
             self.variable_unit = variable_units[0]
-            self.data = value
-            self.iso_timestamps = dataset.nc_data.timestamp_to_iso_8601(time)
-            self.data = np.multiply(self.data, scale_factors[0])
-            self.data = self.data.transpose()
+            self.data = np.multiply(data, scale_factors[0]).T
+            self.iso_timestamps = times
 
             # Get colourmap
             if self.cmap is None:
@@ -113,39 +85,20 @@ class HovmollerPlotter(LinePlotter):
         # Load data sent from Right Map (if in compare mode)
         if self.compare:
             compare_config = DatasetConfig(self.compare['dataset'])
-            with open_dataset(compare_config, variable=self.compare['variables']) as dataset:
+            with open_dataset(compare_config, timestamp=self.compare['starttime'], endtime=self.compare['endtime'], variable=self.compare['variables']) as dataset:
                 self.compare['depth'], self.compare['depth_value'], self.compare['depth_unit'] = find_depth(
                     self.compare['depth'], len(dataset.depths) - 1, dataset)
 
-                self.fix_startend_times(
-                    dataset, self.compare['starttime'], self.compare['endtime'])
-                time = list(
-                    range(self.compare['starttime'], self.compare['endtime'] + 1))
-
-                if len(self.compare['variables']) > 1:
-                    v = []
-                    for name in self.compare['variables']:
-                        path, distance, t, value = dataset.get_path(
-                            self.points,
-                            self.compare['depth'],
-                            time,
-                            name
-                        )
-                        v.append(value ** 2)
-
-                    value = np.sqrt(np.ma.sum(v, axis=0))
-                    self.compare['variable_name'] = \
-                        self.get_vector_variable_name(dataset,
-                                                      self.compare['variables'])
-                else:
-                    path, distance, t, value = dataset.get_path(
-                        self.points,
-                        self.compare['depth'],
-                        time,
-                        self.compare['variables'][0]
-                    )
-                    self.compare['variable_name'] = self.get_variable_names(
-                        dataset, self.compare['variables'])[0]
+                path, distance, times, data = dataset.get_path(
+                    self.points,
+                    self.compare['depth'],
+                    self.compare['variables'][0],
+                    self.compare['starttime'],
+                    self.compare['endtime'],
+                    tile_time=False
+                )
+                self.compare['variable_name'] = self.get_variable_names(
+                    dataset, self.compare['variables'])[0]
 
                 # Colourmap
                 if (self.compare['colormap'] == 'default'):
@@ -161,17 +114,8 @@ class HovmollerPlotter(LinePlotter):
                     dataset, self.compare['variables'])
 
                 self.compare['variable_unit'] = variable_units[0]
-                self.compare['data'] = value
-                self.compare['times'] = dataset.nc_data.timestamps[self.compare['starttime']: self.compare['endtime'] + 1]
-                self.compare['data'] = np.multiply(
-                    self.compare['data'], scale_factors[0])
-                self.compare['data'] = self.compare['data'].transpose()
-
-                # Comparison over different time ranges makes no sense
-                if self.starttime != self.compare['starttime'] or\
-                        self.endtime != self.compare['endtime']:
-                    raise ClientError(gettext(
-                        "Please ensure the Start Time and End Time for the Left and Right maps are identical."))
+                self.compare['data'] = np.multiply(data, scale_factors[0]).T
+                self.compare['times'] = times
 
     # Render Hovmoller graph(s)
     def plot(self):

--- a/plotting/point.py
+++ b/plotting/point.py
@@ -56,8 +56,8 @@ class PointPlotter(Plotter):
                 prof, d = dataset.get_profile(
                     float(p[0]),
                     float(p[1]),
-                    time,
-                    v
+                    v,
+                    time
                 )
                 data.append(prof)
                 depths.append(d)

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -74,11 +74,11 @@ class TimeseriesPlotter(PointPlotter):
                 self.depth = 0
 
             point_data = []
-            dep = []
+            depths = []
             for p in self.points:
                 data = []
                 if self.depth == 'all':
-                    d, dep = dataset.get_timeseries_profile(
+                    d, depths = dataset.get_timeseries_profile(
                         float(p[0]),
                         float(p[1]),
                         self.starttime,
@@ -86,7 +86,7 @@ class TimeseriesPlotter(PointPlotter):
                         variable
                     )
                 else:
-                    d, dep = dataset.get_timeseries_point(
+                    d, depths = dataset.get_timeseries_point(
                         float(p[0]),
                         float(p[1]),
                         self.depth,

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -125,7 +125,7 @@ class TimeseriesPlotter(PointPlotter):
 
             self.times = times
             self.data = point_data
-            self.depths = dep
+            self.depths = depths
             self.depth_unit = "m"
 
 

--- a/plotting/transect.py
+++ b/plotting/transect.py
@@ -143,8 +143,8 @@ class TransectPlotter(LinePlotter):
                     dataset.get_path(
                         self.points,
                         0,
-                        self.time,
                         self.surface,
+                        self.time
                     )
                 vc = self.dataset_config.variable[dataset.variables[self.surface]]
                 surface_unit = vc.unit

--- a/tests/disabled/test_fvcom.py
+++ b/tests/disabled/test_fvcom.py
@@ -59,7 +59,7 @@ class TestFvcom(unittest.TestCase):
 
     def test_get_profile(self):
         with Fvcom('tests/testdata/fvcom_test.nc') as n:
-            p, d = n.get_profile(45.3, -64.0, 0, 'temp')
+            p, d = n.get_profile(45.3, -64.0, 'temp', 0)
             self.assertAlmostEqual(p[0], 6.78, places=2)
             self.assertAlmostEqual(p[10], 6.78, places=2)
 

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -77,16 +77,16 @@ class TestMercator(unittest.TestCase):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
             self.assertAlmostEqual(
-                ds.get_point(13.0, -149.0, 0, 2119651200, 'votemper'),
+                ds.get_point(13.0, -149.0, 0, 'votemper', 2119651200),
                 298.426, places=3
             )
             self.assertAlmostEqual(
-                ds.get_point(47.0, -47.0, 0, 2119651200, 'votemper'),
+                ds.get_point(47.0, -47.0, 0, 'votemper', 2119651200),
                 273.66, places=2
             )
 
             p = ds.get_point([13.0, 47.0], [-149.0, -47.0], 0,
-                            2119651200, 'votemper')
+                            'votemper', 2119651200)
             self.assertAlmostEqual(p[0], 298.426, places=3)
             self.assertAlmostEqual(p[1], 273.66, places=2)
 
@@ -105,7 +105,7 @@ class TestMercator(unittest.TestCase):
     def test_get_profile(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
-            p, d = ds.get_profile(13.0, -149.0, 2119651200, 'votemper')
+            p, d = ds.get_profile(13.0, -149.0, 'votemper', 2119651200)
             self.assertAlmostEqual(p[0], 298.426, places=3)
             self.assertAlmostEqual(p[10], 298.426, places=3)
             self.assertTrue(np.ma.is_masked(p[49]))
@@ -114,7 +114,7 @@ class TestMercator(unittest.TestCase):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
             self.assertAlmostEqual(
-                ds.get_point(13.01, -149.0, 'bottom', 2119651200, 'votemper'),
+                ds.get_point(13.01, -149.0, 'bottom', 'votemper', 2119651200),
                 273.95, places=2
             )
 

--- a/tests/test_nemo.py
+++ b/tests/test_nemo.py
@@ -65,7 +65,7 @@ class TestNemo(unittest.TestCase):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         with Nemo(nc_data) as ds:
             self.assertAlmostEqual(
-                ds.get_point(13.0, -149.0, 0, 2031436800, 'votemper'),
+                ds.get_point(13.0, -149.0, 0, 'votemper', 2031436800),
                 299.17, places=2
             )
 
@@ -84,7 +84,7 @@ class TestNemo(unittest.TestCase):
     def test_get_profile(self):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         with Nemo(nc_data) as ds:
-            p, d = ds.get_profile(13.0, -149.0, 2031436800, 'votemper')
+            p, d = ds.get_profile(13.0, -149.0, 'votemper', 2031436800)
             self.assertAlmostEqual(p[0], 299.17, places=2)
             self.assertAlmostEqual(p[10], 299.15, places=2)
             self.assertAlmostEqual(p[20], 296.466766, places=6)
@@ -109,7 +109,7 @@ class TestNemo(unittest.TestCase):
         nc_data = NetCDFData('tests/testdata/nemo_test.nc')
         with Nemo(nc_data) as ds:
             self.assertAlmostEqual(
-                ds.get_point(13.0, -149.0, 'bottom', 2031436800, 'votemper'),
+                ds.get_point(13.0, -149.0, 'bottom', 'votemper', 2031436800),
                 274.13, places=2
             )
 

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -527,8 +527,8 @@ def get_point_data(dataset, variable, time, depth, location):
                 location[0],
                 location[1],
                 depth,
-                time,
-                v
+                v,
+                time
             )
             variable_name = dsc.variable[ds.variables[v]].name
             variable_unit = dsc.variable[ds.variables[v]].unit


### PR DESCRIPTION
Partially addresses #673 

tldr: virtual mooring is back (except for bottom depths)!

FVCOM will come at a later date since @geoffholden has work that depends on the fixes in here, so time is an issue. We don't have any operational FVCOM datasets currently, nor do we expect such datasets in the short-to-medium term.

**Note** timeseries for "bottom" depths won't be addressed in this PR for the above reasoning (i.e. remain broken). I believe there is some numpy axis magic possible to reduce the complexity of our bottom calculations and reduce the volume of code.

## Background

Our timeseries plots have been broken from some time so the basic idea behind these changes is to fix all that. At a lower level, I've tried to simplify the "data getter" functions in `Model.py` so callers can explicitly pass an `endtime` argument to indicate a timeseries is being requested. Before, we were doing implicit checks of the `time`/`timestamp` arguments which resulted in a vague API and code instability.

This PR will re-implement support for timeseries data for any depth level, and "All" depths. "Bottom" depths will come soon.

## Why did you take this approach?
Maybe not the simplest way to do things, but I've opted to delete some dead code (will be commented below) and factor out some code into `Model` thus reducing duplication in the classes deriving from `Model`. This is a first pass at cleaning things up. Further cleaning can come later and is outside the scope of this PR.

## Anything in particular that should be highlighted?
I had to make some minor alterations to our resampling functions in terms of data layout. No changes were made to the actual interpolation though. Screenshots below demonstrate no change in the final result, as intended. Now that we pass slice objects for the time dimension when extracting data, this has caused some issues where the time dim size == 1. To remedy this, I've sprinkled some numpy squeezes to get things back to their expected shape (I compared the shapes of the old resampling vs what I have here and there was a difference in the shapes). Maybe not the "best" approach but the scope was rapidly exploding at that point.

## Screenshot(s)
Virtual mooring (all depths) - Mercator:
![image](https://user-images.githubusercontent.com/5572045/77078512-a416d180-69d9-11ea-82ea-afc4f7f3cbe5.png)
Virtual mooring (depth 0) - Mercator:
![image](https://user-images.githubusercontent.com/5572045/77078613-c6105400-69d9-11ea-98c7-bdc535e66444.png)
Virtual mooring (all depths) - Nemo:
![image](https://user-images.githubusercontent.com/5572045/77100005-d7685900-69f7-11ea-9888-dd8a95f3850a.png)
Virtual mooring (depth 1) - Nemo:
![image](https://user-images.githubusercontent.com/5572045/77340308-122c0300-6d10-11ea-810a-986f41c97f78.png)

Hovmoller - Nemo:
![image](https://user-images.githubusercontent.com/5572045/77332679-46e68d00-6d05-11ea-9c44-5d7264f0444e.png)
Hovmoller - Mercator:
![image](https://user-images.githubusercontent.com/5572045/77335814-a050bb00-6d09-11ea-8d60-e78ee9b4708e.png)


Change comparisons

Profiles:
Before:
![image](https://user-images.githubusercontent.com/5572045/77076768-3b2e5a00-69d7-11ea-86dc-6ef6789438a1.png)
After:
![image](https://user-images.githubusercontent.com/5572045/77076810-4c776680-69d7-11ea-9dba-bcee6c55bc07.png)

Transects:
Before:
![image](https://user-images.githubusercontent.com/5572045/77168134-439b9900-6a9a-11ea-8586-ff69f7208337.png)
After:
![image](https://user-images.githubusercontent.com/5572045/77168142-47c7b680-6a9a-11ea-8e03-c1cf28097454.png)

Deep Sound Channel (calculated):
![image](https://user-images.githubusercontent.com/5572045/77426892-6094dc80-6db8-11ea-8f79-20e7c2d16357.png)

No behaviour change to calculated variables or map tiles:
![image](https://user-images.githubusercontent.com/5572045/77100522-ba805580-69f8-11ea-88af-6e2f321f9d38.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
