### PR TITLE
Change showmap default to false for Points & Class4 UI overlays

### DIFF
--- a/oceannavigator/frontend/src/components/Class4Window.jsx
+++ b/oceannavigator/frontend/src/components/Class4Window.jsx
@@ -17,7 +17,7 @@ export default class Class4Window extends React.Component {
 
     this.state = {
       forecast: "best",
-      showmap: true,
+      showmap: false,
       climatology: false,
       error: "none",
       size: "10x7",

--- a/oceannavigator/frontend/src/components/Class4Window.jsx
+++ b/oceannavigator/frontend/src/components/Class4Window.jsx
@@ -43,11 +43,11 @@ export default class Class4Window extends React.Component {
 
   onLocalUpdate(key, value) {
     if (this._mounted) {
-     
+
       let newState = {};
       if (typeof(key) === "string") {
         newState[key] = value;
-      } 
+      }
       else {
         for (let i = 0; i < key.length; ++i) {
           newState[key[i]] = value[i];
@@ -96,7 +96,7 @@ export default class Class4Window extends React.Component {
       <div className='Class4Window Window'>
         <Row>
           <Col lg={2}>
-            <Panel 
+            <Panel
               defaultExpanded
               bsStyle='primary'
             >

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -42,7 +42,7 @@ export default class PointWindow extends React.Component {
       selected: TabEnum.PROFILE,
       scale: props.scale + ",auto",
       depth: props.depth,
-      showmap: true,
+      showmap: false,
       colormap: "default",
       starttime: Math.max(props.time - 24, 0),
       variables: [],

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -37,7 +37,7 @@ export default class PointWindow extends React.Component {
 
     // Track if mounted to prevent no-op errors with the Ajax callbacks.
     this._mounted = false;
-    
+
     this.state = {
       selected: TabEnum.PROFILE,
       scale: props.scale + ",auto",
@@ -90,7 +90,7 @@ export default class PointWindow extends React.Component {
       }
       if (this.state.scale.indexOf("auto") !== -1) {
         state.scale = props.scale + ",auto";
-      } 
+      }
       else {
         state.scale = props.scale;
       }
@@ -109,7 +109,7 @@ export default class PointWindow extends React.Component {
       url: "/api/v1.0/variables/?dataset=" + dataset,
       dataType: "json",
       cache: true,
-  
+
       success: function(data) {
         if (this._mounted) {
           const vars = data.map(function(d) {
@@ -119,7 +119,7 @@ export default class PointWindow extends React.Component {
           if (vars.indexOf(this.props.variable.split(",")[0]) === -1) {
             this.props.onUpdate("variable", vars[0]);
           }
-          
+
           this.setState({
             variables: data.map(function(d) {
               return d.id;
@@ -127,7 +127,7 @@ export default class PointWindow extends React.Component {
           });
         }
       }.bind(this),
-  
+
       error: function(xhr, status, err) {
         if (this._mounted) {
           console.error(this.props.url, status, err.toString());
@@ -151,7 +151,7 @@ export default class PointWindow extends React.Component {
 
       if (typeof(key) === "string") {
         newState[key] = value;
-      } 
+      }
       else {
         for (let i = 0; i < key.length; i++) {
           newState[key[i]] = value[i];
@@ -243,7 +243,7 @@ export default class PointWindow extends React.Component {
             onUpdate={this.onLocalUpdate}
             title={_("Show Location")}>{_("showmap_help")}
           </SelectBox>
-          
+
           <div style={{display: this.props.point.length == 1 ? "block" : "none",}}>
             <LocationInput
               key='point'
@@ -253,7 +253,7 @@ export default class PointWindow extends React.Component {
               onUpdate={this.onLocalUpdate}
             />
           </div>
-          
+
           <ImageSize
             key='size'
             id='size'
@@ -314,7 +314,7 @@ export default class PointWindow extends React.Component {
         onUpdate={this.props.onUpdate}
         min={this.state.starttime}
       /> </div> : null;
-    
+
     // Only show depth and scale selector for Mooring tab.
     const showDepthVariableScale = this.state.selected === TabEnum.MOORING;
     const depthVariableScale = showDepthVariableScale ? <div>
@@ -326,7 +326,7 @@ export default class PointWindow extends React.Component {
         onUpdate={this.onLocalUpdate}
         url={"/api/v1.0/depth/?variable=" + this.props.variable + "&dataset=" + this.props.dataset + "&all=True"}
         title={_("Depth")}></ComboBox>
-      
+
       <ComboBox
         key='variable'
         id='variable'
@@ -366,12 +366,12 @@ export default class PointWindow extends React.Component {
         def={""}
         onUpdate={this.onLocalUpdate}
         url={"/api/v1.0/depth/?variable=" + this.state.variable + "&dataset=" + this.props.dataset}
-        title={_("Depth")}></ComboBox> 
+        title={_("Depth")}></ComboBox>
     </div> : null;
-  
-    
+
+
     // Create Variable dropdown for Profile and Observation
-    const showProfileVariable = this.state.selected == TabEnum.PROFILE || 
+    const showProfileVariable = this.state.selected == TabEnum.PROFILE ||
                                 this.state.selected == TabEnum.OBSERVATION;
     const profilevariable = showProfileVariable ? <ComboBox
       key='variable'
@@ -396,7 +396,7 @@ export default class PointWindow extends React.Component {
           multiple
           onUpdate={this.onLocalUpdate}
         />;
-      } 
+      }
       else {
         observation_data = this.props.point[0][2].datatypes.map(
           function (o, i) {
@@ -436,7 +436,7 @@ export default class PointWindow extends React.Component {
         plot_query.variable = this.state.variable;
         inputs = [global, time, profilevariable];
         break;
-      
+
       case TabEnum.CTD:
         plot_query.type = "profile";
         plot_query.time = this.props.time;
@@ -453,7 +453,7 @@ export default class PointWindow extends React.Component {
         }
         inputs = [global, time];
         break;
-    
+
       case TabEnum.TS:
         plot_query.type = "ts";
         plot_query.time = this.props.time;
@@ -463,7 +463,7 @@ export default class PointWindow extends React.Component {
 
         inputs = [global, time];
         break;
-      
+
       case TabEnum.SOUND:
         plot_query.type = "sound";
         plot_query.time = this.props.time;
@@ -474,11 +474,11 @@ export default class PointWindow extends React.Component {
         plot_query.observation = this.props.point.map(function (o) {
           return o[2];
         });
-        
+
         plot_query.observation_variable = this.state.observation_variable;
         plot_query.variable = this.state.variable;
         inputs = [global, observation_variable, profilevariable];
-        
+
         break;
       case TabEnum.MOORING:
         plot_query.type = "timeseries";
@@ -521,7 +521,7 @@ export default class PointWindow extends React.Component {
     // and Salinity. This is used to enable/disable some tabs.
     const hasTempSalinity =
     ( this.state.variables.indexOf("votemper") !== -1 ||
-      this.state.variables.indexOf("temp") !== -1) && 
+      this.state.variables.indexOf("temp") !== -1) &&
     ( this.state.variables.indexOf("vosaline") !== -1 ||
       this.state.variables.indexOf("salinity") !== -1);
 


### PR DESCRIPTION
## Background
In the hunt for ways to improve the performance of the profile plots in the Points UI overlay I found that the map generated when the Show Location checkbox is checked takes a significant percentage of the total rendering time. The changes in this PR make the default for Show Location in the Points and Class3 overlays unchecked.

I also considered changing the default checked setting of the Show Map checkbox in the Lines and Observation Tracks overlays, but decided that the map tiles in those overlays provide sufficiently useful information that they should remain. Please see the notes on the screenshots below. **I would like confirmation of that decision from people who are closer to the user community than I am.**


## Why did you take this approach?
The backend code that runs when `showmap` is `true` takes 2 to 3 seconds, which is 30%-50% of the total time to generate the content of the Points and Class4 overlays. In those overlays the graphic produced when `showmap` is `true` is a fairly uninformative single point on a map tile. Speeding up the generation of the overlays content at the expense of not showing those map tiles seems like a good trade-off to improve UX, and @VanessaSutton-Pande's recent discussion with users of that trade-off got their agreement to go ahead with it.


## Anything in particular that should be highlighted?
@dwayne-hart Please note that deployment of this change requires a rebuild of the frontend components in the production container.


## Screenshot(s)
Points overlay with this PR's change in place:
![ProfileShowLocationUnchecked](https://user-images.githubusercontent.com/76797/98166866-f7705e00-1e9c-11eb-8238-bf0ece0b4781.png)

Class4 overlay with this PR's change in palce:
![Class4ShowLocationUnchecked](https://user-images.githubusercontent.com/76797/98166902-09ea9780-1e9d-11eb-872c-3c0059c07297.png)

Lines overly Show Map Location provides useful information about the direction of the transect, so it remains checked by default:
![LineShowMapLocationChecked](https://user-images.githubusercontent.com/76797/98167020-3c949000-1e9d-11eb-8d58-8345a3379d61.png)

Observations Track overlay Show Map provides useful information about the shape of the the track, so it remains checked by default:
![ObservarionsShowMapChecked](https://user-images.githubusercontent.com/76797/98167293-af9e0680-1e9d-11eb-9184-e416c45d6470.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
