### PR TITLE
Issue/784 816 fixing the start date for vm

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -32,12 +32,9 @@ def open_dataset(dataset, **kwargs):
             starttime (and endtime) do not exactly correspond to a timestamp integer
             in the dataset, and will perform a binary search to find the nearest timestamp
             that is less-than-or-equal-to the given starttime (and endtime).
+        * meta_only {bool} -- Skip some dataset access operations in order to speed up
+            response.
     """
-    MODEL_CLASSES = {
-        "mercator": Mercator,
-        "nemo": Nemo,
-        "fvcom": Fvcom,
-    }
 
     if not dataset:
         raise ValueError("Unknown dataset.")
@@ -52,19 +49,25 @@ def open_dataset(dataset, **kwargs):
     if url is None:
         raise ValueError("Dataset url is None.")
 
-    try:
-        model_class = MODEL_CLASSES[getattr(dataset, "model_class", "").lower()]
-    except (AttributeError, KeyError):
-        raise ValueError(f"Missing or unrecongized model_class attribute in config for dataset {dataset}")
+    args = {
+        "calculated": calculated_vars,
+        "meta_only": kwargs.get("meta_only", False),
+        "grid_angle_file_url": getattr(dataset, "grid_angle_file_url", ""),
+        "bathymetry_file_url": getattr(dataset, "bathymetry_file_url", ""),
+        "dataset_key": getattr(dataset, "key", ""),
+    }
 
-    kwargs.update(
-        {
-            "calculated": calculated_vars,
-            "grid_angle_file_url": getattr(dataset, "grid_angle_file_url", ""),
-            "bathymetry_file_url": getattr(dataset, "bathymetry_file_url", ""),
-            "dataset_key": getattr(dataset, "key", ""),
-        }
-    )
+    nc_data = CalculatedData(url, **args)
+    if not args["meta_only"]:
+        # Get required NC files from database and add to args
+        nc_data.get_nc_file_list(dataset, **kwargs)
 
-    nc_data = CalculatedData(url, **kwargs)
-    return model_class(nc_data)
+    dimension_list = nc_data.dimensions
+    if not dimension_list:
+        raise RuntimeError(f"Dataset not supported: {url}.")
+
+    if 'longitude' in dimension_list or 'latitude' in dimension_list:
+        return Mercator(nc_data)
+    if 'siglay' in dimension_list:
+        return Fvcom(nc_data)
+    return Nemo(nc_data)

--- a/data/mercator.py
+++ b/data/mercator.py
@@ -18,13 +18,15 @@ class Mercator(Model):
         self.latvar = None
         self.lonvar = None
         self.nc_data = nc_data
+        self._meta_only = nc_data.meta_only
         self.variables = nc_data.variables
 
     def __enter__(self):
         self.nc_data.__enter__()
 
-        if self.latvar is None:
-            self.latvar, self.lonvar = self.nc_data.latlon_variables
+        if not self._meta_only:
+            if self.latvar is None:
+                self.latvar, self.lonvar = self.nc_data.latlon_variables
 
         return self
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sqlite3
 import uuid
 import warnings
 import zipfile
@@ -35,9 +36,11 @@ class NetCDFData(Data):
 
     def __init__(self, url: Union[str, list], **kwargs: Dict) -> None:
         super().__init__(url)
+        self.meta_only: bool = kwargs.get('meta_only', False)
         self.dataset: Union[xarray.Dataset, netCDF4.Dataset] = None
         self._variable_list: VariableList = None
         self.__timestamp_cache: TTLCache = TTLCache(1, 3600)
+        self._nc_files: list = []
         self._grid_angle_file_url: str = kwargs.get('grid_angle_file_url', "")
         self._bathymetry_file_url: str = kwargs.get('bathymetry_file_url', "")
         self._time_variable: xarray.IndexVariable = None
@@ -46,68 +49,68 @@ class NetCDFData(Data):
         self._dataset_config: DatasetConfig = (
             DatasetConfig(self._dataset_key) if self._dataset_key else None
         )
-        self._nc_files: Union[List, None] = self.get_nc_file_list(self._dataset_config, **kwargs)
 
     def __enter__(self):
-        # Don't decode times since we do it anyways.
-        decode_times = False
+        if not self.meta_only:
+            # Don't decode times since we do it anyways.
+            decode_times = False
 
-        if self._nc_files:
-            try:
-                if len(self._nc_files) > 1:
-                    self.dataset = xarray.open_mfdataset(
-                        self._nc_files,
-                        decode_times=decode_times,
-                        chunks=200,
+            if self._nc_files:
+                try:
+                    if len(self._nc_files) > 1:
+                        self.dataset = xarray.open_mfdataset(
+                            self._nc_files,
+                            decode_times=decode_times,
+                            chunks=200,
+                        )
+                    else:
+                        self.dataset = xarray.open_dataset(
+                            self._nc_files[0],
+                            decode_times=decode_times,
+                        )
+                except xarray.core.variable.MissingDimensionsError:
+                    # xarray won't open FVCOM files due to dimension/coordinate/variable label
+                    # duplication issue, so fall back to using netCDF4.Dataset()
+                    self.dataset = netCDF4.MFDataset(self._nc_files)
+
+            elif (self.url.endswith(".zarr") if not isinstance(self.url, list) else False):
+                ds_zarr = xarray.open_zarr(self.url, decode_times=decode_times)
+                self.dataset = ds_zarr
+
+            else:
+                try:
+                    # Handle list of URLs for staggered grid velocity field datasets
+                    url = self.url if isinstance(self.url, list) else [self.url]
+                    # This will raise a FutureWarning for xarray>=0.12.2.
+                    # That warning should be resolvable by changing to:
+                    # fields = xarray.open_mfdataset(self.url, combine="by_coords", decode_times=decode_times)
+                    fields = xarray.open_mfdataset(url, decode_times=decode_times)
+                except xarray.core.variable.MissingDimensionsError:
+                    # xarray won't open FVCOM files due to dimension/coordinate/variable label
+                    # duplication issue, so fall back to using netCDF4.Dataset()
+                    fields = netCDF4.Dataset(self.url)
+                if getattr(self._dataset_config, "geo_ref", {}):
+                    drop_variables = self._dataset_config.geo_ref.get("drop_variables", [])
+                    geo_refs = xarray.open_dataset(
+                        self._dataset_config.geo_ref["url"], drop_variables=drop_variables,
                     )
-                else:
-                    self.dataset = xarray.open_dataset(
-                        self._nc_files[0],
-                        decode_times=decode_times,
-                    )
-            except xarray.core.variable.MissingDimensionsError:
-                # xarray won't open FVCOM files due to dimension/coordinate/variable label
-                # duplication issue, so fall back to using netCDF4.Dataset()
-                self.dataset = netCDF4.MFDataset(self._nc_files)
+                    fields = fields.merge(geo_refs)
+                self.dataset = fields
 
-        elif (self.url.endswith(".zarr") if not isinstance(self.url, list) else False):
-            ds_zarr = xarray.open_zarr(self.url, decode_times=decode_times)
-            self.dataset = ds_zarr
-
-        else:
-            try:
-                # Handle list of URLs for staggered grid velocity field datasets
-                url = self.url if isinstance(self.url, list) else [self.url]
-                # This will raise a FutureWarning for xarray>=0.12.2.
-                # That warning should be resolvable by changing to:
-                # fields = xarray.open_mfdataset(self.url, combine="by_coords", decode_times=decode_times)
-                fields = xarray.open_mfdataset(url, decode_times=decode_times)
-            except xarray.core.variable.MissingDimensionsError:
-                # xarray won't open FVCOM files due to dimension/coordinate/variable label
-                # duplication issue, so fall back to using netCDF4.Dataset()
-                fields = netCDF4.Dataset(self.url)
-            if getattr(self._dataset_config, "geo_ref", {}):
-                drop_variables = self._dataset_config.geo_ref.get("drop_variables", [])
-                geo_refs = xarray.open_dataset(
-                    self._dataset_config.geo_ref["url"], drop_variables=drop_variables,
+            if self._grid_angle_file_url:
+                angle_file = xarray.open_dataset(
+                    self._grid_angle_file_url,
+                    drop_variables=[self._dataset_config.lat_var_key, self._dataset_config.lon_var_key]
                 )
-                fields = fields.merge(geo_refs)
-            self.dataset = fields
+                self.dataset = self.dataset.merge(angle_file)
+                angle_file.close()
 
-        if self._grid_angle_file_url:
-            angle_file = xarray.open_dataset(
-                self._grid_angle_file_url,
-                drop_variables=[self._dataset_config.lat_var_key, self._dataset_config.lon_var_key]
-            )
-            self.dataset = self.dataset.merge(angle_file)
-            angle_file.close()
+            if self._bathymetry_file_url:
+                bathy_file = xarray.open_dataset(self._bathymetry_file_url)
+                self.dataset = self.dataset.merge(bathy_file)
+                bathy_file.close()
 
-        if self._bathymetry_file_url:
-            bathy_file = xarray.open_dataset(self._bathymetry_file_url)
-            self.dataset = self.dataset.merge(bathy_file)
-            bathy_file.close()
-
-        self._dataset_open = True
+            self._dataset_open = True
 
         return self
 
@@ -638,11 +641,31 @@ class NetCDFData(Data):
 
     @property
     def dimensions(self) -> List[str]:
-        try:
-            return list(self.dataset.dims)
-        except AttributeError:
-            # FVCOM datasets are netCDF4.Dataset instances that use a dimensions property
-            return [dim for dim in self.dataset.dimensions]
+        """Return a list of the dimensions in the dataset.
+        """
+        # Handle possible list of URLs for staggered grid velocity field datasets
+        url = self.url if not isinstance(self.url, list) else self.url[0]
+
+        if url.endswith(".sqlite3"):
+            try:
+                with SQLiteDatabase(url) as db:
+                    dimension_list = db.get_all_dimensions()
+            except sqlite3.OperationalError:
+                dimension_list = []
+
+        elif url.endswith(".zarr"):
+            ds = xarray.open_zarr(url)
+            dimension_list = list(ds.dims)
+
+        # Open dataset (can't use xarray here since it doesn't like FVCOM files)
+        else:
+            try:
+                with netCDF4.Dataset(url) as ds:
+                    dimension_list = [dim for dim in ds.dimensions]
+            except FileNotFoundError:
+                dimension_list = []
+
+        return dimension_list
 
     @property
     def depth_dimensions(self) -> List[str]:
@@ -822,19 +845,28 @@ class NetCDFData(Data):
             # Probably a file path dataset config for which this method is also not applicable
             return
 
-        try:
-            variables = kwargs['variable']
-        except KeyError:
-            variables = datasetconfig.variables[0]
-        variables = {variables} if isinstance(variables, str) else set(variables)
-        calculated_variables = datasetconfig.calculated_variables
         with SQLiteDatabase(self.url) as db:
-            variables_to_load = self.__get_variables_to_load(db, variables, calculated_variables)
 
-            timestamp = self.__get_requested_timestamps(
-                db, variables_to_load[0], kwargs.get('timestamp', -1),
-                kwargs.get('endtime'), kwargs.get('nearest_timestamp', False)
-            )
+            try:
+                variable = kwargs['variable']
+            except KeyError:
+                raise RuntimeError(
+                    "Opening a dataset via sqlite requires the 'variable' keyword argument.")
+            if isinstance(variable, str):
+                variable = { variable }
+            else:
+                if not isinstance(variable, set):
+                    variable = set(variable)
+
+            calculated_variables = datasetconfig.calculated_variables
+            variables_to_load = self.__get_variables_to_load(db, variable, calculated_variables)
+
+            try:
+                timestamp = self.__get_requested_timestamps(
+                    db, variables_to_load[0], kwargs['timestamp'], kwargs.get('endtime'), kwargs.get('nearest_timestamp', False))
+            except KeyError:
+                raise RuntimeError(
+                    "Opening a dataset via sqlite requires the 'timestamp' keyword argument.")
 
             if not timestamp:
                 raise RuntimeError("Error finding timestamp(s) in database.")
@@ -843,7 +875,7 @@ class NetCDFData(Data):
             if not file_list:
                 raise RuntimeError("NetCDF file list is empty.")
 
-            return file_list
+            self._nc_files = file_list
 
     def __get_variables_to_load(self, db: SQLiteDatabase, variable: set,
                                     calculated_variables: dict) -> List[str]:

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -105,10 +105,6 @@ class DatasetConfig:
         return self._get_attribute("bathymetry_file_url")
 
     @property
-    def model_class(self) -> str:
-        return self._get_attribute("model_class")
-
-    @property
     def lat_var_key(self) -> str:
         return self._get_attribute("lat_var_key")
 

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -123,6 +123,15 @@ export default class OceanNavigator extends React.Component {
     this.updateScale = this.updateScale.bind(this);
     this.get_variables_promise = this.get_variables_promise.bind(this);
     this.get_timestamp_promise = this.get_timestamp_promise.bind(this);
+    // Setting the starttime and time variable default value
+    const time_promise = this.get_timestamp_promise("giops_day", "votemper");
+      $.when(time_promise).done(function(time) {
+        let newTime = time[time.length-1].id;
+        let newStarttime = time[0].id;
+        this.state.time = newTime;
+        this.state.starttime = newStarttime;
+        this.setState(state);
+      }.bind(this));
   }
   
   //Updates the page language upon user request
@@ -272,16 +281,18 @@ export default class OceanNavigator extends React.Component {
 
 
       let newTime = 0;
+      let newStarttime = 0;
       const time_promise = this.get_timestamp_promise(dataset, newVariable);
       $.when(time_promise).done(function(time) {
         newTime = time[time.length-1].id;
-
+        newStarttime = time[0].id;
         if (state === undefined) {
           state = {};
         }
         state.dataset = dataset;
         state.variable = newVariable;
         state.time = newTime;
+        state.starttime = newStarttime;
         state.busy = false;
 
         this.setState(state);

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -285,7 +285,11 @@ export default class OceanNavigator extends React.Component {
       const time_promise = this.get_timestamp_promise(dataset, newVariable);
       $.when(time_promise).done(function(time) {
         newTime = time[time.length-1].id;
-        newStarttime = time[0].id;
+        // check the length of the timestamp array and set the start time according to that
+        if (time.length > 24)
+          newStarttime = time[time.length-25].id;
+        else
+          newStarttime = time[0].id;
         if (state === undefined) {
           state = {};
         }

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -128,9 +128,7 @@ export default class OceanNavigator extends React.Component {
       $.when(time_promise).done(function(time) {
         let newTime = time[time.length-1].id;
         let newStarttime = time[0].id;
-        this.state.time = newTime;
-        this.state.starttime = newStarttime;
-        this.setState(state);
+        this.setState({time:newTime,starttime:newStarttime});
       }.bind(this));
   }
   

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -44,7 +44,8 @@ export default class PointWindow extends React.Component {
       depth: props.depth,
       showmap: false,
       colormap: "default",
-      starttime: Math.max(props.time - 24, 0),
+      //starttime: Math.max(props.time - 24, 0),
+      starttime: props.starttime,
       variables: [],
       variable: [props.variable],
       observation_variable: [0],
@@ -52,6 +53,8 @@ export default class PointWindow extends React.Component {
       dpi: 144,
       plotTitles: Array(7).fill(""),
     };
+    //console.log("State [Starttime] "+this.state.starttime);
+    //console.log("Props [Time] "+ props.starttime);
 
     if (props.init !== null) {
       $.extend(this.state, props.init);

--- a/tests/test_data_open_dataset.py
+++ b/tests/test_data_open_dataset.py
@@ -24,25 +24,23 @@ class TestOpenDataset(unittest.TestCase):
         with self.assertRaises(ValueError):
             open_dataset(config)
 
+    @patch.object(data.calculated, "CalculatedData")
+    def test_open_dataset_bad_dim_list_raises(self, patch_calculated_data):
+        with self.assertRaises(RuntimeError):
+            open_dataset("tests/testdata/does_not_exist.nc", meta_only=True)
+
     @patch.object(DatasetConfig, "_get_dataset_config")
-    def test_open_dataset_no_model_class_raises(self, patch_get_dataset_config):
+    @patch.object(data.calculated, "CalculatedData")
+    def test_open_dataset_meta_only_returns_mercator_object(
+        self, patch_calculated_data, patch_get_dataset_config
+    ):
         patch_get_dataset_config.return_value = {
             "giops": {"url": "tests/testdata/mercator_test.nc", "variables": {}}
         }
         config = DatasetConfig("giops")
 
-        with self.assertRaises(ValueError):
-            open_dataset(config)
-
-    @patch.object(DatasetConfig, "_get_dataset_config")
-    def test_open_dataset_bad_model_class_raises(self, patch_get_dataset_config):
-        patch_get_dataset_config.return_value = {
-            "giops": {"url": "tests/testdata/mercator_test.nc", "model_class": "Foo", "variables": {}}
-        }
-        config = DatasetConfig("giops")
-
-        with self.assertRaises(ValueError):
-            open_dataset(config)
+        with open_dataset(config, meta_only=True) as ds:
+            self.assertTrue(isinstance(ds, Mercator))
 
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch.object(data.calculated, "CalculatedData")
@@ -50,7 +48,7 @@ class TestOpenDataset(unittest.TestCase):
         self, patch_calculated_data, patch_get_dataset_config
     ):
         patch_get_dataset_config.return_value = {
-            "giops": {"url": "tests/testdata/mercator_test.nc", "model_class": "Mercator", "variables": {}}
+            "giops": {"url": "tests/testdata/mercator_test.nc", "variables": {}}
         }
         config = DatasetConfig("giops")
 
@@ -59,11 +57,24 @@ class TestOpenDataset(unittest.TestCase):
 
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch.object(data.calculated, "CalculatedData")
+    def test_open_dataset_meta_only_returns_nemo_object(
+        self, patch_calculated_data, patch_get_dataset_config
+    ):
+        patch_get_dataset_config.return_value = {
+            "giops": {"url": "tests/testdata/nemo_test.nc", "variables": {}}
+        }
+        config = DatasetConfig("giops")
+
+        with open_dataset(config, meta_only=True) as ds:
+            self.assertTrue(isinstance(ds, Nemo))
+
+    @patch.object(DatasetConfig, "_get_dataset_config")
+    @patch.object(data.calculated, "CalculatedData")
     def test_open_dataset_returns_nemo_object(
         self, patch_calculated_data, patch_get_dataset_config
     ):
         patch_get_dataset_config.return_value = {
-            "giops": {"url": "tests/testdata/nemo_test.nc", "model_class": "Nemo", "variables": {}}
+            "giops": {"url": "tests/testdata/nemo_test.nc", "variables": {}}
         }
         config = DatasetConfig("giops")
 
@@ -72,11 +83,24 @@ class TestOpenDataset(unittest.TestCase):
 
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch.object(data.calculated, "CalculatedData")
+    def test_open_dataset_meta_only_returns_fvcom_object(
+        self, patch_calculated_data, patch_get_dataset_config
+    ):
+        patch_get_dataset_config.return_value = {
+            "giops": {"url": "tests/testdata/fvcom_test.nc", "variables": {}}
+        }
+        config = DatasetConfig("giops")
+
+        with open_dataset(config, meta_only=True) as ds:
+            self.assertTrue(isinstance(ds, Fvcom))
+
+    @patch.object(DatasetConfig, "_get_dataset_config")
+    @patch.object(data.calculated, "CalculatedData")
     def test_open_dataset_returns_fvcom_object(
         self, patch_calculated_data, patch_get_dataset_config
     ):
         patch_get_dataset_config.return_value = {
-            "giops": {"url": "tests/testdata/fvcom_test.nc", "model_class": "Fvcom", "variables": {}}
+            "giops": {"url": "tests/testdata/fvcom_test.nc", "variables": {}}
         }
         config = DatasetConfig("giops")
 
@@ -89,7 +113,7 @@ class TestOpenDataset(unittest.TestCase):
         open_dataset.cache_clear()  # clear the cache from other test runs
 
         patch_get_dataset_config.return_value = {
-            "giops": {"url": "tests/testdata/mercator_test.nc", "model_class": "Mercator", "variables": {}}
+            "giops": {"url": "tests/testdata/mercator_test.nc", "variables": {}}
         }
         config = DatasetConfig("giops")
 

--- a/tests/test_dataset_config.py
+++ b/tests/test_dataset_config.py
@@ -27,7 +27,6 @@ class TestUtil(unittest.TestCase):
                 "type": "my_type",
                 "grid_angle_file_url": "my_grid_angle_file_url",
                 "bathymetry_file_url": "my_bathy_file_url.nc",
-                "model_class": "my_model_class",
                 "time_dim_units": "my_time_units",
                 "attribution": "my_<b>attribution</b>",
                 "cache": "123",
@@ -54,7 +53,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(result.quantum, "my_quantum")
         self.assertEqual(result.grid_angle_file_url, "my_grid_angle_file_url")
         self.assertEqual(result.bathymetry_file_url, "my_bathy_file_url.nc")
-        self.assertEqual(result.model_class, "my_model_class")
         self.assertEqual(result.type, "my_type")
         self.assertEqual(result.time_dim_units, "my_time_units")
         self.assertEqual(result.lat_var_key, "my_lat")

--- a/tests/test_merc.py
+++ b/tests/test_merc.py
@@ -1,7 +1,9 @@
+import datetime
 import unittest
 from unittest.mock import patch
 
 import numpy as np
+import pytz
 
 from data.mercator import Mercator
 from data.netcdf_data import NetCDFData
@@ -23,9 +25,10 @@ class TestMercator(unittest.TestCase):
         self.assertIsNone(ds.latvar)
         self.assertIsNone(ds.lonvar)
         self.assertIs(ds.nc_data, nc_data)
+        self.assertIs(ds._meta_only, nc_data.meta_only)
         self.assertEqual(ds.variables, nc_data.variables)
 
-    def test_enter(self):
+    def test_enter_not_meta_only(self):
         nc_data = NetCDFData('tests/testdata/mercator_test.nc')
         with Mercator(nc_data) as ds:
             self.assertIsNotNone(ds.latvar)
@@ -44,6 +47,15 @@ class TestMercator(unittest.TestCase):
                 4833.29, 5274.78, 5727.92],
                 dtype=np.float32)
             np.testing.assert_array_equal(ds.depths, expected)
+
+    @patch("tests.test_merc.NetCDFData")
+    def test_no_depth_variable(self, patch_netcdfdata):
+        # This is a hack to trigger the no depth variable edge case
+        patch_netcdfdata.depth_dimensions.return_value = []
+
+        nc_data = NetCDFData('tests/testdata/mercator_test.nc')
+        with Mercator(nc_data) as ds:
+            np.testing.assert_array_equal(ds.depths, np.array([0]))
 
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
     def test_variables(self, mock_query_func):

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -54,14 +54,21 @@ class TestNetCDFData(unittest.TestCase):
         self.assertEqual(nc_data.interp, "gaussian")
         self.assertEqual(nc_data.radius, 25000)
         self.assertEqual(nc_data.neighbours, 10)
+        self.assertFalse(nc_data.meta_only)
         self.assertIsNone(nc_data.dataset)
         self.assertIsNone(nc_data._variable_list)
+        self.assertEqual(nc_data._nc_files, [])
         self.assertEqual(nc_data._grid_angle_file_url, "")
         self.assertIsNone(nc_data._time_variable)
         self.assertFalse(nc_data._dataset_open)
         self.assertEqual(nc_data._dataset_key, "")
         self.assertIsNone(nc_data._dataset_config)
-        self.assertIsNone(nc_data._nc_files)
+
+    def test_enter_meta_only(self):
+        kwargs = {"meta_only": True}
+        with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
+            self.assertFalse(nc_data._dataset_open)
+            self.assertIsNone(nc_data.dataset)
 
     def test_enter_nc_files_list(self):
         nc_data = NetCDFData("tests/testdata/nemo_test.nc")
@@ -288,8 +295,8 @@ class TestNetCDFData(unittest.TestCase):
             self.assertEqual(variables[0].valid_max, 373.0)
 
     def test_xarray_dimensions(self):
-        with NetCDFData("tests/testdata/mercator_test.nc") as nc_data:
-            self.assertEqual(['depth', 'latitude', 'longitude', 'time'], nc_data.dimensions)
+        nc_data = NetCDFData("tests/testdata/mercator_test.nc")
+        self.assertEqual(['time', 'depth', 'latitude', 'longitude'], nc_data.dimensions)
 
     def test_zarr_xarray_variables(self):
         with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
@@ -305,8 +312,8 @@ class TestNetCDFData(unittest.TestCase):
             self.assertEqual(variables[0].valid_max, 373.0)
 
     def test_zarr_xarray_dimensions(self):
-        with NetCDFData("tests/testdata/giops_test.zarr") as nc_data:
-            self.assertEqual(['depth', 'latitude', 'longitude', 'time'], nc_data.dimensions)
+        nc_data = NetCDFData("tests/testdata/giops_test.zarr")
+        self.assertEqual(['depth', 'latitude', 'longitude', 'time'], nc_data.dimensions)
 
     def test_fvcom_variables(self):
         with NetCDFData("tests/testdata/fvcom_test.nc") as nc_data:
@@ -322,8 +329,24 @@ class TestNetCDFData(unittest.TestCase):
             self.assertIsNone(variables[3].valid_max)
 
     def test_fvcom_dimensions(self):
-        with NetCDFData("tests/testdata/fvcom_test.nc") as nc_data:
-            self.assertEqual(["time", "maxStrlen64", "node", "siglay"], nc_data.dimensions)
+        nc_data = NetCDFData("tests/testdata/fvcom_test.nc")
+        self.assertEqual(["time", "maxStrlen64", "node", "siglay"], nc_data.dimensions)
+
+    def test_fvcom_dimensions_file_not_found(self):
+        nc_data = NetCDFData("tests/testdata/not_fvcom_test.nc")
+        self.assertEqual([], nc_data.dimensions)
+
+    def test_sqlite3_dimensions(self):
+        nc_data = NetCDFData("tests/testdata/databases/Historical.sqlite3")
+        self.assertEqual(['y', 'x', 'time_counter', 'axis_nbounds', 'depthv'], nc_data.dimensions)
+
+    def test_sqlite3_dimensions_operational_error(self):
+        nc_data = NetCDFData("tests/testdata/databases/not_Historical.sqlite3")
+        self.assertEqual([], nc_data.dimensions)
+
+    def test_dimensions_url_list(self):
+        nc_data = NetCDFData(["tests/testdata/nemo_test.nc", "tests/testdata/nemo_grid_angle.nc"])
+        self.assertEqual(['deptht', 'time_counter', 'x', 'y'], nc_data.dimensions)
 
     def test_variable_list_cached(self):
         with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:
@@ -368,7 +391,7 @@ class TestNetCDFData(unittest.TestCase):
         kwargs = {"dataset_key": "giops"}
         with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
             file_list = nc_data.get_nc_file_list(nc_data._dataset_config)
-            self.assertIsNone(nc_data._nc_files)
+            self.assertEqual(nc_data._nc_files, [])
 
     @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
     def test_get_nc_file_list_no_dataset_config_url(self, patch_get_dataset_config):
@@ -377,7 +400,24 @@ class TestNetCDFData(unittest.TestCase):
         kwargs = {"dataset_key": "giops_no_url"}
         with NetCDFData("tests/testdata/nemo_test.nc", **kwargs) as nc_data:
             nc_data.get_nc_file_list(nc_data._dataset_config)
-            self.assertIsNone(nc_data._nc_files)
+            self.assertEqual(nc_data._nc_files, [])
+
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_get_nc_file_no_variable_kwarg_raises(self, patch_get_dataset_config):
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        with NetCDFData("tests/testdata/nemo_test.nc", **{"dataset_key": "nemo_sqlite3"}) as nc_data:
+            with self.assertRaises(RuntimeError):
+                nc_data.get_nc_file_list(nc_data._dataset_config)
+
+    @patch("data.netcdf_data.DatasetConfig._get_dataset_config")
+    def test_get_nc_file_no_timestep_kwarg_raises(self, patch_get_dataset_config):
+        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
+
+        with NetCDFData("tests/testdata/nemo_test.nc", **{"dataset_key": "nemo_sqlite3"}) as nc_data:
+            with self.assertRaises(RuntimeError):
+                kwargs = {"variable": "votemper"}
+                nc_data.get_nc_file_list(nc_data._dataset_config, **kwargs)
 
     def test_get_dataset_variable_raises_on_unknown_variable(self):
         with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -3,7 +3,6 @@
         "enabled": 1,
         "url": "tests/testdata/nemo_test.nc",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "model_class": "Mercator",
         "quantum": "day",
         "name": "GIOPS",
         "help": "help",
@@ -16,7 +15,6 @@
     "giops_no_url": {
         "enabled": 1,
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "model_class": "Mercator",
         "quantum": "day",
         "name": "GIOPS",
         "help": "help",
@@ -30,7 +28,6 @@
         "enabled": 1,
         "url": "tests/testdata/giops_test.nc",
         "name": "GIOPS Forecast 3D - Polar Stereographic",
-        "model_class": "Mercator",
         "quantum": "day",
         "type": "forecast",
         "lat_var_key": "latitude",
@@ -50,7 +47,6 @@
         "enabled": 1,
         "url": "tests/testdata/databases/test-nemo.sqlite3",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "model_class": "Nemo",
         "variables": {
             "votemper": { "name": "Temperature", "unit": "Celsius", "scale": [-5, 30] }
         }
@@ -67,7 +63,6 @@
         "quantum": "hour",
         "type": "historical",
         "time_dim_units": "seconds since 1970-01-01 00:00:00",
-        "model_class": "Nemo",
         "attribution": "UBC-MOAD",
         "lat_var_key": "nav_lat",
         "lon_var_key": "nav_lon",
@@ -90,7 +85,6 @@
         },
         "quantum": "hour",
         "time_dim_units": "seconds since 1970-01-01 00:00:00",
-        "model_class": "Nemo",
         "lat_var_key": "nav_lat",
         "lon_var_key": "nav_lon",
         "attribution": "UBC-MOAD",
@@ -104,7 +98,6 @@
         "enabled": 1,
         "url": "tests/testdata/mercator_test.nc",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
-        "model_class": "Mercator",
         "lat_var_key": "latitude",
         "lon_var_key": "longitude",
         "variables": {


### PR DESCRIPTION
## Background
When VM tab is selected upon selecting a point, the Point Window component was showing the loading animation and the start time is loaded as NaN. And also in the backend it shows **IndexError: index 0 is out of bounds for axis 0 with size 0** as seen in [Issue 816](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/816). There was a flaw in the calculation of the _starttime_ state variable in _PointWindow.jsx:Line47_, which was causing _netcdf_data.timestamp_to_time_index()_ to face an indexerror. 
## Why did you take this approach?
Instead of calculating the starttime state variable from props.time, we can use the props.starttime as the starttime for PointWindow component. We can pass the starttime from the parent OceanNavigator component as the props for PointWindow (Which we are already doing, but not trying to access that from PointWindow component).

On each time we change the dataset, and call changeDataset() method OceanNavigator.jsx: Line 257, we can change the global state.starttime to id of first element of the result from the call to /api/v1.0/timestamps/?dataset=[DATASET]&variable=[VARIABLE]. This call returns an array of the available timestamps and setting starttime to the first element's id of this returned array, sets the starttime to the earliest available timestamp on that selected dataset. This starttime value is then passed to the PointWindow component and can be used to perform the starttime calculation on various context, including the VM plot.

Although, this method will set the starttime value when user changed the dataset once (As the code steps in the changeDataset() function after user changes a dataset). So, I have also set the OceanNavigator component so that, it gets the timestamps for "giops_day" dataset and "votemper" variable as it is the default first selected dataset and variable. 



## Anything in particular that should be highlighted?

But for long time-series datasets like SalishSeaCast (hourly since 2007-01-01, so >100,000 timestamps). Setting _starttime_ to its first available timestamp would result in a large amount of backend task, so the _starttime_ is set to first element of the timestamp array if the length of timestamp array is less than 24. If it is larger than 24, it is set as the 24th element from the end of the timestamp array. 


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
I checked different datasets' VM tab after selecting a point on the global map, and the start time is properly set in my developer environment. 

