### PR TITLE
Observational Data Importers

### DIFF
--- a/scripts/data_importers/argo.py
+++ b/scripts/data_importers/argo.py
@@ -42,9 +42,9 @@ def main(uri: str, filename: str):
     else:
         filenames = [filename]
 
-    for filename in filenames:
-        print(filename)
-        with xr.open_dataset(filename) as ds:
+    for fname in filenames:
+        print(fname)
+        with xr.open_dataset(fname) as ds:
             times = pd.to_datetime(ds.JULD.values)
 
             for f in META_FIELDS:

--- a/scripts/data_importers/argo.py
+++ b/scripts/data_importers/argo.py
@@ -1,11 +1,9 @@
 #!env python
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 import defopt
 import seawater
-import datetime
 import os
 import glob
 import data.observational

--- a/scripts/data_importers/argo.py
+++ b/scripts/data_importers/argo.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import pandas as pd
 import xarray as xr

--- a/scripts/data_importers/argo.py
+++ b/scripts/data_importers/argo.py
@@ -1,0 +1,133 @@
+#!env python
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import defopt
+import seawater
+import datetime
+import os
+import glob
+import data.observational
+from data.observational import Platform, Sample, Station, DataType
+
+VARIABLES = [ 'TEMP', 'PSAL' ]
+
+META_FIELDS = {
+    'PLATFORM_NUMBER': None,
+    'PROJECT_NAME': None,
+    'PI_NAME': None,
+    'DATA_CENTRE': None,
+    'PLATFORM_TYPE': None,
+    'FLOAT_SERIAL_NO': None,
+    'FIRMWARE_VERSION': None,
+    'WMO_INST_TYPE': None
+}
+
+datatype_map = {}
+
+def main(uri: str, filename: str):
+    """Import Argo Profiles
+
+    :param str uri: Database URI
+    :param str filename: Argo NetCDF Filename, or directory of files
+    """
+    data.observational.init_db(uri, echo=False)
+    data.observational.create_tables()
+
+    session = data.observational.db.session
+
+    if os.path.isdir(filename):
+        filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))
+    else:
+        filenames = [filename]
+
+    for filename in filenames:
+        print(filename)
+        with xr.open_dataset(filename) as ds:
+            times = pd.to_datetime(ds.JULD.values)
+
+            for f in META_FIELDS:
+                META_FIELDS[f] = ds[f].values.astype(str)
+
+            for prof in ds.N_PROF.values:
+                plat_number = ds.PLATFORM_NUMBER.values.astype(str)[prof]
+                unique_id = f"argo_{plat_number}"
+
+                # Grab the platform from the db base on the unique id
+                platform = session.query(Platform).filter(
+                    Platform.unique_id == unique_id,
+                    Platform.type == Platform.Type.argo
+                ).first()
+                if platform is None:
+                    # ... or make a new platform
+                    platform = Platform(type=Platform.Type.argo,
+                                        unique_id=unique_id)
+                    attrs = {}
+                    for f in META_FIELDS:
+                        attrs[ds[f].long_name] = META_FIELDS[f][prof].strip()
+
+                    platform.attrs = attrs
+                    session.add(platform)
+
+                # Make a new Station
+                station = Station(
+                    time=times[prof],
+                    latitude=ds.LATITUDE.values[prof],
+                    longitude=ds.LONGITUDE.values[prof]
+                )
+                platform.stations.append(station)
+                # We need to commit the station here so that it'll have an id
+                session.commit()
+
+                depth = seawater.dpth(
+                    ds.PRES[prof].dropna('N_LEVELS').values,
+                    ds.LATITUDE.values[prof]
+                )
+
+                samples = []
+                for variable in VARIABLES:
+                    # First check our local cache for the DataType object, if
+                    # that comes up empty, check the db, and failing that,
+                    # create a new one from the variable's attributes
+                    if variable not in datatype_map:
+                        dt = DataType.query.get(ds[variable].standard_name)
+                        if dt is None:
+                            dt = DataType(
+                                key=ds[variable].standard_name,
+                                name=ds[variable].long_name,
+                                unit=ds[variable].units
+                            )
+
+                            data.observational.db.session.add(dt)
+                            # Commit the DataType right away. This might lead
+                            # to a few extra commits on the first import, but
+                            # reduces overall complexity in having to
+                            # 'remember' if we added a new one later.
+                            data.observational.db.session.commit()
+                            datatype_map[variable] = dt
+                    else:
+                        dt = datatype_map[variable]
+
+                    values = ds[variable][prof].dropna('N_LEVELS').values
+
+                    # Using station_id and datatype_key here instead of the
+                    # actual objects so that we can use bulk_save_objects--this
+                    # is much faster, but it doesn't follow any relationships.
+                    samples = [
+                        Sample(
+                        depth=pair[0],
+                        datatype_key=dt.key,
+                        value=pair[1],
+                        station_id = station.id
+                        )
+                        for pair in zip(depth, values)
+                    ]
+
+                    data.observational.db.session.bulk_save_objects(samples)
+
+                session.commit()
+
+
+if __name__ == '__main__':
+    defopt.run(main)

--- a/scripts/data_importers/concepts_drifter.py
+++ b/scripts/data_importers/concepts_drifter.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import numpy as np
 import xarray as xr

--- a/scripts/data_importers/concepts_drifter.py
+++ b/scripts/data_importers/concepts_drifter.py
@@ -35,9 +35,9 @@ def main(uri: str, filename: str):
     else:
         filenames = [filename]
 
-    for filename in filenames:
-        print(filename)
-        with xr.open_dataset(filename) as ds:
+    for fname in filenames:
+        print(fname)
+        with xr.open_dataset(fname) as ds:
             df = ds.to_dataframe().drop(['wmo', 'deployment', 'imei'], axis=1)
             columns = list(filter(lambda c: c in DATATYPE_MAPPING, df.columns))
 

--- a/scripts/data_importers/concepts_drifter.py
+++ b/scripts/data_importers/concepts_drifter.py
@@ -83,7 +83,7 @@ def main(uri: str, filename: str):
 
                 for c in columns:
                     value = row[c]
-                    if type(value) is pd.Timestamp:
+                    if isinstance(value, pd.Timestamp):
                         value = value.value / 10 ** 9
 
                     if np.isfinite(value):
@@ -103,7 +103,7 @@ def main(uri: str, filename: str):
 
             # If there are any samples that haven't been committed yet, do so
             # now.
-            if len(samples) > 0:
+            if samples:
                 data.observational.db.session.bulk_save_objects(samples)
                 data.observational.db.session.commit()
                 samples = []

--- a/scripts/data_importers/concepts_drifter.py
+++ b/scripts/data_importers/concepts_drifter.py
@@ -41,7 +41,6 @@ def main(uri: str, filename: str):
             df = ds.to_dataframe().drop(['wmo', 'deployment', 'imei'], axis=1)
             columns = list(filter(lambda c: c in DATATYPE_MAPPING, df.columns))
 
-            row = df.iloc[0]
             dt_map = {}
             for c in columns:
                 # First check our local cache for the DataType object, if

--- a/scripts/data_importers/concepts_drifter.py
+++ b/scripts/data_importers/concepts_drifter.py
@@ -1,0 +1,116 @@
+#!env python
+
+import numpy as np
+import xarray as xr
+import pandas as pd
+import defopt
+import os
+import glob
+import data.observational
+from data.observational import Platform, Sample, Station, DataType
+
+# These files were created by our scripts so they don't have nice attributes
+# like standard_name, etc.
+# Ideally this script won't stick around as anything other than an example for
+# bulk loading drifter data. Going forward a new importer should be written to
+# read from the incoming csv files and just add the new samples.
+DATATYPE_MAPPING = {
+    'sst': ('sea_water_temperature', 'Water Temperature', 'degree_Celsius'),
+    'vbat': ('battery_voltage', 'Battery Voltage', 'Volts'),
+    'bp': ('air_pressure', 'Barometric Pressure', 'mbar'),
+    'bpt': ('tendency_of_air_pressure', 'Barometric Pressure Tendency', 'mbar'),
+}
+
+def main(uri: str, filename: str):
+    """Import CONCEPTS drifter NetCDF
+
+    :param str uri: Database URI
+    :param str filename: Drifter Filename, or directory of NetCDF files
+    """
+    data.observational.init_db(uri, echo=False)
+    data.observational.create_tables()
+
+    if os.path.isdir(filename):
+        filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))
+    else:
+        filenames = [filename]
+
+    for filename in filenames:
+        print(filename)
+        with xr.open_dataset(filename) as ds:
+            df = ds.to_dataframe().drop(['wmo', 'deployment', 'imei'], axis=1)
+            columns = list(filter(lambda c: c in DATATYPE_MAPPING, df.columns))
+
+            row = df.iloc[0]
+            dt_map = {}
+            for c in columns:
+                # First check our local cache for the DataType object, if
+                # that comes up empty, check the db, and failing that,
+                # create a new one.
+                if c not in dt_map:
+                    dt = DataType.query.get(DATATYPE_MAPPING[c][0])
+                    if dt is None:
+                        dt = DataType(key=DATATYPE_MAPPING[c][0],
+                                    name=DATATYPE_MAPPING[c][1],
+                                    unit=DATATYPE_MAPPING[c][2])
+
+                        data.observational.db.session.add(dt)
+
+                    dt_map[c] = dt
+
+            # Commit to make sure all the variables are in the db so we don't
+            # get any foreign key errors
+            data.observational.db.session.commit()
+
+            p = Platform(type=Platform.Type.drifter)
+            attrs = dict(ds.attrs)
+            attrs['wmo'] = ds.wmo.values[0]
+            attrs['deployment'] = ds.deployment.values[0]
+            attrs['imei'] = ds.imei.values[0]
+            p.attrs = attrs
+            data.observational.db.session.add(p)
+            data.observational.db.session.commit()
+            
+            samples = []
+            for index, row in df.iterrows():
+                time = index[0]
+                lat = row['latitude']
+                lon = row['longitude']
+
+                station = Station(time=time, latitude=lat, longitude=lon,
+                                platform_id=p.id)
+                data.observational.db.session.bulk_save_objects(
+                    [station], return_defaults=True)
+
+                for c in columns:
+                    value = row[c]
+                    if type(value) is pd.Timestamp:
+                        value = value.value / 10 ** 9
+
+                    if np.isfinite(value):
+                        samples.append(Sample(
+                            depth=0,
+                            datatype_key=DATATYPE_MAPPING[c][0],
+                            value=value,
+                            station_id=station.id
+                        ))
+
+                # Commit every 1000 samples, that's a decent balance between
+                # locking the db for too long and performance
+                if len(samples) > 1000:
+                    data.observational.db.session.bulk_save_objects(samples)
+                    data.observational.db.session.commit()
+                    samples = []
+
+            # If there are any samples that haven't been committed yet, do so
+            # now.
+            if len(samples) > 0:
+                data.observational.db.session.bulk_save_objects(samples)
+                data.observational.db.session.commit()
+                samples = []
+
+        data.observational.db.session.commit()
+
+
+if __name__ == '__main__':
+    defopt.run(main)

--- a/scripts/data_importers/glider.py
+++ b/scripts/data_importers/glider.py
@@ -27,9 +27,9 @@ def main(uri: str, filename: str):
         filenames = [filename]
 
     datatype_map = {}
-    for filename in filenames:
-        print(filename)
-        with xr.open_dataset(filename) as ds:
+    for fname in filenames:
+        print(fname)
+        with xr.open_dataset(fname) as ds:
             variables = [v for v in VARIABLES if v in ds.variables]
             df = ds[
                 ['TIME', 'LATITUDE', 'LONGITUDE', 'PRES', *variables]

--- a/scripts/data_importers/glider.py
+++ b/scripts/data_importers/glider.py
@@ -1,0 +1,103 @@
+#!env python
+
+import numpy as np
+import xarray as xr
+import pandas as pd
+import defopt
+import os
+import glob
+import seawater
+import data.observational
+from data.observational import Platform, Sample, Station, DataType
+
+VARIABLES = [ 'CHLA', 'PSAL', 'TEMP', 'CNDC']
+
+def main(uri: str, filename: str):
+    """Import Glider NetCDF
+
+    :param str uri: Database URI
+    :param str filename: Glider Filename, or directory of NetCDF files
+    """
+    data.observational.init_db(uri, echo=False)
+    data.observational.create_tables()
+
+    if os.path.isdir(filename):
+        filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))
+    else:
+        filenames = [filename]
+
+    datatype_map = {}
+    for filename in filenames:
+        print(filename)
+        with xr.open_dataset(filename) as ds:
+            variables = [v for v in VARIABLES if v in ds.variables]
+            df = ds[
+                ['TIME', 'LATITUDE', 'LONGITUDE', 'PRES', *variables]
+            ].to_dataframe().reset_index().dropna()
+
+            df['DEPTH'] = seawater.dpth(df.PRES, df.LATITUDE)
+
+            for variable in variables:
+                if variable not in datatype_map:
+                    dt = DataType.query.get(ds[variable].standard_name)
+                    if dt is None:
+                        dt = DataType(
+                            key=ds[variable].standard_name,
+                            name=ds[variable].long_name,
+                            unit=ds[variable].units
+                        )
+                        data.observational.db.session.add(dt)
+
+                    datatype_map[variable] = dt
+            
+            data.observational.db.session.commit()
+
+            p = Platform(type=Platform.Type.glider,
+                         unique_id=f"glider_{ds.deployment_label}")
+            attrs = {
+                'Glider Platform': ds.platform_code,
+                'WMO': ds.wmo_platform_code,
+                'Deployment': ds.deployment_label,
+                'Institution': ds.institution,
+                'Contact': ds.contact,
+            }
+            p.attrs = attrs
+            data.observational.db.session.add(p)
+            data.observational.db.session.commit()
+            
+            stations = [Station(
+                platform_id=p.id,
+                time=row.TIME,
+                latitude=row.LATITUDE,
+                longitude=row.LONGITUDE,
+            ) for idx, row in df.iterrows()]
+
+            # Using return_defaults=True here so that the stations will get
+            # updated with id's. It's slower, but it means that we can just
+            # put all the station ids into a pandas series to use when
+            # constructing the samples.
+            data.observational.db.session.bulk_save_objects(
+                stations,
+                return_defaults=True
+            )
+            df["STATION_ID"] = [s.id for s in stations]
+
+            samples = [
+                [Sample(
+                    station_id=row.STATION_ID,
+                    depth=row.DEPTH,
+                    value=row[variable],
+                    datatype_key=datatype_map[variable].key
+                ) for variable in variables]
+                for idx, row in df.iterrows()
+            ]
+            data.observational.db.session.bulk_save_objects(
+                [item for sublist in samples for item in sublist]
+            )
+            data.observational.db.session.commit()
+
+        data.observational.db.session.commit()
+
+
+if __name__ == '__main__':
+    defopt.run(main)

--- a/scripts/data_importers/glider.py
+++ b/scripts/data_importers/glider.py
@@ -1,8 +1,6 @@
 #!env python
 
-import numpy as np
 import xarray as xr
-import pandas as pd
 import defopt
 import os
 import glob

--- a/scripts/data_importers/glider.py
+++ b/scripts/data_importers/glider.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import xarray as xr
 import defopt

--- a/scripts/data_importers/nafc_ctd.py
+++ b/scripts/data_importers/nafc_ctd.py
@@ -1,0 +1,90 @@
+#!env python
+
+import numpy as np
+import xarray as xr
+import pandas as pd
+import datetime
+import seawater
+import defopt
+import os
+import glob
+import data.observational
+from data.observational import Platform, Sample, Station, DataType
+
+def main(uri: str, filename: str):
+    """Import NAFC CTD
+
+    :param str uri: Database URI
+    :param str filename: NetCDF file, or directory of files
+    """
+    data.observational.init_db(uri, echo=False)
+    data.observational.create_tables()
+
+    datatype_map = {}
+
+    if os.path.isdir(filename):
+        filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))
+    else:
+        filenames = [filename]
+
+    for filename in filenames:
+        print(filename)
+        with xr.open_dataset(filename) as ds:
+            if len(datatype_map) == 0:
+                # Generate the DataTypes; only consider variables that have depth
+                for var in filter(
+                    lambda x: 'level' in ds[x].coords,
+                    [d for d in ds.data_vars]
+                ):
+                    dt = DataType.query.get(ds[var].standard_name)
+                    if dt is None:
+                        dt = DataType(
+                            key=ds[var].standard_name,
+                            name=ds[var].long_name,
+                            unit=ds[var].units
+                        )
+                    datatype_map[var] = dt
+
+                data.observational.db.session.add_all(datatype_map.values())
+
+            # Query or generate the platform
+            # The files I worked off of were not finalized -- in this case the
+            # trip id also included the cast number, so I strip off the last 3
+            # digits.
+            unique_id = f"nafc_ctd_{ds.trip_id[:-3]}"
+            p = Platform.query.filter(Platform.unique_id==unique_id).one_or_none()
+            if p is None:
+                p = Platform(type=Platform.Type.mission, unique_id=unique_id)
+                p.attrs = {
+                    'Institution': ds.institution,
+                    'Trip ID': ds.trip_id[:-3],
+                    'Ship Name': ds.shipname,
+                }
+                data.observational.db.session.add(p)
+
+            # Generate the station
+            s = Station(
+                latitude = ds.latitude.values[0],
+                longitude = ds.longitude.values[0],
+                time = pd.Timestamp(ds.time.values[0]),
+            )
+            p.stations.append(s)
+            data.observational.db.session.commit()
+
+            ds['level'] = seawater.dpth(
+                ds.level.values,
+                ds.latitude[0].values
+            )
+            
+            # Generate the samples
+            for var, dt in datatype_map.items():
+                da = ds[var].dropna('level')
+                samples = [ Sample(value=d.item(), depth=d.level.item(),
+                                datatype_key=dt.key, station_id=s.id) for d in da ]
+                data.observational.db.session.bulk_save_objects(samples)
+
+            data.observational.db.session.commit()
+
+
+if __name__ == '__main__':
+    defopt.run(main)

--- a/scripts/data_importers/nafc_ctd.py
+++ b/scripts/data_importers/nafc_ctd.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import xarray as xr
 import pandas as pd

--- a/scripts/data_importers/nafc_ctd.py
+++ b/scripts/data_importers/nafc_ctd.py
@@ -27,13 +27,13 @@ def main(uri: str, filename: str):
     else:
         filenames = [filename]
 
-    for filename in filenames:
-        print(filename)
-        with xr.open_dataset(filename) as ds:
+    for fname in filenames:
+        print(fname)
+        with xr.open_dataset(fname) as ds:
             if len(datatype_map) == 0:
                 # Generate the DataTypes; only consider variables that have depth
                 for var in filter(
-                    lambda x: 'level' in ds[x].coords,
+                    lambda x, dataset=ds: 'level' in dataset[x].coords,
                     [d for d in ds.data_vars]
                 ):
                     dt = DataType.query.get(ds[var].standard_name)

--- a/scripts/data_importers/nafc_ctd.py
+++ b/scripts/data_importers/nafc_ctd.py
@@ -1,9 +1,7 @@
 #!env python
 
-import numpy as np
 import xarray as xr
 import pandas as pd
-import datetime
 import seawater
 import defopt
 import os

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -39,7 +39,7 @@ def main(uri: str, filename: str):
     else:
         filenames = [filename]
 
-    for fname in fname:
+    for fname in filenames:
         print(fname)
         # We're only loading Temperature and Salinity from these files, so
         # we'll just make sure the DataTypes are in the db now.

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import numpy as np
 import pandas as pd

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -1,0 +1,143 @@
+#!env python
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import defopt
+import seawater
+import datetime
+import os
+import glob
+import data.observational
+from data.observational import Platform, Sample, Station, DataType
+
+VARIABLES = [ 'TEMP', 'PSAL' ]
+
+META_FIELDS = {
+    'PLATFORM_NUMBER': None,
+    'PROJECT_NAME': None,
+    'PI_NAME': None,
+    'DATA_CENTRE': None,
+    'PLATFORM_TYPE': None,
+    'FLOAT_SERIAL_NO': None,
+    'FIRMWARE_VERSION': None,
+    'WMO_INST_TYPE': None
+}
+
+datatype_map = {}
+
+def main(uri: str, filename: str):
+    """Import Seal Profiles
+
+    :param str uri: Database URI
+    :param str filename: Seal NetCDF Filename, or directory of files
+    """
+    data.observational.init_db(uri, echo=False)
+    data.observational.create_tables()
+
+    session = data.observational.db.session
+
+    if os.path.isdir(filename):
+        filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))
+    else:
+        filenames = [filename]
+
+    for filename in filenames:
+        print(filename)
+        # We're only loading Temperature and Salinity from these files, so
+        # we'll just make sure the DataTypes are in the db now.
+        if DataType.query.get('sea_water_temperature') is None:
+            dt = DataType(
+                key='sea_water_temperature',
+                name='Water Temperature',
+                unit='degree_Celsius'
+            )
+            data.observational.db.session.add(dt)
+
+        if DataType.query.get('sea_water_temperature') is None:
+            dt = DataType(
+                key='sea_water_salinity',
+                name='Water Salinity',
+                unit='PSU'
+            )
+            data.observational.db.session.add(dt)
+
+        data.observational.db.session.commit()
+
+        with xr.open_dataset(filename) as ds:
+            ds['TIME'] = ds.JULD.to_index().to_datetimeindex()
+            ds['TIME'] = ds.TIME.swap_dims({'TIME': 'N_PROF'})
+            depth = seawater.dpth(
+                ds.PRES_ADJUSTED,
+                np.tile(ds.LATITUDE, (ds.PRES.shape[1], 1)).transpose()
+            )
+            ds['DEPTH'] = (['N_PROF', 'N_LEVELS'], depth)
+
+            # This is a single platform, so we can construct it here.
+            p = Platform(
+                type=Platform.Type.animal,
+                unique_id=ds.reference_file_name
+            )
+            p.attrs = {
+                'Principle Investigator': ds.pi_name,
+                'Platform Code': ds.platform_code,
+                'Species': ds.species,
+            }
+
+            data.observational.db.session.add(p)
+            data.observational.db.session.commit()
+
+            # Generate Stations
+            df = ds[['LATITUDE', 'LONGITUDE', 'TIME']].to_dataframe()
+            stations = [
+                Station(
+                    platform_id=p.id,
+                    latitude=row.LATITUDE,
+                    longitude=row.LONGITUDE,
+                    time=row.TIME,
+                )
+                for idx, row in df.iterrows()
+            ]
+
+            # Using return_defaults=True here so that the stations will get
+            # updated with id's. It's slower, but it means that we can just
+            # put all the station ids into a pandas series to use when
+            # constructing the samples.
+            data.observational.db.session.bulk_save_objects(
+                stations,
+                return_defaults=True
+            )
+            df['STATION_ID'] = [s.id for s in stations]
+
+            # Generate Samples
+            df_samp = ds[
+                ['TEMP_ADJUSTED', 'PSAL_ADJUSTED', 'DEPTH']
+            ].to_dataframe().reorder_levels(['N_PROF', 'N_LEVELS'])
+
+            samples = [
+                [
+                    Sample(
+                        station_id=df.STATION_ID[idx[0]],
+                        datatype_key='sea_water_temperature',
+                        value=row.TEMP_ADJUSTED,
+                        depth=row.DEPTH,
+                    ),
+                    Sample(
+                        station_id=df.STATION_ID[idx[0]],
+                        datatype_key='sea_water_salinity',
+                        value=row.PSAL_ADJUSTED,
+                        depth=row.DEPTH,
+                    )
+                ]
+
+                for idx, row in df_samp.iterrows()
+            ]
+            samples = [item for sublist in samples for item in sublist]
+            samples = [s for s in samples if not pd.isna(s.value)]
+
+            data.observational.db.session.bulk_save_objects(samples)
+            data.observational.db.session.commit()
+
+
+if __name__ == '__main__':
+    defopt.run(main)

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -5,7 +5,6 @@ import pandas as pd
 import xarray as xr
 import defopt
 import seawater
-import datetime
 import os
 import glob
 import data.observational
@@ -34,8 +33,6 @@ def main(uri: str, filename: str):
     """
     data.observational.init_db(uri, echo=False)
     data.observational.create_tables()
-
-    session = data.observational.db.session
 
     if os.path.isdir(filename):
         filenames = sorted(glob.glob(os.path.join(filename, "*.nc")))

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -42,8 +42,8 @@ def main(uri: str, filename: str):
     else:
         filenames = [filename]
 
-    for filename in filenames:
-        print(filename)
+    for fname in fname:
+        print(fname)
         # We're only loading Temperature and Salinity from these files, so
         # we'll just make sure the DataTypes are in the db now.
         if DataType.query.get('sea_water_temperature') is None:
@@ -64,7 +64,7 @@ def main(uri: str, filename: str):
 
         data.observational.db.session.commit()
 
-        with xr.open_dataset(filename) as ds:
+        with xr.open_dataset(fname) as ds:
             ds['TIME'] = ds.JULD.to_index().to_datetimeindex()
             ds['TIME'] = ds.TIME.swap_dims({'TIME': 'N_PROF'})
             depth = seawater.dpth(


### PR DESCRIPTION
## Background
I'm not sure if you'll want these as part of the repo or not--probably so for 'sample' ones, but possibly not going forward if you get the data providers to manage their own importers.

## Why did you take this approach?
These have been somewhat optimized for import speed (they're still pretty slow) by going around the ORM a little by using things like bulk_save_objects that doesn't follow relationships. This cuts down on a lot of DB transactions and speeds things up a lot at the expense of a little readability.

## Anything in particular that should be highlighted?
For anybody writing a new importer, my first suggestion would be to switch echo to True in init_db so you'll see every SQL statement printed to screen. With that set, you can use an in-memory sqlite database (URI sqlite:///:memory:) so that you can mess with things a fair bit without touching the proper DB. Even after that, you can test on file-backed sqlite locally.


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
