### PR TITLE
Mask out surface values for some acoustic variables

### DIFF
--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -6,6 +6,10 @@
 
 [[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
 
-NUMBER_PROCS=$(awk /processor/'{processor++} END {print processor}' < /proc/cpuinfo)
+if [ ! -e /usr/bin/bc ] ; then
+    NUMBER_PROCS=$(awk /^processor/'{processor++} END {print processor}' < /proc/cpuinfo)
+else
+    NUMBER_PROCS=$(echo "$(awk /^processor/'{processor++} END {print processor}' < /proc/cpuinfo) * 2" | bc)
+fi
 
 gunicorn -w $((NUMBER_PROCS)) -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -253,6 +253,7 @@ def tempgradient(depth, latitude, temperature, salinity) -> np.ndarray:
     tempgradient = seawater.adtg(salinity, temperature, press)
     return np.array(tempgradient)
 
+
 def __get_soniclayerdepth_mask(soundspeed: np.ndarray, min_depth_indices: np.ndarray) -> np.ndarray:  
     """
     Create mask which masks out values BELOW deep sound channel.
@@ -274,8 +275,15 @@ def __soniclayerdepth_from_sound_speed(soundspeed: np.ndarray, depth: np.ndarray
 
     # Find sonic layer depth indices
     max_indices = __find_depth_index_of_max_value(soundspeed)
+    
+    data = depth[max_indices]
 
-    return depth[max_indices]
+    # Mask out surface depths, since sonic layer depth cannot physically
+    # be present at the surface. Using np.nan  will make the main map have
+    # transparent spots when the surface is masked out.
+    data[data == depth[0]] = np.nan
+
+    return data
 
 
 def soniclayerdepth(depth, latitude, temperature, salinity) -> np.ndarray:
@@ -319,7 +327,13 @@ def deepsoundchannel(depth, latitude, temperature, salinity) -> np.ndarray:
 
     min_indices = __find_depth_index_of_min_value(sound_speed)
 
-    return depth[min_indices]
+    data = depth[min_indices]
+
+    # Mask out depth values above 500 meters since deep sound
+    # channel cannot occour above this in general.
+    data[data < 500] = np.nan
+
+    return data
 
 
 def deepsoundchannelbottom(depth, latitude, temperature, salinity) -> np.ndarray:


### PR DESCRIPTION
## Background

As the title states, this is to help avoid any misunderstandings with the visual results, since these ocean features cannot occur at the surface.

* Sonic layer depth
* Deep sound channel axis.

## Why did you take this approach?
Computationally quickest method that I know of. Just used numpy broadcasting to handle the masking since it's just a fast one-liner.

## Anything in particular that should be highlighted?
Nope.

## Screenshot(s)

Sonic Layer Depth:
![image](https://user-images.githubusercontent.com/5572045/89651391-6dfdbf80-d89e-11ea-8323-6d3ea0538dfa.png)

Deep Sound Channel Axis:
![image](https://user-images.githubusercontent.com/5572045/90134870-66ca2c00-dd4c-11ea-9b6e-be7df7cc941e.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
