### PR TITLE
Cast Class 4 ID to S8 when reading from file

### DIFF
--- a/data/class4.py
+++ b/data/class4.py
@@ -139,7 +139,7 @@ def class4(class4_id, projection, resolution, extent):
     with xr.open_dataset(dataset_url) as ds:
         lat_in = ds['latitude'][:]
         lon_in = ds['longitude'][:]
-        ids = np.char.decode(ds['id'][:].values, 'UTF-8')
+        ids = np.char.decode(ds['id'].astype('|S8').values, 'UTF-8')
         for i in range(0, lat_in.shape[0]):
             x, y = proj(lon_in[i], lat_in[i])
             p = Point(y, x)


### PR DESCRIPTION
## Background
While checking Greg's class 4 file, I needed to add this cast in order for it to be read, since the files present on Dory have this encoding and his were just a byte array.

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
