### PR TITLE
Add possible Sentry environment name from envvar

### DIFF
--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from sys import argv
 
 from flask import Flask, request, send_file
@@ -20,7 +21,11 @@ def config_blueprints(app):
 
 def create_app(testing = False):
     # Sentry DSN URL will be read from SENTRY_DSN environment variable
-    sentry_sdk.init(integrations=[FlaskIntegration()], traces_sample_rate=1.0)
+    sentry_sdk.init(
+        integrations=[FlaskIntegration()],
+        traces_sample_rate=1.0,
+        environment=os.getenv("SENTRY_ENV"),
+    )
     app = Flask(__name__, static_url_path='', static_folder='frontend')
     app.add_url_rule('/', 'root', lambda: app.send_static_file('index.html'))
     app.config.from_pyfile('oceannavigator.cfg', silent=False)


### PR DESCRIPTION
## Background
This change adds tagging of exception events captured by Sentry with and environment name that is read from the `SENTRY_ENV` environment variable. If that envvar is unset, the exceptions are not tagged, but they are still captured by Sentry.


## Why did you take this approach?
Using an environment variable and the fact at the value returned by `os.getenv()` defaults to `None` gives us the flexibility to deploy Navigator instances with `SENTRY_ENV` not set with no negative consequences. When `SENTRY_ENV` is set, exception events captured by Sentry will be tagged with the environment name, enabling easy filtering of events from different environments; e.g. NAFC and `dory` production containers.

## Anything in particular that should be highlighted?
I propose that we use `NAFC` and `dory-prod` as environment names for the two deployments where we presently have Sentry activated.


## Screenshot(s)
N/A


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
