### PR TITLE
Set default [...]/oceannavigator/configs to use the off-site branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "oceannavigator/configs"]
 	path = oceannavigator/configs
 	url = https://github.com/DFO-Ocean-Navigator/configurations.git
-	branch = master
+	branch = off-site


### PR DESCRIPTION
Alter the default [...]/oceannavigator/configs to use the off-site branch by default. As the number of instances grow it is better to adjust to meet the needs of the many to those of the few.