### PR TITLE
Erddap access

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -63,7 +63,15 @@ class NetCDFData(Data):
                     self.dataset = netCDF4.MFDataset(self._nc_files)
             else:
                 try:
-                    self.dataset = xarray.open_dataset(self.url, decode_times=decode_times)
+                    if not getattr(self._dataset_config, "geo_ref", {}):
+                        self.dataset = xarray.open_dataset(self.url, decode_times=decode_times)
+                    else:
+                        fields = xarray.open_dataset(self.url, decode_times=decode_times)
+                        drop_variables = self._dataset_config.geo_ref.get("drop_variables", [])
+                        geo_refs = xarray.open_dataset(
+                            self._dataset_config.geo_ref["url"], drop_variables=drop_variables,
+                        )
+                        self.dataset = fields.merge(geo_refs)
                 except xarray.core.variable.MissingDimensionsError:
                     # xarray won't open FVCOM files due to dimension/coordinate/variable label
                     # duplication issue, so fall back to using netCDF4.Dataset()

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -710,7 +710,7 @@ class NetCDFData(Data):
 
         return self.__timestamp_cache.get("timestamps")
 
-    def get_nc_file_list(self, datasetconfig, **kwargs):
+    def get_nc_file_list(self, datasetconfig: DatasetConfig, **kwargs: dict) -> Union[List, None]:
         try:
             if not datasetconfig.url.endswith(".sqlite3"):
                 # This method is only applicable to SQLite-indexed datasets

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import os
 import re

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -263,7 +263,7 @@ class VariableConfig:
     def quantum(self) -> str:
         """
         Returns the quantum (time scale) for the variable as defined in dataset config file
-        
+
         Returns:
             str -- variable quantum
         """
@@ -274,7 +274,7 @@ class VariableConfig:
 
         return quantum
 
-    
+
     @property
     def unit(self) -> str:
         """
@@ -316,7 +316,7 @@ class VariableConfig:
         """
         Returns variable scale factor from dataset config file
         """
-        
+
         try:
             scale_factor = self.__get_attribute("scale_factor")
         except KeyError:

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -45,6 +45,14 @@ class DatasetConfig():
         return self._get_attribute("url")
 
     @property
+    def geo_ref(self) -> dict:
+        """
+        Returns the dict of information about the ERDDAP dataset that provides the mapping of
+        grid index to lat/lon for the given dataset.
+        """
+        return self._get_attribute("geo_ref")
+
+    @property
     def key(self) -> str:
         return self._dataset_key
 

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -3,15 +3,16 @@
 import json
 import os
 import re
+from typing import Union
 
 from flask import current_app
 
 
-class DatasetConfig():
+class DatasetConfig:
     """Access class for the dataset configuration"""
     __config = None
 
-    def __init__(self, dataset: str):
+    def __init__(self, dataset: str) -> None:
         self._config = DatasetConfig._get_dataset_config()[dataset]
         self._dataset_key: str = dataset
 
@@ -34,7 +35,7 @@ class DatasetConfig():
 
         return DatasetConfig.__config
 
-    def _get_attribute(self, key: str) -> str:
+    def _get_attribute(self, key: str) -> Union[str, dict]:
         return self._config.get(key) if not None else ""
 
     @property
@@ -92,18 +93,18 @@ class DatasetConfig():
         return self._get_attribute("help")
 
     @property
-    def grid_angle_file_url(self):
+    def grid_angle_file_url(self) -> str:
         """
         Returns the url to the grid angle file for this dataset's model.
         """
         return self._get_attribute("grid_angle_file_url")
 
     @property
-    def lat_var_key(self):
+    def lat_var_key(self) -> str:
         return self._get_attribute("lat_var_key")
 
     @property
-    def lon_var_key(self):
+    def lon_var_key(self) -> str:
         return self._get_attribute("lon_var_key")
 
     @property
@@ -200,19 +201,20 @@ class DatasetConfig():
         """
         return self._VariableGetter(self)
 
-    class _VariableGetter():
-        def __init__(self, datasetconfig):
+    class _VariableGetter:
+        def __init__(self, datasetconfig) -> None:
             self._config = datasetconfig
 
         def __getitem__(self, key):
             return VariableConfig(self._config, key)
 
-class VariableConfig():
+
+class VariableConfig:
     """
     Access class for an individual variable's portion of the datasetconfig.
     """
 
-    def __init__(self, datasetconfig, variable):
+    def __init__(self, datasetconfig, variable) -> None:
         """
         Parameters:
         datasetconfig -- the parent DatasetConfig object

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -451,7 +451,7 @@
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>                 <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2013)</li>                 <li>Variables Available:                     <ul>                         <li>Eastward Velocity</li>                         <li>Ice Concentration</li>                         <li>Northward Velocity</li>                         <li>Salinity</li>                         <li>Sea Ice Eastward Velocity</li>                         <li>Sea Ice Northward Velocity</li>                         <li>Sea Ice Thickness</li>                         <li>Sea Ice Velocity</li>                         <li>Sea Surface Height</li>                         <li>Sea Water Velocity</li>                         <li>Temperature</li>                     </ul>                 </li>             </ul>",
         "name": "GLORYS v3",
         "quantum": "month",
-        "type": "historical",   
+        "type": "historical",
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
         "url": "/data/db/climatology-glorysv3.sqlite3",
         "variables": {
@@ -554,7 +554,7 @@
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>             <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2014)</li>             </ul>",
         "name": "GLORYS v4",
         "quantum": "month",
-        "type": "historical",      
+        "type": "historical",
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
         "url": "/home/buildadm/ocean-nav/db/GLORYSV4.sqlite3",
         "variables": {
@@ -754,7 +754,7 @@
         "url": "/data/db/glorys4_climatology.sqlite3",
         "name": "GLORYS v4 Climatology",
         "quantum": "month",
-        "type": "historical",       
+        "type": "historical",
         "enabled": true,
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
         "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
@@ -781,7 +781,7 @@
         "help": "Global Ocean Reanalysis and Simulation             <ul>             <li>Global Coverage</li>             <li>1/4° Mercator grid</li>             <li>75 vertical z-levels</li>             <li>Computed from the monthly averages January 1993&ndash;December 2013</li>             <li>Variables Available:                 <ul>                     <li>Eastward Velocity</li>                     <li>Ice Concentration</li>                     <li>Northward Velocity</li>                     <li>Salinity</li>                     <li>Sea Ice Eastward Velocity</li>                     <li>Sea Ice Northward Velocity</li>                     <li>Sea Ice Thickness</li>                     <li>Sea Ice Velocity</li>                     <li>Sea Surface Height</li>                     <li>Sea Water Velocity</li>                     <li>Temperature</li>                 </ul>             </li>             </ul>",
         "name": "GLORYSV3 Climatology",
         "quantum": "month",
-        "type": "historical",    
+        "type": "historical",
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
         "url": "/home/buildadm/ocean-nav/db/GLORYSV3-Climatology.sqlite3",
         "variables": {
@@ -904,7 +904,7 @@
         "help": "Combination of Levitus98 and PHC 2.1             <ul>             <li>Global Coverage</li>             <li>Tri-polar ORCA grid 1/4° resolution (ORCA025), &lt; 15km in Arctic</li>             <li>50 vertical z-levels</li>             <li>Variables Available:                 <ul>                     <li>Salinity</li>                     <li>Water Temperature</li>                 </ul>             </li>             </ul>",
         "name": "World Ocean Atlas Climatology",
         "quantum": "month",
-        "type": "historical",        
+        "type": "historical",
         "time_dim_units": "seconds since 1950-01-01 00: 00: 00",
         "url": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "variables": {

--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -1189,5 +1189,25 @@
             "so": { "name": "Salinity", "envtype": "ocean", "unit": "PSU", "scale": [0, 33] },
             "zos": { "name": "Sea Surface Height", "envtype": "ocean", "unit": "m", "scale": [-0.55, 0.72] }
         }
+    },
+    "salishseacast_2d_ssh": {
+        "enabled": true,
+        "name": "SalishSeaCast Sea Surface Height",
+        "envtype": ["ocean"],
+        "type": "historical",
+        "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSgSurfaceTracerFields1hV19-05",
+        "geo_ref": {
+            "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV17-02",
+            "drop_variables": ["bathymetry"]
+        },
+        "quantum": "hour",
+        "time_dim_units": "seconds since 1970-01-01 00:00:00",
+        "lat_var_key": "latitude",
+        "lon_var_key": "longitude",
+        "attribution": "Mesoscale Ocean & Atmosphere Dynamics Group (MOAD), Earth, Ocean & Atmopspheric Sciences (EOAS), University of British Columbia",
+        "help": "&nbsp; SalishSeaCast NEMO Model - <a href=\"https://salishsea.eos.ubc.ca/nemo/\" target=\"_new\">https://salishsea.eos.ubc.ca/nemo/</a> \n<p>\n2d sea surface height values averaged over 1 hour intervals from SalishSeaCast NEMO model runs with physics, biology and chemistry. The values are calculated for the surface of the model grid that includes Juan de Fuca Strait, the Strait of Georgia, Puget Sound, and Johnstone Strait on the coasts of Washington State and British Columbia. The time values are UTC. They are the centre of the intervals over which the calculated model results are averaged.\n</p>\n<p>\nMore information about this dataset, a web interface and an API for it, can be found on the SalishSeaCast ERDDAP server at\n<a href=\"https://salishsea.eos.ubc.ca/erddap/info/ubcSSgSurfaceTracerFields1hV19-05/index.html\"\" target=\"_new\">https://salishsea.eos.ubc.ca/erddap/info/ubcSSgSurfaceTracerFields1hV19-05/index.html</a>,\nor by contacting <a href=\"sallen@eoas.ubc.ca\">Dr. Susan Allen</a>.\n</p>\n<p>\nIf you use this dataset in your research,\nplease reference it with wording similar to the example below,\nand include citations of the publications below.\nInclusion of the date(s) when you downloaded the dataset,\nand the dataset id help to ensure reproducibility of your work.\n</p>\n<p>\nReference wording:\n</p>\n<blockquote>\nSea surface height fields from the SalishSeaCast model\n(Soontiens et al, 2016; Soontiens and Allen, 2017)\nwere downloaded from their ERDDAP server\n(https://salishsea.eos.ubc.ca/erddap/)\non DATE from dataset ubcSSgSurfaceTracerFields1hV19-05.\n</blockquote>\n<p>Citations:</p>\n<ul>\n  <li>\n    Soontiens, N., Allen, S., Latornell, D., Le Souef, K., Machuca, I., Paquin, J.-P., Lu, Y., Thompson, K., Korabel, V., 2016. Storm surges in the Strait of Georgia simulated with a regional model. Atmosphere-Ocean 54 1-21. \n    <a href=\"https://dx.doi.org/10.1080/07055900.2015.1108899\" target=\"_new\">https://dx.doi.org/10.1080/07055900.2015.1108899</a> \n  </li>\n  <li>\n    Soontiens, N. and Allen, S., 2017. Modelling sensitivities to mixing and advection in a sill-basin estuarine system. Ocean Modelling, 112, 17-32. \n    <a href=\"https://dx.doi.org/10.1016/j.ocemod.2017.02.008\">https://dx.doi.org/10.1016/j.ocemod.2017.02.008</a>\n  </li>\n</ul>\n<p>\n  The SalishSeaCast project is supported by:\n</p>\n<ul>\n  <li>The Marine Environmental Observation Prediction &\nResponse network (MEOPAR)</li>\n  <li>Ocean Networks Canada (ONC)</li>\n  <li>Compute Canada</li>\n</ul>\n<p>\nThe Salish Sea MEOPAR NEMO model results are copyright by the Salish Sea MEOPAR Project Contributors and The University of British Columbia. They are licensed under the Apache License, Version 2.0. https://www.apache.org/licenses/LICENSE-2.0\n</p>",
+        "variables": {
+            "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
+        }
     }
 }

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -766,14 +766,17 @@ def timestamps():
         raise APIError("Please specify a variable via ?variable=variable_name")
     variable = args.get("variable")
 
-    vals = []
-    with SQLiteDatabase(config.url) as db:
-        if variable in config.calculated_variables:
-            data_vars = get_data_vars_from_equation(config.calculated_variables[variable]['equation'],
-                                                    [v.key for v in db.get_data_variables()])
-            vals = db.get_timestamps(data_vars[0])
-        else:
-            vals = db.get_timestamps(variable)
+    if config.url.endswith(".sqlite3"):
+        with SQLiteDatabase(config.url) as db:
+            if variable in config.calculated_variables:
+                data_vars = get_data_vars_from_equation(config.calculated_variables[variable]['equation'],
+                                                        [v.key for v in db.get_data_variables()])
+                vals = db.get_timestamps(data_vars[0])
+            else:
+                vals = db.get_timestamps(variable)
+    else:
+        with open_dataset(config, variable=variable) as ds:
+            vals = list(map(int, ds.nc_data.time_variable.values))
     converted_vals = time_index_to_datetime(vals, config.time_dim_units)
 
     result = []

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import gzip
-import hashlib
 import json
 import os
 import shutil

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -84,11 +84,25 @@ class TestAPIv1(unittest.TestCase):
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
     @patch('data.sqlite_database.SQLiteDatabase.get_timestamps')
-    def test_timestamps_endpoint(self, patch_get_all_timestamps, patch_get_data_variables, patch_get_dataset_config):
+    def test_timestamps_endpoint_sqlite(self, patch_get_all_timestamps, patch_get_data_variables, patch_get_dataset_config):
 
         patch_get_all_timestamps.return_value = sorted(
             [2031436800, 2034072000])
         patch_get_data_variables.return_value = self.patch_data_vars_ret_val
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        res = self.app.get(
+            '/api/v1.0/timestamps/?dataset=nemo_sqlite3&variable=votemper')
+
+        self.assertEqual(res.status_code, 200)
+
+        res_data = self.__get_response_data(res)
+        self.assertEqual(len(res_data), 2)
+        self.assertEqual(res_data[0]['id'], 2031436800)
+        self.assertEqual(res_data[0]['value'], '2014-05-17T00:00:00+00:00')
+
+    @patch.object(DatasetConfig, "_get_dataset_config")
+    def test_timestamps_endpoint_xarray(self, patch_get_dataset_config):
         patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
 
         res = self.app.get(

--- a/tests/test_dataset_config.py
+++ b/tests/test_dataset_config.py
@@ -16,12 +16,16 @@ class TestUtil(unittest.TestCase):
             "key": {
                 "enabled": True,
                 "url": "my_url",
+                "geo_ref": {
+                    "url": "my_geo_ref_url",
+                    "drop_variables": ["bathymetry"],
+                },
                 "climatology": "my_climatology",
                 "name": "my_name",
                 "help": "my_help",
                 "quantum": "my_quantum",
                 "type": "my_type",
-                "grid_angle_file_url": "my_url",
+                "grid_angle_file_url": "my_grid_angle_file_url",
                 "time_dim_units": "my_time_units",
                 "attribution": "my_<b>attribution</b>",
                 "cache": "123",
@@ -39,12 +43,14 @@ class TestUtil(unittest.TestCase):
 
         result = DatasetConfig("key")
         self.assertEqual(result.url, "my_url")
+        self.assertEqual(result.geo_ref["url"], "my_geo_ref_url")
+        self.assertEqual(result.geo_ref["drop_variables"], ["bathymetry"])
         self.assertEqual(result.key, "key")
         self.assertEqual(result.climatology, "my_climatology")
         self.assertEqual(result.name, "my_name")
         self.assertEqual(result.help, "my_help")
         self.assertEqual(result.quantum, "my_quantum")
-        self.assertEqual(result.grid_angle_file_url, "my_url")
+        self.assertEqual(result.grid_angle_file_url, "my_grid_angle_file_url")
         self.assertEqual(result.type, "my_type")
         self.assertEqual(result.time_dim_units, "my_time_units")
         self.assertEqual(result.lat_var_key, "my_lat")

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -239,8 +239,12 @@ class TestNetCDFData(unittest.TestCase):
             file_list = nc_data.get_nc_file_list(nc_data._dataset_config)
             self.assertEqual(nc_data._nc_files, [])
 
-    def test_get_nc_file_list_no_dataset_config_url(self):
-        with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_get_nc_file_list_no_dataset_config_url(self, patch_get_dataset_config):
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        kwargs = {"dataset_key": "giops_no_url"}
+        with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
             nc_data.get_nc_file_list(nc_data._dataset_config)
             self.assertEqual(nc_data._nc_files, [])
 

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -70,6 +70,39 @@ class TestNetCDFData(unittest.TestCase):
             self.assertIsInstance(nc_data.dataset, netCDF4.Dataset)
             self.assertTrue(nc_data._dataset_open)
 
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_enter_no_geo_ref(self, patch_get_dataset_config):
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        kwargs = {"dataset_key": "giops"}
+        with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
+            self.assertIsInstance(nc_data.dataset, xarray.Dataset)
+            self.assertTrue(nc_data._dataset_open)
+
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_enter_geo_ref(self, patch_get_dataset_config):
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        kwargs = {"dataset_key": "salishseacast_ssh"}
+        with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
+            self.assertIsInstance(nc_data.dataset, xarray.Dataset)
+            self.assertTrue(nc_data._dataset_open)
+            self.assertIn("latitude", nc_data.dataset.variables)
+            self.assertNotIn("bathymetry", nc_data.dataset.variables)
+
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_enter_geo_ref_no_drop_variables(self, patch_get_dataset_config):
+        geo_ref = self.patch_dataset_config_ret_val["salishseacast_ssh"]["geo_ref"]
+        with patch.dict(geo_ref, {"url": geo_ref["url"], "drop_variables": []}):
+            patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+            kwargs = {"dataset_key": "salishseacast_ssh"}
+            with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
+                self.assertIsInstance(nc_data.dataset, xarray.Dataset)
+                self.assertTrue(nc_data._dataset_open)
+                self.assertIn("latitude", nc_data.dataset.variables)
+                self.assertIn("bathymetry", nc_data.dataset.variables)
+
     @unittest.skip(
         "Some incompatibility between tests/testdata/nemo_test.nc and "
         "tests/testdata/nemo_grid_angle.nc results in "

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -2,7 +2,6 @@
     "giops": {
         "enabled": 1,
         "url": "tests/testdata/nemo_test.nc",
-        "grid_angle_file_url": "tests/testdata/nemo_grid_angle.nc",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "quantum": "day",
         "name": "GIOPS",

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -13,6 +13,18 @@
         }
     },
 
+    "giops_no_url": {
+        "enabled": 1,
+        "time_dim_units": "seconds since 1950-01-01 00:00:00",
+        "quantum": "day",
+        "name": "GIOPS",
+        "help": "help",
+        "attribution": "attrib",
+        "variables": {
+            "votemper": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] }
+        }
+    },
+
     "giops_real": {
         "enabled": 1,
         "url": "tests/testdata/giops_test.nc",
@@ -31,8 +43,28 @@
     "nemo_sqlite3": {
         "enabled": 1,
         "url": "tests/testdata/databases/test-nemo.sqlite3",
+        "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "variables": {
             "votemper": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] }
+        }
+    },
+
+    "salishseacast_ssh": {
+        "enabled": true,
+        "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSgSurfaceTracerFields1hV19-05",
+        "geo_ref": {
+            "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV17-02",
+            "drop_variables": ["bathymetry"]
+        },
+        "name": "SalishSeaCast Sea Surface Height",
+        "quantum": "hour",
+        "type": "historical",
+        "time_dim_units": "seconds since 1970-01-01 00:00:00",
+        "attribution": "UBC-MOAD",
+        "lat_var_key": "latitude",
+        "lon_var_key": "longitude",
+        "variables": {
+            "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
         }
     }
 }


### PR DESCRIPTION
## Background
Add the ability to load datasets from ERDDAP servers via OPeNDAP dataset URLs. 

In particular, enable datasets to be loaded from the SalishSeaCast ERDDAP server. Those datasets require the extra optional feature of merging in a dataset that maps the model x-y grid indices to longitude-latitude.

## Why did you take this approach?
It was the obvious path after having been immersed in the `data` modules doing the `open_dataset()` refactoring for PR#641,

## Anything in particular that should be highlighted?
This adds an optional `geo_ref` item to the datasetconfig shcema. I will update the wiki to add it tomorrow.

Presently there is only one of the SalishSeaCast tracer datasets (sea surface height) included in the dataset config. I can add more to this PR if I get them pushed before it is merged, but merging doesn't need to wait on them. They can just as easily be separate PRs.


## Screenshot(s)
![image](https://user-images.githubusercontent.com/76797/77022779-c19b5b00-6947-11ea-8715-655f960eb519.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
