### PR TITLE
Fix for issue #798 re: FileNotFoundError in class4 forecasts API request

### DIFF
--- a/data/class4.py
+++ b/data/class4.py
@@ -215,10 +215,10 @@ def list_class4_forecasts(class4_id: str) -> List[dict]:
     """
     dataset_url = current_app.config["CLASS4_FNAME_PATTERN"] % (
         class4_id[7:11], class4_id.rsplit('_', maxsplit=1)[0])
-    with xr.open_dataset(dataset_url) as ds:
-        var = ds['modeljuld']
-        forecast_date = [d.strftime("%d %B %Y") for d in
-                         cftime.utime(var.units).num2date(var[:])]
+    with xr.open_dataset(dataset_url, decode_times=False) as ds:
+        forecast_date = [
+            f"{d:%d %B %Y}" for d in cftime.utime(ds.modeljuld.units).num2date(ds.modeljuld)
+        ]
 
     result = [{
         'id': 'best',

--- a/data/class4.py
+++ b/data/class4.py
@@ -202,30 +202,39 @@ def class4(class4_id, projection, resolution, extent):
     return result
 
 
-def list_class4_forecasts(class4_id):
-    # Expecting specific class4 ID format: "class4_YYYMMDD_*.nc"
+def list_class4_forecasts(class4_id: str) -> List[dict]:
+    """Get list of all forecasts for a given class4 id.
+
+    Arguments:
+
+        * `class4_id` -- {str} Class4 ID (e.g. `class4_20190501_GIOPS_CONCEPTS_2.3_profile_343`)
+
+    Returns:
+
+        List of dictionaries with `id` and `name` fields.
+    """
     dataset_url = current_app.config["CLASS4_FNAME_PATTERN"] % (
-        class4_id[7:11], class4_id)
+        class4_id[7:11], class4_id.rsplit('_', maxsplit=1)[0])
     with xr.open_dataset(dataset_url) as ds:
         var = ds['modeljuld']
         forecast_date = [d.strftime("%d %B %Y") for d in
                          cftime.utime(var.units).num2date(var[:])]
 
-    res = [{
+    result = [{
         'id': 'best',
         'name': 'Best Estimate',
     }]
 
     if len(set(forecast_date)) > 1:
         for idx, date in enumerate(forecast_date):
-            if res[-1]['name'] == date:
+            if result[-1]['name'] == date:
                 continue
-            res.append({
+            result.append({
                 'id': idx,
                 'name': date
             })
 
-    return res
+    return result
 
 
 def list_class4_models(class4_id: str) -> List[dict]:

--- a/tests/test_data_class4.py
+++ b/tests/test_data_class4.py
@@ -1,11 +1,12 @@
 """Unit tests for data.class4 module.
 """
 import unittest
-from pathlib import Path
-
 import os
-
+from pathlib import Path
 import shutil
+
+import numpy
+import xarray
 
 import data.class4
 import oceannavigator
@@ -43,15 +44,22 @@ class TestListClass4Forecasts(unittest.TestCase):
     def setUp(self):
         self.test_data = Path("testdata")
         self.class4_test_data = Path("class4/2020/")
-        (self.test_data/self.class4_test_data).mkdir(parents=True)
-        (self.test_data / self.class4_test_data / "class4_20201209_GIOPS_CONCEPTS_3.0_profile.nc").touch()
+        (self.test_data/self.class4_test_data).mkdir(parents=True, exist_ok=True)
+        modeljuld = xarray.DataArray(
+            numpy.array([25915.5]*10),
+            attrs={"units": "Days since 1950-01-01 00:00:00 utc"}
+        )
+        xarray.Dataset({"modeljuld": modeljuld}).to_netcdf(
+            self.test_data / self.class4_test_data / "class4_20201214_GIOPS_CONCEPTS_3.0_profile.nc",
+        )
+
 
     def tearDown(self):
         shutil.rmtree(self.test_data/self.class4_test_data.parents[1])
 
-    def test_list_class4_forecasts(self):
+    def test_list_class4_forecasts_1_forecast_date(self):
         app.config["CLASS4_FNAME_PATTERN"] = f"{self.test_data/self.class4_test_data.parents[0]}/%s/%s.nc"
-        class4_id = "class4_20201209_GIOPS_CONCEPTS_3.0_profile_541"
+        class4_id = "class4_20201214_GIOPS_CONCEPTS_3.0_profile_541"
         with app.app_context():
             result = data.class4.list_class4_forecasts(class4_id)
         self.assertEqual(result, [{"id": "best", "name": "Best Estimate"}])

--- a/tests/test_data_class4.py
+++ b/tests/test_data_class4.py
@@ -44,14 +44,14 @@ class TestListClass4Forecasts(unittest.TestCase):
         self.test_data = Path("testdata")
         self.class4_test_data = Path("class4/2020/")
         (self.test_data/self.class4_test_data).mkdir(parents=True)
-        (self.test_data / self.class4_test_data / "class4_20201208_GIOPS_CONCEPTS_3.0_profile.nc").touch()
+        (self.test_data / self.class4_test_data / "class4_20201209_GIOPS_CONCEPTS_3.0_profile.nc").touch()
 
     def tearDown(self):
         shutil.rmtree(self.test_data/self.class4_test_data.parents[1])
 
     def test_list_class4_forecasts(self):
         app.config["CLASS4_FNAME_PATTERN"] = f"{self.test_data/self.class4_test_data.parents[0]}/%s/%s.nc"
-        class4_id = "class4_20201208_GIOPS_CONCEPTS_3.0_profile_541"
+        class4_id = "class4_20201209_GIOPS_CONCEPTS_3.0_profile_541"
         with app.app_context():
-            with self.assertRaises(FileNotFoundError):
-                res = data.class4.list_class4_forecasts(class4_id)
+            result = data.class4.list_class4_forecasts(class4_id)
+        self.assertEqual(result, [{"id": "best", "name": "Best Estimate"}])

--- a/tests/test_data_class4.py
+++ b/tests/test_data_class4.py
@@ -21,8 +21,8 @@ class TestListClass4Models(unittest.TestCase):
         self.class4_test_data = Path("class4/2020/20201208")
         (self.test_data/self.class4_test_data).mkdir(parents=True)
         test_files = (
-            "class4_20201201_FOAM_orca025_14.1_profile.nc",
-            "class4_20201201_GIOPS_CONCEPTS_3.0_profile.nc",
+            "class4_20201208_FOAM_orca025_14.1_profile.nc",
+            "class4_20201208_GIOPS_CONCEPTS_3.0_profile.nc",
         )
         for f in test_files:
             (self.test_data / self.class4_test_data/f).touch()
@@ -32,7 +32,26 @@ class TestListClass4Models(unittest.TestCase):
 
     def test_list_class4_models(self):
         app.config["CLASS4_PATH"] = os.fspath(self.test_data/self.class4_test_data.parents[1])
-        class4_id = "class4_20201208_GIOPS_CONCEPTS_3.0_profile_541.nc"
+        class4_id = "class4_20201208_GIOPS_CONCEPTS_3.0_profile_541"
         with app.app_context():
             result = data.class4.list_class4_models(class4_id)
-        self.assertEqual(result, [{"id": "class4_20201201_FOAM_orca025_14.1_profile", "value": "FOAM"}])
+        self.assertEqual(result, [{"id": "class4_20201208_FOAM_orca025_14.1_profile", "value": "FOAM"}])
+
+
+class TestListClass4Forecasts(unittest.TestCase):
+
+    def setUp(self):
+        self.test_data = Path("testdata")
+        self.class4_test_data = Path("class4/2020/")
+        (self.test_data/self.class4_test_data).mkdir(parents=True)
+        (self.test_data / self.class4_test_data / "class4_20201208_GIOPS_CONCEPTS_3.0_profile.nc").touch()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_data/self.class4_test_data.parents[1])
+
+    def test_list_class4_forecasts(self):
+        app.config["CLASS4_FNAME_PATTERN"] = f"{self.test_data/self.class4_test_data.parents[0]}/%s/%s.nc"
+        class4_id = "class4_20201208_GIOPS_CONCEPTS_3.0_profile_541"
+        with app.app_context():
+            with self.assertRaises(FileNotFoundError):
+                res = data.class4.list_class4_forecasts(class4_id)


### PR DESCRIPTION
## Background
re: GitHub issue #798 and Sentry issue # PUBLIC-PROD-4

The class4 id in the API request ends with an index number that `data.class4.list_class4.forecasts()` is not expecting. Fixed that parsing by stripping of the index number. That revealed an [AttributeError issue](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/798#issuecomment-742164788) a few lines later. It was resolved by adding `decode_times=False` to xarray.open_dataset(), consistent with how we open datasets in `netcdf_data.NetCDFData.__enter__()` because the netCDF times are decoded in our code.


## Why did you take this approach?
Only way to make the code work.


## Anything in particular that should be highlighted?
Added unit test for part of `data.list_class4_models()` functionality.

The that generates the list of forecast dates for the frontend to use can't possibly add anything to the `result` list because the values in the `modeljuld` variable in the class 4 dataset are all always the observation date. The `leadtime` variable needs to be incorporated into the calculation. But that is all beyond the scope of the issue that this PR is addressing.

## Screenshot(s)
N/A


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
