### PR TITLE
Custom debug log msg

### DIFF
--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import logging
+
 from flask import Flask, request, send_file
 from flask_compress import Compress
 from flask_babel import Babel
@@ -19,6 +21,10 @@ def create_app(testing = False):
     app.config.from_pyfile('oceannavigator.cfg', silent=False)
     app.config.from_envvar('OCEANNAVIGATOR_SETTINGS', silent=True)
     app.testing = testing
+    # Customize Flask debug logger message format
+    app.logger.handlers[0].setFormatter(logging.Formatter(
+        '%(asctime)s %(levelname)s in [%(pathname)s:%(lineno)d]: %(message)s',
+        datefmt="%Y-%m-%d %H:%M:%S"))
     db.init_app(app)
 
     datasetConfig = argv[-1]

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -1,9 +1,9 @@
 import logging
+from sys import argv
 
 from flask import Flask, request, send_file
 from flask_compress import Compress
 from flask_babel import Babel
-from sys import argv
 
 # Although DatasetConfig is not used in this module, this import is absolutely necessary
 # because it is how the rest of the app gets access to DatasetConfig

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 from flask import Flask, request, send_file

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -4,6 +4,9 @@ from flask import Flask, request, send_file
 from flask_compress import Compress
 from flask_babel import Babel
 from sys import argv
+
+# Although DatasetConfig is not used in this module, this import is absolutely necessary
+# because it is how the rest of the app gets access to DatasetConfig
 from .dataset_config import DatasetConfig
 from data.observational import db
 

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -32,7 +32,7 @@ def create_app(testing = False):
         app.config['datasetConfig'] = datasetConfig
     else:
         app.config['datasetConfig'] = "datasetconfig.json"
-    
+
     @app.route('/public/')
     def public_index():
         res = send_file('frontend/public/index.html')


### PR DESCRIPTION
## Background
The Flask default 4-line message format for DEBUG level messages (2 lines of content, delimited with ---- lines
above and below) is a little over the top IMHO. So, I am proposing to change it to a 1-line format:

Before:
```
50.67.188.80 - - [05/Oct/2020 23:24:25] "GET /api/v1.0/class4/ HTTP/1.1" 200 -
--------------------------------------------------------------------------------
DEBUG in api_v1_0 [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0  .py:104]:
This is a DEBUG level log message
--------------------------------------------------------------------------------
50.67.188.80 - - [05/Oct/2020 23:24:25] "GET /api/v1.0/datasets/ HTTP/1.1" 200   -
```

After:
```
50.67.188.80 - - [05/Oct/2020 23:26:39] "GET /api/v1.0/variables/?dataset=giops_day HTTP/1.1" 200 -
2020-10-05 23:26:39 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:104]: This is a DEBUG level log message
50.67.188.80 - - [05/Oct/2020 23:26:39] "GET /api/v1.0/datasets/ HTTP/1.1" 200   -
```

## Why did you take this approach?
The 1-line format is more compact in the log, and more amenable to programmatic log parsing (should we decide we want to do that at some point).

## Anything in particular that should be highlighted?
1. b2f4b01 s the crux of this change. The other commits are code clean-up.

2. I hesitated to so a PR for this because I thought it was only useful in my local dev env for the performance timing work that I am doing, but a Slack conversation with @CubeCode93 indicated that this might also be useful to him.

3. I make use of DEBUG logging to report on code execution timing as follows:
```python
import time as stdlib_time

from flask import current_app
```
`time` is used often enough as a variable name in the codebase that it is safer to alias the `time` module on import, and I couldn't come up with a better alias name than `stdlib_time`. When the Flask app is set up, it puts the `logger` instance that outputs to the console on the `flask.current_app` object.

To log the execution time for a piece of code, I record the time before the code, and write a log message after is:
```python
    t_start = stdlib_time.time()
    img, mime, filename = plotter.run()
    current_app.logger.debug(f"plot_v1_0 plotter.run(): {stdlib_time.time() - t_start}")
```
That results in a log message that looks like:
```
2020-10-23 21:26:21 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:528]: plot_v1_0 plotter.run(): 7.914980173110962
```
4. One downside of this is that if you instrument bits of code down a call chain in that way, the messages appear in the log kind of "inside out". Example:
```
2020-10-23 21:26:13 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:515]: plot_v1_0: plottype=profile, dataset=giops_day, variable=['votemper']
2020-10-23 21:26:13 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:524]: plot_v1_0 plotter prep: 0.0010960102081298828
2020-10-23 21:26:13 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/data/mercator.py:285]: get_profile __bounding_box(): 0.14525938034057617
2020-10-23 21:26:13 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/data/mercator.py:295]: get_profile var[].values: 0.3907015323638916
2020-10-23 21:26:14 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/data/mercator.py:304]: get_profile __resample(): 1.0631771087646484
2020-10-23 21:26:15 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/data/mercator.py:308]: get_profile squeeze depths: 0.852062463760376
2020-10-23 21:26:15 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/point.py:73]: get_data(): 2.4578309059143066
2020-10-23 21:26:15 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:113]: plot() layout prep: 0.0014548301696777344
2020-10-23 21:26:18 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:122]: plot() showmap: 2.5651354789733887
2020-10-23 21:26:18 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:135]: plot() matplotlib.plt.plot(): 0.005829811096191406
2020-10-23 21:26:18 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:170]: plot() fig.tight_layout(): 0.43133997917175293
2020-10-23 21:26:18 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:173]: plot(): 3.069526433944702
2020-10-23 21:26:21 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/plotter.py:251]: plot() matplotlib.plt.savefig(): 2.2836880683898926
2020-10-23 21:26:21 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/plotting/profile.py:176]: super('ProfilePlotter').plot(): 2.285094976425171
2020-10-23 21:26:21 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:528]: plot_v1_0 plotter.run(): 7.914980173110962
2020-10-23 21:26:21 DEBUG in [/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py:552]: plot_v1_0 response prep: 0.0017085075378417969
```
The times that make up the 7.914980173110962 seconds spent in `api_v1_0.plot_v1_0.plotter.run()` are listed above it's message on the 2nd last line. That takes some getting used to...

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
