### PR TITLE
Subset + Scriptgen fix

### DIFF
--- a/oceannavigator/datasetconfig.json
+++ b/oceannavigator/datasetconfig.json
@@ -6,6 +6,8 @@
         "help": "Global Ice Ocean Prediction System<U+2029>        <ul><U+2029>            <li>Global Coverage</li><U+2029>            <li>Tri-polar ORCA grid 1/4° resolution (ORCA025), &lt; 15km in Arctic</li><U+2029>            <li>50 vertical z-levels</li><U+2029>            <li>Available as monthly averages (May 2014&ndash;April 2015)</li><U+2029>            <li>Variables Available:<U+2029>                <ul><U+2029> <li>Ice Concentration</li><U+2029>                    <li>Ice Volume</li><U+2029>                    <li>Meridional Wind</li><U+2029> <li>Salinity</li><U+2029>                    <li>Sea Surface Height (Free Surface)</li><U+2029>                    <li>Sea Water Velocity</li> <U+2029>                    <li>Sea Water East Velocity</li><U+2029>                    <li>Sea Water North Velocity</li><U+2029> <li>Sea Water X Velocity</li><U+2029>                    <ul><U+2029>                      <li>water velocity along model x grid lines</li><U+2029> </ul><U+2029>                    <li>Sea Water Y Velocity</li><U+2029>                     <ul><U+2029>                      <li >water velocity along model y grid lines</li><U+2029>                    </ul><U+2029>                    <li>Water Temperature</li><U+2029> <li>Wind</li><U+2029>                    <li>Zonal Wind</li><U+2029>                </ul><U+2029>            </li><U+2029>        </ul>",
         "name": "Historical GIOPS Monthly",
         "quantum": "month",
+        "lat_var_key": "y",
+        "lon_var_key": "x",
         "url": "/data/db/historical-giops-monthly.sqlite3",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "variables": {
@@ -27,6 +29,8 @@
         "quantum": "day",
         "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/Levitus98_PHC21/aggregated.ncml",
         "attribution": "GIOPS Daily Values from CONCEPTS",
+        "lat_var_key": "y",
+        "lon_var_key": "x",
         "help": "Global Ice Ocean Prediction System<U+2029>        <ul><U+2029>            <li>Global Coverage</li><U+2029>            <li>Tri-polar ORCA grid 1/4° resolution (ORCA025), &lt; 15km in Arctic</li><U+2029>            <li>50 vertical z-levels</li><U+2029>            <li>Available as monthly averages (May 2014&ndash;April 2015)</li><U+2029>            <li>Variables Available:<U+2029>                <ul><U+2029>                    <li>Ice Concentration</li><U+2029>                    <li>Ice Volume</li><U+2029>                    <li>Meridional Wind</li><U+2029>                    <li>Salinity</li><U+2029>                    <li>Sea Surface Height (Free Surface)</li><U+2029>                    <li>Sea Water Velocity</li><U+2029>                    <li>Sea Water East Velocity</li><U+2029>                    <li>Sea Water North Velocity</li><U+2029>                    <li>Sea Water X Velocity</li><U+2029>                    <ul><U+2029>                      <li>water velocity along model x grid lines</li><U+2029>                    </ul><U+2029>                    <li>Sea Water Y Velocity</li><U+2029>                     <ul><U+2029>                      <li>water velocity along model y grid lines</li><U+2029>                    </ul><U+2029>                    <li>Water Temperature</li><U+2029>                    <li>Wind</li><U+2029>                    <li>Zonal Wind</li><U+2029>                </ul><U+2029>            </li><U+2029>        </ul>",
         "variables": {
             "vozocrtx": { "name": "Water X Velocity", "envtype": "ocean", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
@@ -438,109 +442,7 @@
             "soniclayerdepth": { "name": "Sonic Layer Depth", "unit": "m", "scale": [0, 1400], "equation": "soniclayerdepth([depth], latitude, [votemper] - 273.15, [vosaline])", "dims": ["time", "yc", "xc"] }
         }
     },
-    "glorys3": {
-        "attribution": "GLORYS2V3 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
-        "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys/aggregated.ncml",
-        "enabled": false,
-        "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>                 <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2013)</li>                 <li>Variables Available:                     <ul>                         <li>Eastward Velocity</li>                         <li>Ice Concentration</li>                         <li>Northward Velocity</li>                         <li>Salinity</li>                         <li>Sea Ice Eastward Velocity</li>                         <li>Sea Ice Northward Velocity</li>                         <li>Sea Ice Thickness</li>                         <li>Sea Ice Velocity</li>                         <li>Sea Surface Height</li>                         <li>Sea Water Velocity</li>                         <li>Temperature</li>                     </ul>                 </li>             </ul>",
-        "name": "GLORYS v3",
-        "quantum": "month",
-        "type": "historical",
-        "time_dim_units": "seconds since 1991-12-04 00:00:00",
-        "url": "/data/db/climatology-glorysv3.sqlite3",
-        "variables": {
-            "iicethic": {
-                "hide": "false",
-                "name": "Ice Thickness",
-                "scale": [
-                    0,
-                    10
-                ],
-                "scale_factor": 1,
-                "unit": "m"
-            },
-            "iicevelu": {
-                "hide": "false",
-                "name": "Sea Ice X Velocity",
-                "scale": [
-                    -1,
-                    1
-                ],
-                "scale_factor": 1,
-                "unit": "m/s"
-            },
-            "iicevelv": {
-                "hide": "false",
-                "name": "Sea Ice Y Velocity",
-                "scale": [
-                    -1,
-                    1
-                ],
-                "scale_factor": 1,
-                "unit": "m/s"
-            },
-            "ileadfra": {
-                "hide": "false",
-                "name": "Ice Concentration",
-                "scale": [
-                    0,
-                    1
-                ],
-                "scale_factor": 1,
-                "unit": "fraction"
-            },
-            "sossheig": {
-                "hide": "false",
-                "name": "Sea Surface Height",
-                "scale": [
-                    -3,
-                    3
-                ],
-                "scale_factor": 1,
-                "unit": "m"
-            },
-            "vomecrty": {
-                "hide": "false",
-                "name": "Water Y Velocity",
-                "scale": [
-                    -3,
-                    3
-                ],
-                "scale_factor": 1,
-                "unit": "m/s"
-            },
-            "vosaline": {
-                "hide": "false",
-                "name": "Salinity",
-                "scale": [
-                    30,
-                    40
-                ],
-                "scale_factor": 1,
-                "unit": "PSU"
-            },
-            "votemper": {
-                "hide": "false",
-                "name": "Temperature",
-                "scale": [
-                    -5,
-                    30
-                ],
-                "scale_factor": 1,
-                "unit": "Celsius"
-            },
-            "vozocrtx": {
-                "hide": "false",
-                "name": "Water X Velocity",
-                "scale": [
-                    -3,
-                    3
-                ],
-                "scale_factor": 1,
-                "unit": "m/s"
-            }
-        }
-    },
+
     "glorys4": {
         "attribution": "GLORYS2V4 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
         "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
@@ -550,6 +452,8 @@
         "quantum": "month",
         "type": "historical",
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
+        "lat_var_key": "y",
+        "lon_var_key": "x",
         "url": "/home/buildadm/ocean-nav/db/GLORYSV4.sqlite3",
         "variables": {
             "iicevele": {
@@ -751,6 +655,8 @@
         "type": "historical",
         "enabled": true,
         "time_dim_units": "seconds since 1991-12-04 00:00:00",
+        "lat_var_key": "y",
+        "lon_var_key": "x",
         "climatology": "http://navigator.oceansdata.ca:8080/thredds/dodsC/climatology/glorys4/aggregated.ncml",
         "attribution": "GLORYS2V4 from <a href='https://www.mercator-ocean.fr/'>Mercator Ocean</a>",
         "help": "Global Ocean Reanalysis and Simulation -&nbsp;             <a href=\\\"https://www.mercator-ocean.fr/wp-content/uploads/2015/08/FS-GLORYS2V3_EN.pdf\\\" target=\\\"_new\\\">System Sheet</a>             <ul>                 <li>Global Coverage</li>                 <li>1/4° Mercator grid</li>                 <li>75 vertical z-levels</li>                 <li>Available as monthly averages (January 1993&ndash;December 2014)</li>             </ul>",

--- a/plotting/templates/pythonSUBSETtemplate.txt
+++ b/plotting/templates/pythonSUBSETtemplate.txt
@@ -2,9 +2,7 @@ import requests
 import os
 import shutil
 from urllib.request import urlopen
-from urllib.parse import urlencode
 from contextlib import closing
-import json
 
 
 def requestFile():
@@ -14,7 +12,9 @@ def requestFile():
 
    # Assemble full request
    base_url = "http://navigator.oceansdata.ca/api/v1.0/subset/?"
-   url = base_url + urlencode({{"query": json.dumps(query)}})
+   url = base_url
+   for key in query:
+      url += f"&{{key}}={{query[key]}}"
    print(url)
 
 


### PR DESCRIPTION
## Background
Resolves #717

A user alerted us to a problem with subsetting Historical GIOPS, this fixes that.

Generated python subset scripts now build their API requests correctly
Historical GIOPS and GLORYS datasets can now be subset

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
python -m unittest `find tests -name "*.py" | grep -v disabled`
```
