### PR TITLE
Changed the way the host IP is determined.

### DIFF
--- a/bin/launch-web-service.sh
+++ b/bin/launch-web-service.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-HOST_IP=$(ip addr show | grep -E "e(th|np|ns)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//')
+
+HOST_IP=$(hostname -I | awk '{print $1}')
 
 PORT=5000
 


### PR DESCRIPTION
## Background

`HOST_IP=$(ip addr show | grep -E "e(th|np|ns)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//')`

this command is based on finding the eth, enp, and / or ens interface and then determining what the assigned ip is for a given interface. This command fails to work with other interface names. Particularly infiniband network interfaces which use the string ifb,

## Why did you take this approach?

`HOST_IP=$(hostname -I | awk '{print $1}')`

the command determines what ip the machine has and prints it.

The desired behavior is obtained with a smaller command.
```
(navigator) ubuntu@u2004-onav-2:~/Ocean-Data-Map-Project$ ip addr show | grep -E "e(th|np|ns)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//'
10.0.3.60
(navigator) ubuntu@u2004-onav-2:~/Ocean-Data-Map-Project$ hostname -I | awk '{print $1}'
10.0.3.60
```

