### PR TITLE
zarr unittest issue fix

### DIFF
--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -295,7 +295,7 @@ class TestNetCDFData(unittest.TestCase):
             self.assertEqual(variables[0].valid_max, 373.0)
     
     def test_zarr_xarray_variables(self):
-        with NetCDFData("testdata/giops_test.zarr") as nc_data:
+        with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
             variables = nc_data.variables
 
             self.assertEqual(variables[0].key, "votemper")
@@ -308,7 +308,7 @@ class TestNetCDFData(unittest.TestCase):
             self.assertEqual(variables[0].valid_max, 373.0)
     
     def test_zarr_xarray_dimensions(self):
-        with NetCDFData("testdata/giops_test.zarr") as nc_data:
+        with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
             dimensions = nc_data.dimensions
             self.assertEqual(dimensions, ['depth', 'latitude', 'longitude', 'time'])
 


### PR DESCRIPTION
## Background
To fix the Zarr unit test issue: https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/801

## Why did you take this approach?
Previous test Zarr file path was wrong, changed it to the correct path.

## Anything in particular that should be highlighted?
N/A

## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
