### PR TITLE
Get Sentry traces_sample_rate value from environment variable

### DIFF
--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -23,7 +23,7 @@ def create_app(testing = False):
     # Sentry DSN URL will be read from SENTRY_DSN environment variable
     sentry_sdk.init(
         integrations=[FlaskIntegration()],
-        traces_sample_rate=1.0,
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_RATE", 0)),
         environment=os.getenv("SENTRY_ENV"),
     )
     app = Flask(__name__, static_url_path='', static_folder='frontend')


### PR DESCRIPTION
## Background
We exceeded the 100k/mo transactions recorded threshold included in our Sentry subscription in 15 days after we started collecting transactions data for performance analysis.

The probability of a given transaction being sent to Sentry is set by the `traces_sample_rate` in the `sentry_sdk.init()` call; see https://docs.sentry.io/platforms/python/performance/sampling/. This PR makes it so that value is read from a new `SENTRY_TRACES_RATE` environment variable when the app starts up. If that envvar does not exist, or is empty, the value of `traces_sample_rate` will be 0; i.e. no transaction tracing from that deployment.

I propose that we `export SENTRY_TRACES_RATE=0.4` in the DAL-Prod deployment and leave `SENTRY_TRACES_RATE` unset in the DAL-Staging and NAFC deployments. We don't need transaction records from staging and NAFC - performance analysis on the public production instance will give us the information we need.

Note: this is all about API transactions, not backend Python exceptions. We will continue to get exception captures from all deployments that have `SENTRY_DSN` set.


## Why did you take this approach?
Using an environment variable lets us tune the transactions sampling rate on a per-deployment basis. A traces sampling rate of 0.4 on the production deployment should keep us under the 100k/mo threshold. That can be monitored on https://sentry.io/settings/dfo-ocean-navigator/billing/overview/

## Anything in particular that should be highlighted?
No.

## Screenshot(s)
N/A


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
