### PR TITLE
Fix for issue #796 re: class4/models/{class4_id} API endpoint

### DIFF
--- a/data/class4.py
+++ b/data/class4.py
@@ -4,6 +4,7 @@ import glob
 import os
 import pickle as pickle
 import time
+from pathlib import Path
 from typing import List
 
 import cftime
@@ -239,17 +240,17 @@ def list_class4_models(class4_id: str) -> List[dict]:
         List of dictionaries with `id` and `value` fields.
     """
 
-    path = current_app.config["CLASS4_PATH"]
     yyyymmdd = class4_id[7:15]
     yyyy = yyyymmdd[:4]
+    path = Path(current_app.config["CLASS4_PATH"], yyyy, yyyymmdd)
 
     result = []
     # file pattern globbing != regex
-    for f in glob.iglob(f"{path}/{yyyy}/{yyyymmdd}/*_profile.nc"):
-        model = f.split("_")[2]  # e.g get FOAM from class4_20190501_FOAM_orca025_14.1_profile
+    for f in path.glob("*_profile.nc"):
+        model = f.name.split("_")[2]  # e.g get FOAM from class4_20190501_FOAM_orca025_14.1_profile.nc
         if model != "GIOPS":
             result.append({
-                'id': os.path.splitext(os.path.basename(f))[0],  # chop off .nc extension
+                'id': f.stem,  # chop off .nc extension
                 'value': model
             })
 

--- a/data/class4.py
+++ b/data/class4.py
@@ -240,14 +240,16 @@ def list_class4_models(class4_id: str) -> List[dict]:
     """
 
     path = current_app.config["CLASS4_PATH"]
+    yyyymmdd = class4_id[7:15]
+    yyyy = yyyymmdd[:4]
+
     result = []
-    
     # file pattern globbing != regex
-    for f in glob.iglob(f"{path}/{class4_id[7:15]}/*_profile.nc"):
-        model = f.split("_")[2] # e.g get FOAM from class4_20190501_FOAM_orca025_14.1_profile
+    for f in glob.iglob(f"{path}/{yyyy}/{yyyymmdd}/*_profile.nc"):
+        model = f.split("_")[2]  # e.g get FOAM from class4_20190501_FOAM_orca025_14.1_profile
         if model != "GIOPS":
             result.append({
-                'id': os.path.splitext(os.path.basename(f))[0], # chop off .nc extension
+                'id': os.path.splitext(os.path.basename(f))[0],  # chop off .nc extension
                 'value': model
             })
 

--- a/tests/test_data_class4.py
+++ b/tests/test_data_class4.py
@@ -1,0 +1,38 @@
+"""Unit tests for data.class4 module.
+"""
+import unittest
+from pathlib import Path
+
+import os
+
+import shutil
+
+import data.class4
+import oceannavigator
+
+
+app = oceannavigator.create_app(testing=True)
+
+
+class TestListClass4Models(unittest.TestCase):
+
+    def setUp(self):
+        self.test_data = Path("testdata")
+        self.class4_test_data = Path("class4/2020/20201208")
+        (self.test_data/self.class4_test_data).mkdir(parents=True)
+        test_files = (
+            "class4_20201201_FOAM_orca025_14.1_profile.nc",
+            "class4_20201201_GIOPS_CONCEPTS_3.0_profile.nc",
+        )
+        for f in test_files:
+            (self.test_data / self.class4_test_data/f).touch()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_data/self.class4_test_data.parents[1])
+
+    def test_list_class4_models(self):
+        app.config["CLASS4_PATH"] = os.fspath(self.test_data/self.class4_test_data.parents[1])
+        class4_id = "class4_20201208_GIOPS_CONCEPTS_3.0_profile_541.nc"
+        with app.app_context():
+            result = data.class4.list_class4_models(class4_id)
+        self.assertEqual(result, [{"id": "class4_20201201_FOAM_orca025_14.1_profile", "value": "FOAM"}])


### PR DESCRIPTION
## Background
re: issue #796 The `/api/v1.0/class4/models/{class4_id}` endpoint always returns an empty list, resulting in no "Additional Models" selector section in the "Class 4 Settings" panel of the overlay.

## Why did you take this approach?
This fix makes the code compatible with the `/data/class4/yyyy/yyyymmdd/` files storage scheme that is in use.

## Anything in particular that should be highlighted?
I also took the opportunity to modernize the code to use `pathlib`.


## Screenshot(s)
Broken:
![image](https://user-images.githubusercontent.com/76797/101551277-a7862a80-3965-11eb-90b2-8294f3702a1c.png)

Fixed:
![image](https://user-images.githubusercontent.com/76797/101552992-af939980-3968-11eb-9c43-f6916df446e9.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
