### PR TITLE
Fix data.class4.list_class4_models crash

### DIFF
--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -209,8 +209,7 @@ class TestAPIv1(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
 
 
-    @unittest.skip("Skipping api/class4.. needs re-write")
-    def test_class4_query_endpoint(self):
+    def test_class4_models_endpoint(self):
         res = self.app.get('/api/v1.0/class4/models/class4_20190102_GIOPS_CONCEPTS_2.3_profile/')
         self.assertEqual(res.status_code, 200)
 


### PR DESCRIPTION
## Background
#704 forgot to remove the FTP code in `data.class4.list_class4_models` so a crash was occurring. This PR just re-writes that function to use the same `glob` pattern established in #704.

I renamed `tests.test_api_v_1_0.test_class4_query_endpoint` to `tests.test_api_v_1_0.test_class4_models_endpoint`. It has also been enabled.

## Why did you take this approach?
Simplest way.

## Anything in particular that should be highlighted?
I still don't like how we figure out which class4 file to open but that can be re-done another time.

## Screenshot(s)
Alternate models can be selected again:
![image](https://user-images.githubusercontent.com/5572045/78147511-307bb800-740e-11ea-93d9-427bbc13ffb3.png)

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
