### PR TITLE
Image Optimization removed

### DIFF
--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pint
 from flask_babel import format_date, format_datetime
-from PIL import Image
 
 import plotting.colormap as colormap
 import plotting.utils as utils

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -244,13 +244,13 @@ class Plotter(metaclass=ABCMeta):
             )
             plt.close(fig)
 
-            if self.filetype == 'png':
-                buf.seek(0)
-                im = Image.open(buf)
-                with contextlib.closing(BytesIO()) as buf2:
-                    im.save(buf2, format='PNG', optimize=True)
-                    buf2.seek(0)
-                    return (buf2.getvalue(), self.mime, self.filename)
+            #if self.filetype == 'png':
+            #    buf.seek(0)
+            #    im = Image.open(buf)
+            #    with contextlib.closing(BytesIO()) as buf2:
+            #        im.save(buf2, format='PNG', optimize=True)
+            #        buf2.seek(0)
+            #        return (buf2.getvalue(), self.mime, self.filename)
 
             buf.seek(0)
             return (buf.getvalue(), self.mime, self.filename)

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -244,14 +244,6 @@ class Plotter(metaclass=ABCMeta):
             )
             plt.close(fig)
 
-            #if self.filetype == 'png':
-            #    buf.seek(0)
-            #    im = Image.open(buf)
-            #    with contextlib.closing(BytesIO()) as buf2:
-            #        im.save(buf2, format='PNG', optimize=True)
-            #        buf2.seek(0)
-            #        return (buf2.getvalue(), self.mime, self.filename)
-
             buf.seek(0)
             return (buf.getvalue(), self.mime, self.filename)
 


### PR DESCRIPTION
## Background
Optimize the ocean navigator performance in terms of response time

## Why did you take this approach?
Based on the profiling results it shows this particular function (Compress/optimize the image) takes more time.
If it takes more time, then no point in optimizing, surprisingly without that function we can see improvement in response time based on the profiling results. 

## Anything, in particular, that should be highlighted?
N/A

## Screenshot(s)
After modification
![image](https://user-images.githubusercontent.com/46497911/96661481-bae22580-1326-11eb-9c3b-833f082966e3.png)

Before modification
![image](https://user-images.githubusercontent.com/46497911/96661523-d1887c80-1326-11eb-9c27-44375958184a.png)



