### PR TITLE
Fix UnboundLocalError netCDFData.dimensions

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -83,7 +83,7 @@ class NetCDFData(Data):
                     url = self.url if isinstance(self.url, list) else [self.url]
                     # This will raise a FutureWarning for xarray>=0.12.2.
                     # That warning should be resolvable by changing to:
-                    # fields = xarray.open_mfdataset(self.url, combine="by_coords", decode_times=decode_times)                    
+                    # fields = xarray.open_mfdataset(self.url, combine="by_coords", decode_times=decode_times)
                     fields = xarray.open_mfdataset(url, decode_times=decode_times)
                 except xarray.core.variable.MissingDimensionsError:
                     # xarray won't open FVCOM files due to dimension/coordinate/variable label
@@ -656,7 +656,7 @@ class NetCDFData(Data):
         elif url.endswith(".zarr"):
             ds = xarray.open_zarr(url)
             dimension_list = list(ds.dims)
-            
+
         # Open dataset (can't use xarray here since it doesn't like FVCOM files)
         else:
             try:
@@ -664,7 +664,7 @@ class NetCDFData(Data):
                     dimension_list = [dim for dim in ds.dimensions]
             except FileNotFoundError:
                 dimension_list = []
-        
+
         return dimension_list
 
     @property
@@ -740,7 +740,7 @@ class NetCDFData(Data):
         if url.endswith(".sqlite3"):
             with SQLiteDatabase(url) as db:
                 self._variable_list = db.get_data_variables()  # Cache the list for later
-        
+
         elif url.endswith(".zarr"):
             ds_zarr = xarray.open_zarr(url)
             var_list =[]
@@ -753,9 +753,9 @@ class NetCDFData(Data):
                 valid_max = ds_zarr.variables[var].attrs['valid_max'] if ds_zarr.variables[var].attrs['valid_max'] else None
 
                 var_list.append(Variable(name, long_name, units, list(ds_zarr[name].dims), valid_min, valid_max))
-            
+
             self._variable_list = var_list
-            
+
         else:
             try:
                 # Handle possible list of URLs for staggered grid velocity field datasets
@@ -765,13 +765,13 @@ class NetCDFData(Data):
                 # with xarray.open_mfdataset(url, combine="by_coords", decode_times=False) as ds:
                 with xarray.open_mfdataset(url, decode_times=False) as ds:
                     self._variable_list = self._get_xarray_data_variables(ds)  # Cache the list for later
-                
+
             except xarray.core.variable.MissingDimensionsError:
                 # xarray won't open FVCOM files due to dimension/coordinate/variable label
                 # duplication issue, so fall back to using netCDF4.Dataset()
                 with netCDF4.Dataset(self.url) as ds:
                     self._variable_list = self._get_netcdf4_data_variables(ds)  # Cache the list for later
-        
+
         return self._variable_list
 
     @staticmethod

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -651,8 +651,8 @@ class NetCDFData(Data):
                 with SQLiteDatabase(url) as db:
                     dimension_list = db.get_all_dimensions()
             except sqlite3.OperationalError:
-                pass
-        
+                dimension_list = []
+
         elif url.endswith(".zarr"):
             ds = xarray.open_zarr(url)
             dimension_list = list(ds.dims)

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -34,7 +34,7 @@ class NetCDFData(Data):
        Injected as attribute into Model classes like Nemo, Mercator, Fvcom.
     """
 
-    def __init__(self, url: str, **kwargs: Dict) -> None:
+    def __init__(self, url: Union[str, list], **kwargs: Dict) -> None:
         super().__init__(url)
         self.meta_only: bool = kwargs.get('meta_only', False)
         self.dataset: Union[xarray.Dataset, netCDF4.Dataset] = None

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -293,7 +293,11 @@ class TestNetCDFData(unittest.TestCase):
             )
             self.assertEqual(variables[0].valid_min, 173.0)
             self.assertEqual(variables[0].valid_max, 373.0)
-    
+
+    def test_xarray_dimensions(self):
+        nc_data = NetCDFData("tests/testdata/mercator_test.nc")
+        self.assertEqual(['time', 'depth', 'latitude', 'longitude'], nc_data.dimensions)
+
     def test_zarr_xarray_variables(self):
         with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
             variables = nc_data.variables
@@ -308,9 +312,8 @@ class TestNetCDFData(unittest.TestCase):
             self.assertEqual(variables[0].valid_max, 373.0)
     
     def test_zarr_xarray_dimensions(self):
-        with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
-            dimensions = nc_data.dimensions
-            self.assertEqual(dimensions, ['depth', 'latitude', 'longitude', 'time'])
+        nc_data = NetCDFData("tests/testdata/giops_test.zarr")
+        self.assertEqual(['depth', 'latitude', 'longitude', 'time'], nc_data.dimensions)
 
     def test_fvcom_variables(self):
         with NetCDFData("tests/testdata/fvcom_test.nc") as nc_data:
@@ -324,6 +327,18 @@ class TestNetCDFData(unittest.TestCase):
             )
             self.assertIsNone(variables[3].valid_min)
             self.assertIsNone(variables[3].valid_max)
+
+    def test_fvcom_dimensions(self):
+        nc_data = NetCDFData("tests/testdata/fvcom_test.nc")
+        self.assertEqual(["time", "maxStrlen64", "node", "siglay"], nc_data.dimensions)
+
+    def test_fvcom_dimensions_file_not_found(self):
+        nc_data = NetCDFData("tests/testdata/not_fvcom_test.nc")
+        self.assertEqual([], nc_data.dimensions)
+
+    def test_sqlite3_dimensions(self):
+        nc_data = NetCDFData("tests/testdata/databases/Historical.sqlite3")
+        self.assertEqual(['y', 'x', 'time_counter', 'axis_nbounds', 'depthv'], nc_data.dimensions)
 
     def test_variable_list_cached(self):
         with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -340,6 +340,10 @@ class TestNetCDFData(unittest.TestCase):
         nc_data = NetCDFData("tests/testdata/databases/Historical.sqlite3")
         self.assertEqual(['y', 'x', 'time_counter', 'axis_nbounds', 'depthv'], nc_data.dimensions)
 
+    def test_dimensions_url_list(self):
+        nc_data = NetCDFData(["tests/testdata/nemo_test.nc", "tests/testdata/nemo_grid_angle.nc"])
+        self.assertEqual(['deptht', 'time_counter', 'x', 'y'], nc_data.dimensions)
+
     def test_variable_list_cached(self):
         with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:
             self.assertIsNone(nc_data._variable_list)

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -20,12 +20,12 @@ class TestNetCDFData(unittest.TestCase):
     def setUp(self):
         with open('tests/testdata/datasetconfigpatch.json') as dataPatch:
             self.patch_dataset_config_ret_val = json.load(dataPatch)
-        
+
         ds = xarray.Dataset({
             "votemper": xarray.DataArray(
-                            data   = numpy.random.rand(4,4,4,4),   
+                            data   = numpy.random.rand(4,4,4,4),
                             dims   = ['depth', 'latitude', 'longitude', 'time'],
-                
+
                             coords = { "depth": (["depth"], [4.94025e-01, 1.54138e+00, 2.64567e+00, 3.81949e+00]),
                                     "latitude": (["latitude"], [-80. , -79.8, 89.6,  89.8]),
                                     "longitude": (["longitude"], [2.000e-01, 4.000e-01, 3.594e+02, 3.598e+02]),
@@ -40,10 +40,10 @@ class TestNetCDFData(unittest.TestCase):
                             ),
                     }
         )
-    
+
         if not (os.path.exists("tests/testdata/giops_test.zarr")):
             ds.to_zarr("tests/testdata/giops_test.zarr")
-    
+
     def tearDown(self):
         if (os.path.exists("tests/testdata/giops_test.zarr")):
             shutil.rmtree("tests/testdata/giops_test.zarr")
@@ -310,7 +310,7 @@ class TestNetCDFData(unittest.TestCase):
             )
             self.assertEqual(variables[0].valid_min, 173.0)
             self.assertEqual(variables[0].valid_max, 373.0)
-    
+
     def test_zarr_xarray_dimensions(self):
         nc_data = NetCDFData("tests/testdata/giops_test.zarr")
         self.assertEqual(['depth', 'latitude', 'longitude', 'time'], nc_data.dimensions)

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -340,6 +340,10 @@ class TestNetCDFData(unittest.TestCase):
         nc_data = NetCDFData("tests/testdata/databases/Historical.sqlite3")
         self.assertEqual(['y', 'x', 'time_counter', 'axis_nbounds', 'depthv'], nc_data.dimensions)
 
+    def test_sqlite3_dimensions_operational_error(self):
+        nc_data = NetCDFData("tests/testdata/databases/not_Historical.sqlite3")
+        self.assertEqual([], nc_data.dimensions)
+
     def test_dimensions_url_list(self):
         nc_data = NetCDFData(["tests/testdata/nemo_test.nc", "tests/testdata/nemo_grid_angle.nc"])
         self.assertEqual(['deptht', 'time_counter', 'x', 'y'], nc_data.dimensions)


### PR DESCRIPTION
## Background
Investigation of https://sentry.io/organizations/dfo-ocean-navigator/issues/2134767923 lead to the realization that a `sqlite3.OperationalError` was being masked by an `UnboundLocalError` in `NetCDFData.dimensions`. This PR increases unit test coverage for `dimensions`, and make its result of an empty list consistent for the cases of `OperationsError` and `FileNotFoundError`.


## Why did you take this approach?
`UnboundLocalError` is a really bad code-smell. At least we now have a consistent outcome when there is a problem accessing sqlite3 and netCDF4 datasets.


## Anything in particular that should be highlighted?
The `OperationalError` is likely and indication of a deeper file system or container issue that is causing problems with access to the sqlite3 databases.

It is weird that `dimensions` is opening datasets at all. That should be the exclusive job of `NetCDFData.__enter__()`. We're stuck with the present implementation because `data.open_dataset()` accesses `dimensions` before the `NetCDFData` constructor is called do that it can sniff out which flavour of model dataset to create; see issue #664.

## Screenshot(s)
N/A

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
