### PR TITLE
Fix ValueError due to 1D lons/lats in subset API call

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -595,7 +595,7 @@ class NetCDFData(Data):
                 return pyresample.kd_tree.resample_nearest(input_def, data,
                                                            output_def, radius_of_influence=float(self.radius), nprocs=8)
 
-        raise ValueError(f"Unknown interpolation method {self.interp}.")                                               
+        raise ValueError(f"Unknown interpolation method {self.interp}.")
 
     @property
     def time_variable(self):

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -397,6 +397,8 @@ class NetCDFData(Data):
             XI_mg, YI_mg = np.meshgrid(XI, YI)
 
             # Define input/output grid definitions
+            if lon_vals.ndim == 1:
+                lon_vals, lat_vals = np.meshgrid(lon_vals, lat_vals)
             input_def = pyresample.geometry.SwathDefinition(
                 lons=lon_vals, lats=lat_vals)
             output_def = pyresample.geometry.SwathDefinition(

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import cftime
 import netCDF4

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -70,6 +70,7 @@
             "ssh": { "name":  "Sea Surface Height", "unit":  "m", "scale":  [-4, 4], "zero_centered": "true" }
         }
     },
+
     "salishseacast_currents": {
         "enabled": true,
         "name": "SalishSeaCast 3D Currents",

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -91,5 +91,16 @@
             "uVelocity": { "name":  "Eastward Current", "unit":  "m/s", "scale":  [-8, 8], "zero_centered": "true" },
             "vVelocity": { "name":  "Northward Current", "unit":  "m/s", "scale":  [-8, 8], "zero_centered": "true" }
         }
+    },
+
+    "mercator_test": {
+        "enabled": 1,
+        "url": "tests/testdata/mercator_test.nc",
+        "time_dim_units": "seconds since 1950-01-01 00:00:00",
+        "lat_var_key": "latitude",
+        "lon_var_key": "longitude",
+        "variables": {
+            "votemper": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] }
+        }
     }
 }


### PR DESCRIPTION
## Background
Issue #769 revealed 2 ways in which a `subset` API call can result in a `ValueError`. This PR addresses one of them. A subsequent PR will address the other. 

In the case addressed here, @nsoontie identified in https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/769#issuecomment-715537549 that the `ValueError` is due to the lons and lats variables being 1D arrays but `pyresample.geometry.SwathDefinition()` requires 2D arrays. The solution that @nsoontie came up with is to use `numpy.meshgrid()` to generate 2D lons and lats arrays.


## Why did you take this approach?
It's a very simple, elegant 2-line solution to the problem.


## Anything in particular that should be highlighted?
It probably took me longer to cook up the unit test that demonstrates that the problem is resolved than it took @nsoontie to come up with the solution :smile: 


## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
