### PR TITLE
Add salishseacast biology

### DIFF
--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -1209,5 +1209,35 @@
         "variables": {
             "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
         }
+    },
+    "salishseacast_3d_biology": {
+        "enabled": true,
+        "name": "SalishSeaCast 3D Biology",
+        "envtype": ["ocean"],
+        "type": "historical",
+        "url": "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV19-05",
+        "geo_ref": {
+            "url": "/data/grids/salishsea/geo_reference_201702.nc",
+            "drop_variables": ["bathymetry"]
+        },
+        "quantum": "hour",
+        "time_dim_units": "seconds since 1970-01-01 00:00:00",
+        "lat_var_key": "nav_lat",
+        "lon_var_key": "nav_lon",
+        "attribution": "Mesoscale Ocean & Atmosphere Dynamics Group (MOAD), Earth, Ocean & Atmopspheric Sciences (EOAS), University of British Columbia",
+        "help": "",
+        "variables": {
+            "ammonium": { "name":  "Ammonium Concentration", "unit":  "mmol m-3", "scale":  [0, 5] },
+            "biogenic_silicon": { "name":  "Biogenic Silicon Concentration", "unit":  "mmol m-3", "scale":  [0, 70] },
+            "ciliates": { "name":  "Mesodinium rubrum Concentration as Nitrogen", "unit":  "mmol m-3", "scale":  [0, 10] },
+            "diatoms": { "name":  "Diatoms Concentration as Nitrogen", "unit":  "mmol m-3", "scale":  [0, 20] },
+            "dissolved_organic_nitrogen": { "name":  "Dissolved Organic Nitrogen Concentration", "unit":  "mmol m-3", "scale":  [0, 10] },
+            "flagellates": { "name":  "Flagellates Concentration as Nitrogen", "unit":  "mmol m-3", "scale":  [0, 128] },
+            "mesozooplankton": { "name":  "Mesozooplankton Concentration as Nitrogen", "unit":  "mmol m-3", "scale":  [0, 128] },
+            "microzooplankton": { "name":  "Microzooplankton Concentration as Nitrogen", "unit":  "mmol m-3", "scale":  [0, 100] },
+            "nitrate": { "name":  "Nitrate Concentration", "unit":  "mmol m-3", "scale":  [0, 40] },
+            "particulate_organic_nitrogen": { "name":  "Particulate Organic Nitrogen Concentration", "unit":  "mmol m-3", "scale":  [0, 10] },
+            "silicon": { "name":  "Silicon Concentration", "unit":  "mmol m-3", "scale":  [0, 70] }
+        }
     }
 }

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -43,7 +43,10 @@ def find_colormap(name):
 _c = mcolors.ColorConverter().to_rgb
 data_dir = os.path.join(os.path.dirname(plotting.__file__), 'data')
 colormaps = {
+    'ammonium concentration': cmocean.cm.matter,
     'nitrogen': cmocean.cm.balance,
+    'dissolved organic nitrogen concentration': cmocean.cm.amp,
+    'particulate organic nitrogen concentration': cmocean.cm.amp,
     'depth': cmocean.cm.deep,
     'deep': cmocean.cm.deep,
     'partial pressure': cmocean.cm.matter,
@@ -71,12 +74,20 @@ colormaps = {
         np.loadtxt(os.path.join(data_dir, 'phosphate.txt'))),
     'nitrate': mcolors.ListedColormap(
         np.loadtxt(os.path.join(data_dir, 'nitrate.txt'))),
+    'nitrate concentration': cmocean.cm.tempo,
     'ice': cmocean.cm.ice,
     'phytoplankton': cmocean.cm.deep_r,
+    'diatoms concentration as nitrogen': cmocean.cm.algae,
+    'flagellates concentration as nitrogen': cmocean.cm.algae,
+    'mesodinium rubrum concentration as nitrogen': cmocean.cm.algae,
+    'mesozooplankton concentration as nitrogen': cmocean.cm.algae,
+    'microzooplankton concentration as nitrogen': cmocean.cm.algae,
     'silicate': make_colormap([
         _c('#ffffff'),
         _c('#57a6bd'),
     ]),
+    'silicon concentration': cmocean.cm.turbid,
+    'biogenic silicon concentration': cmocean.cm.turbid,
     'ph': make_colormap([
         _c('#ED1B26'),
         _c('#F46432'), 0.1, _c('#F46432'),
@@ -168,21 +179,32 @@ colormaps['wind'] = colormaps['velocity']
 # Babel so that they'll end up in the translation list.
 # If the gettext calls were in the definition of colormap_names, they'd get
 # executed before the user's locale is known and would always be in English.
+gettext('Ammonium Concentration')
 gettext('Anomaly')
 gettext('Bathymetry')
+gettext('Biogenic Silicon Concentration')
 gettext('Chlorophyll')
-gettext('Sea Surface Height (Free Surface)')
+gettext('Diatoms Concentration as Nitrogen')
+gettext('Dissolved Organic Nitrogen Concentration')
+gettext('Flagellates Concentration as Nitrogen')
 gettext('Greyscale')
 gettext('Ice')
 gettext('Iron')
 gettext('Mercator Ocean Current')
 gettext('Mercator')
+gettext('Mesodinium rubrum Concentration as Nitrogen')
+gettext('Mesozooplankton Concentration as Nitrogen')
+gettext('Microzooplankton Concentration as Nitrogen')
 gettext('Nitrate')
+gettext('Nitrate Concentration')
 gettext('Oxygen')
+gettext('Particulate Organic Nitrogen Concentration')
 gettext('Phosphate')
 gettext('Phytoplankton')
 gettext('Salinity')
+gettext('Sea Surface Height (Free Surface)')
 gettext('Silicate')
+gettext('Silicon Concentration')
 gettext('Speed')
 gettext('Temperature')
 gettext('Velocity')
@@ -198,6 +220,7 @@ gettext('Deep')
 gettext('Balance')
 
 colormap_names = {
+    'ammonium concentration': 'Ammonium Concentration',
     'balance': 'Balance',
     'anomaly': 'Anomaly',
     'bathymetry': 'Bathymetry',
@@ -209,11 +232,21 @@ colormap_names = {
     'mercator_current': 'Mercator Ocean Current',
     'mercator': 'Mercator',
     'nitrate': 'Nitrate',
+    'nitrate concentration': 'Nitrate Concentration',
+    'dissolved organic nitrogen concentration': 'Dissolved Organic Nitrogen Concentration',
+    'particulate organic nitrogen concentration': 'Particulate Organic Nitrogen Concentration',
     'oxygen': 'Oxygen',
     'phosphate': 'Phosphate',
     'phytoplankton': 'Phytoplankton',
+    'diatoms concentration as nitrogen': 'Diatoms Concentration as Nitrogen',
+    'flagellates concentration as nitrogen': 'Flagellates Concentration as Nitrogen',
+    'mesodinium rubrum concentration as nitrogen': 'Mesodinium rubrum Concentration as Nitrogen',
+    'mesozooplankton concentration as nitrogen': 'Mesozooplankton Concentration as Nitrogen',
+    'microzooplankton concentration as nitrogen': 'Microzooplankton Concentration as Nitrogen',
     'salinity': 'Salinity',
     'silicate': 'Silicate',
+    'silicon concentration': 'Silicon Concentration',
+    'biogenic silicon concentration': 'Biogenic Silicon Concentration',
     'speed': 'Speed',
     'temperature': 'Temperature',
     'velocity': 'Velocity',
@@ -240,7 +273,7 @@ def get_colormap_names():
 def plot_colormaps():
     fig, axes = plt.subplots(
         nrows=len(colormap_names),
-        figsize=(8, 0.3 * len(colormap_names))
+        figsize=(11, 0.3 * len(colormap_names))
     )
     fig.subplots_adjust(top=0.925, bottom=0.01, left=0.01, right=0.6)
 

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -31,9 +31,12 @@ def make_colormap(seq):
 
 
 def find_colormap(name):
-    for key in list(colormaps.keys()):
-        if re.search(key, name, re.I):
-            return colormaps[key]
+    try:
+        return colormaps[name.lower()]
+    except KeyError:
+        for key in colormaps:
+            if re.search(key, name, re.I):
+                return colormaps[key]
     return colormaps['mercator']
 
 

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -262,14 +262,6 @@ colormap_names = {
 }
 
 
-def get_colormap_names():
-    result = {}
-    for key, value in list(colormap_names.items()):
-        result[key] = gettext(value)
-
-    return result
-
-
 def plot_colormaps():
     fig, axes = plt.subplots(
         nrows=len(colormap_names),
@@ -281,15 +273,14 @@ def plot_colormaps():
     gradient = np.vstack((gradient, gradient))
 
     fig.suptitle(gettext("Ocean Navigator Colourmaps"), fontsize=14)
-    names = get_colormap_names()
-    for ax, cmap in zip(axes, sorted(list(names.keys()),
-                                     key=names.get)):
+    for ax, cmap in zip(axes, sorted(colormap_names, key=colormap_names.get)):
         ax.imshow(gradient, aspect='auto', cmap=colormaps.get(cmap))
         pos = list(ax.get_position().bounds)
         x_text = pos[2] + 0.025
         y_text = pos[1] + pos[3] / 2.
-        fig.text(x_text, y_text, names[
-                 cmap], va='center', ha='left', fontsize=12)
+        fig.text(
+            x_text, y_text, colormap_names[cmap], va='center', ha='left', fontsize=12
+        )
 
     for ax in axes:
         ax.set_axis_off()

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -299,7 +299,7 @@ if __name__ == '__main__':
     import matplotlib.cm
     import sys
 
-    for k, v in list(colormaps.items()):
+    for k, v in colormaps.items():
         matplotlib.cm.register_cmap(name=k, cmap=v)
 
     maps = [i for i in colormaps]

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -611,7 +611,7 @@ def colormaps_v1_0():
             'id': i,
             'value': n
         }
-        for i, n in list(plotting.colormap.get_colormap_names().items())
+        for i, n in plotting.colormap.colormap_names.items()
     ], key=lambda k: k['value'])
     data.insert(0, {'id': 'default', 'value': gettext('Default for Variable')})
 

--- a/tests/disabled/test_routes.py
+++ b/tests/disabled/test_routes.py
@@ -115,11 +115,8 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(result[0]['id'], 'none')
         self.assertEqual(result[1]['id'], 'rnd')
 
-    @mock.patch("plotting.colormap.get_colormap_names")
+    @mock.patch.dict("plotting.colormap.colormap_names", {'colormap1': 'COLORMAP1'})
     def test_colormaps(self, m):
-        m.return_value = {
-            'colormap1': 'COLORMAP1',
-        }
         resp = self.app.get('/api/colormaps/')
         self.assertEquals(resp.status_code, 200)
         self.assertEquals(resp.mimetype, 'application/json')

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -148,6 +148,9 @@ class TestAPIv1(unittest.TestCase):
 
         self.assertEqual(res.status_code, 200)
 
+        res_data = self.__get_response_data(res)
+        self.assertIn({'id': 'temperature', 'value': 'Temperature'}, res_data)
+
     def test_colormaps_image_endpoint(self):
         res = self.app.get('/api/v1.0/colormaps.png')
 

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,0 +1,21 @@
+"""Unit tests for plotting.colormap module.
+"""
+import unittest
+
+import plotting.colormap
+
+
+class TestColormap(unittest.TestCase):
+
+    def test_find_colormap_explicit(self):
+        cmap = plotting.colormap.find_colormap("Nitrate Concentration")
+        self.assertEqual(cmap, plotting.colormap.colormaps["nitrate concentration"])
+
+    def test_find_colormap_regex(self):
+        cmap = plotting.colormap.find_colormap("Nitrate Domination")
+        self.assertEqual(cmap, plotting.colormap.colormaps["nitrate"])
+
+    def test_find_colormap_default(self):
+        cmap = plotting.colormap.find_colormap("foo")
+        self.assertEqual(cmap, plotting.colormap.colormaps["mercator"])
+

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -6,7 +6,6 @@ import plotting.colormap
 
 
 class TestColormap(unittest.TestCase):
-
     def test_find_colormap_explicit(self):
         cmap = plotting.colormap.find_colormap("Nitrate Concentration")
         self.assertEqual(cmap, plotting.colormap.colormaps["nitrate concentration"])
@@ -18,4 +17,3 @@ class TestColormap(unittest.TestCase):
     def test_find_colormap_default(self):
         cmap = plotting.colormap.find_colormap("foo")
         self.assertEqual(cmap, plotting.colormap.colormaps["mercator"])
-


### PR DESCRIPTION
## Background
Add dataset config and colour maps for SalishSeaCast biology model (SMELT) variables.
Also includes some drive-by code quality improvements in the `plotting.colormap` module and a new module of unit tests for that module.

## Why did you take this approach?
Only way.


## Anything in particular that should be highlighted?
Colour maps are the same as those used on [SalishSeaCast site](https://salishsea.eos.ubc.ca/nemo/results/nowcast/biology/23mar20#tracer-fields-along-thalweg-and-near-surface) and, I think avoid visibility issues for ferry tracks and points as best as possible.

## Screenshot(s)
![image](https://user-images.githubusercontent.com/76797/77376478-a2c50c00-6d2d-11ea-8079-16e006a85bd6.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
