### PR TITLE
Changing the size and color used when plotting the bathymetry dataset.

### DIFF
--- a/plotting/map.py
+++ b/plotting/map.py
@@ -667,12 +667,9 @@ class MapPlotter(Plotter):
                 self.longitude, self.latitude, self.bathymetry, latlon=True,
                 linewidths=0.5,
                 norm=LogNorm(vmin=1, vmax=6000),
-                cmap=mcolors.LinearSegmentedColormap.from_list(
-                    'transparent_gray',
-                    [(0, 0, 0, 0.5), (0, 0, 0, 0.1)]
-                ),
+                cmap='Greys',
                 levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])
-            plt.clabel(cs, fontsize='xx-small', fmt='%1.0fm')
+            plt.clabel(cs, fontsize='x-large', fmt='%1.0fm')
 
         if self.area and self.show_area:
             for a in self.area:

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from textwrap import wrap
 
-import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import osr


### PR DESCRIPTION
## Background

A number of end users and stakeholders have requested that the size of the font being used when the bathymetry data is viewed be increased and the color to be a more prominent.

## Why did you take this approach?

The font size change was easier than selecting the color. In the end I removed the array values and used a direct call to a color scheme.

## Anything in particular that should be highlighted?


## Screenshot(s)

![image](https://user-images.githubusercontent.com/44408505/96503825-652a5200-122e-11eb-8c4e-bf5b36864167.png)

## Checks
- [* ] I ran unit tests.
- [*] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
Here are the results of running the unit tests;

```
======================================================================
ERROR: test_deepsoundchannel (tests.test_data_functions.TestDataFunctions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/buildadm/Ocean-Data-Map-Project/tests/test_data_functions.py", line 47, in test_deepsoundchannel
    data=[0], dims=['depth']), [45], [0.5], [32]), 0)
  File "/home/buildadm/Ocean-Data-Map-Project/data/calculated_parser/functions.py", line 334, in deepsoundchannel
    data[data < 500] = np.nan
TypeError: 'numpy.int64' object does not support item assignment

----------------------------------------------------------------------
Ran 183 tests in 1586.729s
FAILED (errors=1, skipped=20)
```