### PR TITLE
Updated the runserver.sh script

### DIFF
--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -6,6 +6,10 @@
 
 [[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
 
-NUMBER_PROCS=$(awk /processor/'{processor++} END {print processor}' < /proc/cpuinfo)
+if [ ! -e /usr/bin/bc ] ; then
+    NUMBER_PROCS=$(awk /^processor/'{processor++} END {print processor}' < /proc/cpuinfo)
+else
+    NUMBER_PROCS=$(echo "$(awk /^processor/'{processor++} END {print processor}' < /proc/cpuinfo) * 2" | bc)
+fi
 
 gunicorn -w $((NUMBER_PROCS)) -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2


### PR DESCRIPTION
During my search for ways to improve the user end experience. We should be launching two gunicorn processes per cpu processor found. The update to the runserver.sh script determines the number of processors an OS instance can see in the /proc/cpuinfo file multiplies that value by 2 and launches the number returned from the bc command.