### PR TITLE
Only use open_mfdataset() when there is >1 dataset

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -56,11 +56,17 @@ class NetCDFData(Data):
 
             if self._nc_files:
                 try:
-                    self.dataset = xarray.open_mfdataset(
-                        self._nc_files,
-                        decode_times=decode_times,
-                        chunks=200,
-                    )
+                    if len(self._nc_files) > 1:
+                        self.dataset = xarray.open_mfdataset(
+                            self._nc_files,
+                            decode_times=decode_times,
+                            chunks=200,
+                        )
+                    else:
+                        self.dataset = xarray.open_dataset(
+                            self._nc_files[0],
+                            decode_times=decode_times,
+                        )
                 except xarray.core.variable.MissingDimensionsError:
                     # xarray won't open FVCOM files due to dimension/coordinate/variable label
                     # duplication issue, so fall back to using netCDF4.Dataset()


### PR DESCRIPTION
## Background
There is a measurable performance cost to using `xarray.open_mfdataset()` with
chunking instead of `xarray.open_dataset()` without chunking when we are only
opening a single dataset.

## Why did you take this approach?
Timing statistics for `routes.api_v1_0.tile_v1_0()` calls for single dataset variables initial page load with cold caches:

`xarray.open_mfdataset(..., chunks=200)`:
Statistic | Value
-- | --
count | 61
min | 0.817 s
mean | 2.496 s
median | 1.854 s
std dev | 1.679 s
max | 7.855 s

`xarray.open_dataset()` with no chunking:
Statistic | Value
-- | --
count | 61
min | 0.578 s
mean | 1.515 s
median | 1.451 s
std dev | 0.411 s
max | 2.491 s


## Anything in particular that should be highlighted?
I don't believe that the uniform chunking factor of 200 on all dimensions that is presently hard-coded is optimal when we are loading multiple datasets (either to retrieve multiple variables, or the retrieve long time series). Chunking for data access should be related to the chunking scheme that is used for the data storage, the memory available for `dask` to operate in, and the dimensionality of the data use. All of those issues need to be considered in addressing issue #690.

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
