### PR TITLE
Updates 202006111822

### DIFF
--- a/bin/launch-web-service.sh
+++ b/bin/launch-web-service.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-HOST_IP=$(ip addr show | grep -E "e(th|np|ns)" | grep inet | awk '{print $2}' | sed -e 's/\/[0-9]*//')
+
+HOST_IP=$(hostname -I | awk '{print $1}')
 
 PORT=5000
 

--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -35,7 +35,7 @@
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",
     "js-yaml": "^3.13.1",
     "ol": "~5.3.3",
-    "papaparse": "^4.3.3",
+    "papaparse": "^5.2.0",
     "proj4": "~2.4.3",
     "prop-types": "^15.5.10",
     "rc-slider": "^9.2.2",
@@ -49,7 +49,8 @@
     "react-ga": "^2.5.3",
     "react-iframe": "1.0.7",
     "react-numeric-input": "^2.2.3",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "yargs-parser": "^13.1.2"
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -1324,6 +1324,11 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -1917,7 +1922,7 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -4418,10 +4423,10 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-papaparse@^4.3.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
-  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
+papaparse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.0.tgz#ab1702feb96e79ab4309652f36db9536563ad05a"
+  integrity sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg==
 
 param-case@2.1.x:
   version "2.1.1"
@@ -6747,6 +6752,14 @@ yargs-parser@5.0.0-security.0:
   dependencies:
     camelcase "^3.0.0"
     object.assign "^4.1.0"
+
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
## Background

Outstanding Dependabot alerts for the papaparse and yargs-parser packages.

## Why did you take this approach?

The papaparse package had a high severity warning and needed to be addressed. 

## Anything in particular that should be highlighted?

Two additional packages were either installed or updated to allow the aforementioned packages to be updated. Those packages are;

- camelcase
- decamelize

## Screenshot(s)

![image](https://user-images.githubusercontent.com/44408505/98420794-837fb280-2062-11eb-90e4-6001d77ac12a.png)


## Checks
- [*] I ran unit tests.
- [*] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
