### PR TITLE
Delete unused UnitRegistry imports

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -2,7 +2,6 @@ from typing import Union
 
 import numpy as np
 import pyresample
-from pint import UnitRegistry
 
 from data.calculated import CalculatedData
 from data.model import Model

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -2,7 +2,6 @@ from typing import Union
 
 import numpy as np
 import pyresample
-from pint import UnitRegistry
 
 from data.calculated import CalculatedData
 from data.model import Model


### PR DESCRIPTION
## Background
This should have been done in PR #791, but I missed it and didn't see that LGTM had flagged it before the PR got merged :frowning_face: 


## Why did you take this approach?
Unused imports are distracting noise in the context of code comprehension.


## Anything in particular that should be highlighted?
No.


## Screenshot(s)
N/A


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
