### PR TITLE
Add 'chunks' parameter to open_mfdataset.

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -56,7 +56,11 @@ class NetCDFData(Data):
 
             if self._nc_files:
                 try:
-                    self.dataset = xarray.open_mfdataset(self._nc_files, decode_times=decode_times)
+                    self.dataset = xarray.open_mfdataset(
+                        self._nc_files,
+                        decode_times=decode_times,
+                        chunks=200,
+                    )
                 except xarray.core.variable.MissingDimensionsError:
                     # xarray won't open FVCOM files due to dimension/coordinate/variable label
                     # duplication issue, so fall back to using netCDF4.Dataset()


### PR DESCRIPTION
Add chunks=200 to open_mfdataset.

## Background
From http://xarray.pydata.org/en/stable/dask.html
    By default, open_mfdataset() will chunk each netCDF file into a single
    Dask array...

The downside to this is that when you load data in from disk, the lazy
loading loads the entire netCDF file; when operating on a single file,
that's not a huge issue, but when you want a small chunk of data from 40
1GB files, you need to read 40GB from storage.
This wasn't an issue with the old netCDF and THREDDS setup because only
the required data was requested via OpenDAP.
The solution is to specify the 'chunks' parameter and let xarray/Dask
break up the dimensions into multiple smaller chunks that can be
accessed independently.

## Why did you take this approach?
I did some experimental testing with 40 timesteps on the giops historical daily dataset. With the default chunking, it took 3:42. With chunks=200 it was down to between 11 and 17 seconds (including database access). I ran the tests multiple times to discount any disk caching, etc.

## Anything in particular that should be highlighted?
The 200 number was the best for that particular dataset, but it might not be the best overall. It'll certainly be better than the default, but it might be worth opening an issue/task for somebody to really optimize this between all datasets. (Or potentially add it to datasetconfig if there are big differences between datasets, but I suspect this won't be necessary)

## Screenshot(s)


## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
