### PR TITLE
Nuke stats tab

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -711,7 +711,6 @@ export default class AreaWindow extends React.Component {
           onSelect={this.onTabChange}
         >
           <NavItem eventKey={1}>{_("Map")}</NavItem>
-          <NavItem eventKey={2}>{_("Statistics")}</NavItem>
         </Nav>
         <Row>
           <Col lg={2}>


### PR DESCRIPTION
## Background

Statistics functionality has been broken on the back end for a very long time, with not timeline on it being fixed. Let's just remove the ability for users to request it to reduce confusion.

## Why did you take this approach?

It's the only way

## Anything in particular that should be highlighted?
Nope

## Screenshot(s)
Tab is gone:
![image](https://user-images.githubusercontent.com/5572045/106405911-3ff2d580-6412-11eb-92ab-c349b013542b.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
