### PR TITLE
Drop unused `pint.UnitRegistry` in `Mercator.depths` & `Nemo.depths` properties

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -48,14 +48,8 @@ class Mercator(Model):
                     break
             self.__depths = var.values if var is not None else np.array([0])
 
-            if var is not None:
-                ureg = UnitRegistry()
-                unit = ureg.parse_units(var.attrs['units'].lower())
-                self.__depths = ureg.Quantity(var[:].values, unit).to(ureg.meters).magnitude
-            else:
-                self.__depths = np.array([0])
-
-            self.__depths.flags.writeable = False
+            # Make immutable
+            self.__depths.setflags(write=False)
 
         return self.__depths
 

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -46,6 +46,7 @@ class Mercator(Model):
                     # Get DataArray for depth
                     var = self.nc_data.get_dataset_variable(v)
                     break
+            self.__depths = var.values if var is not None else np.array([0])
 
             if var is not None:
                 ureg = UnitRegistry()

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -76,7 +76,7 @@ class Mercator(Model):
 
     def __resample(self, lat_in, lon_in, lat_out, lon_out, var, radius=50000):
         var = np.squeeze(var)
-        
+
         origshape = var.shape
 
         data, masked_lat_in, masked_lon_in, output_def = super()._make_resample_data(lat_in,

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -80,7 +80,7 @@ class Nemo(Model):
         """ Resamples data given lat/lon inputs and outputs
         """
         var = np.squeeze(var)
-        
+
         origshape = var.shape
 
         data, masked_lat_in, masked_lon_in, output_def = super()._make_resample_data(lat_in,

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -42,12 +42,7 @@ class Nemo(Model):
                     # Get DataArray for depth
                     var = self.nc_data.get_dataset_variable(v)
                     break
-            if var is not None:
-                ureg = UnitRegistry()
-                unit = ureg.parse_units(var.attrs['units'].lower())
-                self.__depths = ureg.Quantity(var.values, unit).to(ureg.meters).magnitude
-            else:
-                self.__depths = np.array([0])
+            self.__depths = var.values if var is not None else np.array([0])
 
             # Make immutable
             self.__depths.setflags(write=False)


### PR DESCRIPTION
## Background
Instantiation of `pint.UnitRegistry` appears to take ~200ms every time the `depths` property is accessed.
However, code inspection and UI testing show that none of the features of `UnitRegistry` are being used on `depths`;
i.e. there are no accesses of `depths.magnitude` or `depths.units`, nor `pint` unit conversions on `depths`.

The `depths` property is accessed by several API endpoints, notably `tile_v1_0`, so eliminating that ~200ms can produce noticeably snappier performance on pages for which the caches are cold.


## Why did you take this approach?
Timing statistics for `Mercator.depths` with `pint.UnitRegistry()` for single dataset variables initial page load with cold caches:
Statistic | Value
-- | --
count | 61
min | 0.142
mean | 0.253
median | 0.216
std dev | 0.110
max | 0.578

and without `pint.UnitRegistry()`:
Statistic | Value
-- | --
count | 61
min | 0.00046
mean | 0.00185
median | 0.00062
std dev | 0.00376
max | 0.01604

Timing statistics for `routes.api_v1_0.tile_v1_0()` calls with `pint.UnitRegistry()` for single dataset variables initial page load with cold caches:
Statistic | Value
-- | --
count | 61
min | 0.728
mean | 1.542
median | 1.476
std dev | 0.529
max | 3.921

and without `pint.UnitRegistry()`:
Statistic | Value
-- | --
count | 61
min | 0.750
mean | 1.368
median | 1.195
std dev | 0.491
max | 2.457

## Anything in particular that should be highlighted?
The above stats were collected in a context that also includes PR #789.


## Screenshot(s)
N/A


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
