### PR TITLE
Update class4 index pickle generator script

### DIFF
--- a/data/class4.py
+++ b/data/class4.py
@@ -1,6 +1,4 @@
-import datetime
 import fcntl
-import glob
 import os
 import pickle as pickle
 import time
@@ -15,25 +13,7 @@ from flask import current_app
 from shapely.geometry import Point
 from shapely.geometry.polygon import LinearRing
 
-
-def __list_class4_files_slowly():
-    class4_path = current_app.config['CLASS4_PATH']
-    files = []
-    result = []
-
-    for f in glob.iglob(f"{class4_path}/**/*.nc", recursive=True):
-        if f.endswith('profile.nc') and ('GIOPS' in f):
-            files.append(os.path.splitext(os.path.basename(f))[0])
-
-    for names in files:
-        value = names
-        date = datetime.datetime.strptime(value.split("_")[1], "%Y%m%d")
-        result.append({
-            'name': date.strftime("%Y-%m-%d"),
-            'id': value
-        })
-
-    return result
+from scripts import generate_class4_list
 
 
 def list_class4_files():
@@ -54,7 +34,7 @@ def list_class4_files():
                Class 4 files on the fly.
                """
         print(msg)
-        return __list_class4_files_slowly()
+        return _list_class4_files_slowly()
 
     # We need to read from the cache file. To ensure another process is not
     # currently *writing* to the cache file, first acquire a shared lock (i.e.,
@@ -86,10 +66,15 @@ def list_class4_files():
                Class 4 files on the fly.
                """
         print(msg)
-        result = __list_class4_files_slowly()
+        result = _list_class4_files_slowly()
     fp.close()
 
     return result
+
+
+def _list_class4_files_slowly():
+    class4_path = current_app.config['CLASS4_PATH']
+    return generate_class4_list.list_class4_files(class4_path)
 
 
 def list_class4(d):

--- a/data/class4.py
+++ b/data/class4.py
@@ -40,8 +40,8 @@ def list_class4_files():
     # currently *writing* to the cache file, first acquire a shared lock (i.e.,
     # a read lock) on the file. We make at most "max_tries" attempts to acquire
     # the lock.
-    max_tries = 10
-    num_tries = 0
+    num_tries, max_tries = 0, 10
+    attempt_lock, lock_acquired = True, False
     attempt_lock = True
     while attempt_lock:
         try:

--- a/scripts/generate_class4_list.py
+++ b/scripts/generate_class4_list.py
@@ -72,9 +72,8 @@ def main():
     log.info('Obtaining exclusive lock on output file %s ...',
              output_file_name)
     # Make at most "max_tries" attempts to acquire the lock.
-    max_tries = 10
-    num_tries = 0
-    attempt_lock = True
+    num_tries, max_tries = 0, 10
+    attempt_lock, lock_acquired = True, False
     while attempt_lock:
         try:
             fcntl.lockf(output_file, fcntl.LOCK_EX)

--- a/scripts/generate_class4_list.py
+++ b/scripts/generate_class4_list.py
@@ -93,11 +93,7 @@ def main():
         sys.exit(1)
 
     log.info('Writing list of Class4 files to output file ...')
-    try:
-        pickle.dump(class4_files, output_file)
-    except Exception:
-        log.error('Unable to dump to output file %s', output_file_name)
-        sys.exit(1)
+    pickle.dump(class4_files, output_file)
 
     log.info('Releasing lock on output file ...')
     try:

--- a/scripts/generate_class4_list.py
+++ b/scripts/generate_class4_list.py
@@ -45,8 +45,7 @@ def main():
     config = {}
     log.info(f"Attempting to load Ocean Navigator configuration from file {opts.config_file.name}...")
     try:
-        exec(compile(opts.config_file.read(), opts.config_file.name, 'exec'),
-             config)
+        exec(compile(opts.config_file.read(), opts.config_file.name, 'exec'), config)
     except IOError:
         log.error(f"Error: Unable to load configuration file {opts.config_file.name}.")
         sys.exit(1)
@@ -66,11 +65,10 @@ def main():
     try:
         output_file = open(output_file_name, 'wb')
     except IOError:
-        log.error('Unable to open output file %s', output_file_name)
+        log.error(f"Unable to open output file {output_file_name}")
         sys.exit(1)
 
-    log.info('Obtaining exclusive lock on output file %s ...',
-             output_file_name)
+    log.info(f"Obtaining exclusive lock on output file {output_file_name }...")
     # Make at most "max_tries" attempts to acquire the lock.
     num_tries, max_tries = 0, 10
     attempt_lock, lock_acquired = True, False
@@ -89,7 +87,7 @@ def main():
             attempt_lock = False
 
     if not lock_acquired:
-        log.error('Unable to acquire lock on output file %s', output_file_name)
+        log.error(f"Unable to acquire lock on output file {output_file_name}")
         sys.exit(1)
 
     log.info('Writing list of Class4 files to output file ...')
@@ -99,7 +97,7 @@ def main():
     try:
         fcntl.lockf(output_file, fcntl.LOCK_UN)
     except IOError:
-        log.error('Unable to release lock on output file %s', output_file_name)
+        log.error(f"Unable to release lock on output file {output_file_name}")
         sys.exit(1)
     finally:
         output_file.close()

--- a/scripts/generate_class4_list.py
+++ b/scripts/generate_class4_list.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Generate a list of Class 4 files and save it to a cache file.
 

--- a/scripts/generate_class4_list.py
+++ b/scripts/generate_class4_list.py
@@ -1,12 +1,9 @@
 """
-Generate a list of Class 4 files and save it to a cache file.
+Generate an index of Class 4 files and save it as a Python pickle cache file.
 
-Author: Clyde Clements
-Created: 2017-10-02
-
-This script generates the list of Class 4 files by crawling the THREDDS URL of
-the associated catalog. It is intended to be run from a cron job and its output
-cache file used from within the Ocean Navigator code.
+This script generates an index of Class 4 files by globbing the Class 4 storage tree
+in search of GIOPS Class 4 profile files. It is intended to be run from a cron job
+and its output cache file used from within the Ocean Navigator code.
 """
 
 import argparse


### PR DESCRIPTION
## Background
Issue #757 and issue #785 are both a result of the the `scripts/generate_class4_list.py` script being old and out of sync with the way Class 4 files are now stored in data `/data/class4/` directory tree. This PR fixes that script, and modernizes its code and some related code in `data/class4.py`.

## Why did you take this approach?
Class 4 indexing needed to be fixed, and modernizing old code is a good thing to do.


## Anything in particular that should be highlighted?
This PR includes sorting of the Class 4 files going into the index pickle such that the Class 4 date picker in the UI will have its default date set to that of the most recent available GIOPS Class 4 profiles file instead of a random date in the index.

Class 4 files prior to 2016-01-01 appear to be stored in encrypted tarballs like `/data/class4/2015/20151231/class4_20151231_GIOPS_CONCEPTS_1.1_profile.nc.gz.enc`. If those files were unpacked it is likely that `scripts/generate_class4_list.py` would be able to index them too.


## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
