### PR TITLE
Speed up time_index_to_datetime()

### DIFF
--- a/data/utils.py
+++ b/data/utils.py
@@ -92,12 +92,7 @@ def time_index_to_datetime(timestamps, time_units: str):
     if not isinstance(timestamps, list):
         timestamps = [timestamps]
 
-    t = cftime.utime(time_units)
-
-    result = list(map(
-        lambda time: t.num2date(time).replace(tzinfo=pytz.UTC),
-        timestamps
-    ))
+    result = [cftime.num2date(timestamp, time_units).replace(tzinfo=pytz.UTC) for timestamp in timestamps]
 
     if isinstance(result[0], list):
         return list(itertools.chain(*result))


### PR DESCRIPTION
## Background
Replace `list(map(lambda ...))` construct with list comprehension. Combine `cftime.utime()` call into `cftime.num2date()` call. This makes a difference for all UI dataset change operations, but it is a hugely perceptible speed-up for the SalishSeaCast datasets that have >116,000 timestamps. Profiling:

Before:
```
cftime.num2date lambda: 35.860546588897705s
23.16.30.232 - - [02/Apr/2020 15:38:54] "GET /api/v1.0/timestamps/?dataset=salishseacast_3d_tracers&variable=temperature HTTP/1.1" 200 -
23.16.30.232 - - [02/Apr/2020 15:38:57] "GET /api/v1.0/variables/?dataset=salishseacast_3d_tracers HTTP/1.1" 200 -
23.16.30.232 - - [02/Apr/2020 15:39:00] "GET /api/v1.0/depth/?variable=temperature&dataset=salishseacast_3d_tracers HTTP/1.1" 200 -
cftime.num2date lambda: 35.24283742904663s
23.16.30.232 - - [02/Apr/2020 15:39:41] "GET /api/v1.0/timestamps/?dataset=salishseacast_3d_tracers&variable=temperature&_=1585852581819 HTTP/1.1" 200 -
```

After:
```
cftime.num2date list-comp: 5.772451639175415s
23.16.30.232 - - [02/Apr/2020 15:44:17] "GET /api/v1.0/timestamps/?dataset=salishseacast_3d_biology&variable=ammonium HTTP/1.1" 200 -
23.16.30.232 - - [02/Apr/2020 15:44:40] "GET /api/v1.0/variables/?dataset=salishseacast_3d_biology HTTP/1.1" 200 -
23.16.30.232 - - [02/Apr/2020 15:44:44] "GET /api/v1.0/depth/?variable=ammonium&dataset=salishseacast_3d_biology HTTP/1.1" 200 -
cftime.num2date list-comp: 5.658310413360596s
23.16.30.232 - - [02/Apr/2020 15:44:54] "GET /api/v1.0/timestamps/?dataset=salishseacast_3d_biology&variable=ammonium&_=1585852581820 HTTP/1.1" 200 -
```

## Why did you take this approach?
Simpler code. At least 6x faster.

## Anything in particular that should be highlighted?
Why are there 2 frontend calls to the `/api/v1.0/timestamps/` endpoint per dataset change? They both request processing of the full list of dataset timestamps.

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
