### PR TITLE
Add GeoJSON transformer to data package

### DIFF
--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -1,0 +1,56 @@
+import numpy as np
+import xarray as xr
+from data.utils import trunc
+
+from geojson import Feature, FeatureCollection, Point
+
+
+class WrongNumberOfDimensionsError(ValueError):
+    pass
+
+
+def data_array_to_geojson(data_array: xr.DataArray, lat_key: str, lon_key: str) -> FeatureCollection:
+    """
+    Converts a given xarray.DataArray, along with lat and lon keys to a geojson.FeatureCollection (subclass of dict).
+    
+    A FeatureCollection is really just a list of geojson.Feature classes.
+    Each Feature contains a geojson.Point, and a `properties` dict which holds arbitrary attributes
+    of interest for a Point. In the case of this function, each Feature has the following properties:
+
+    * The data value corresponding to a lat/lon pair (e.g. salinity or temperature)
+    * A copy of the `attribs` field held in the data_array (yes there's lots of duplication...blame the geojson spec).
+
+
+    Important notes:
+
+    * All data values are truncated to 3 decimal places.
+
+    Parameters:
+        * data_array -- A 2D field (i.e. lat/lon only...time and depth dims should be sliced out).
+        * lat_key -- Key of the latitude coordinate (e.g. "latitude").
+        * lon_key -- Key of the longitude coordinate (e.g. "longitude").
+
+    Returns:
+        FeatureCollection -- the transformed collection of geojson features.
+    """
+
+    dictionary = data_array.to_dict()
+    data = trunc(np.array(dictionary['data']).squeeze())
+    attributes = dictionary['attrs']
+
+    if len(data.shape) != 2:
+        raise WrongNumberOfDimensionsError(
+            f"Data is not a 2D field: {data.shape}")
+
+    points = [Point(t) for t in list(zip(
+        dictionary['coords'][lat_key]['data'],
+        dictionary['coords'][lon_key]['data']
+    ))]
+
+    num_lats = len(list(dictionary['coords'][lat_key]['data']))
+    features = [Feature(
+        geometry=points[i],
+        properties={**attributes, **{'data': data[i, i]}}
+    ) for i in range(num_lats)]
+
+    return FeatureCollection(features)

--- a/data/utils.py
+++ b/data/utils.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import re
 from bisect import bisect_left, bisect_right
-from typing import List
+from typing import List, Union
 
 import cftime
 import numpy as np
@@ -114,3 +114,14 @@ class DateTimeEncoder(json.JSONEncoder):
             return o.isoformat()
 
         return json.JSONEncoder.default(self, o)
+
+
+def trunc(values: Union[np.float, np.ndarray], num_decimals: int = 3) -> Union[np.float, np.ndarray]:
+    """
+    Truncates the floating-point value(s) to `num_decimals` places.
+
+    Robbed from:
+    https://stackoverflow.com/a/46020635/2231969
+    """
+    ten_to_the_power_of = 10**num_decimals
+    return np.trunc(values*ten_to_the_power_of) / ten_to_the_power_of

--- a/tests/data/transformers/test_geojson.py
+++ b/tests/data/transformers/test_geojson.py
@@ -1,0 +1,32 @@
+"""Unit tests for data.geojson
+"""
+import unittest
+
+import xarray as xr
+from data.transformers.geojson import (WrongNumberOfDimensionsError,
+                                       data_array_to_geojson)
+from geojson import FeatureCollection
+from numpy.testing._private.utils import assert_raises
+
+
+class GeoJSONTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.data_array = xr.open_dataset(
+            'tests/testdata/giops_test.nc', decode_times=False)
+
+    def tearDown(self) -> None:
+        self.data_array.close()
+
+    def test_data_array_to_geojson_builds_correct_feature_collection(self) -> None:
+        expected = {"features": [{"geometry": {"coordinates": [56.799999, 310.399994], "type": "Point"}, "properties": {"data": 3.1, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.0, 310.600006], "type": "Point"}, "properties": {"data": 3.084, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.200001, 310.799988], "type": "Point"}, "properties": {
+            "data": 3.193, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.400002, 311.0], "type": "Point"}, "properties": {"data": 3.357, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.599998, 311.200012], "type": "Point"}, "properties": {"data": 3.459, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}], "type": "FeatureCollection"}
+
+        result = data_array_to_geojson(self.data_array.votemper[0, 0, :5, :5], "latitude", "longitude")
+
+        self.assertEqual(FeatureCollection, type(result))
+        self.assertEqual(expected, result)
+
+    def test_data_array_to_geojson_raises_when_data_not_2d(self) -> None:
+        with self.assertRaises(WrongNumberOfDimensionsError):
+            data_array_to_geojson(self.data_array.votemper[:, 0, :5, :5], "latitude", "longitude")

--- a/tests/data/transformers/test_geojson.py
+++ b/tests/data/transformers/test_geojson.py
@@ -3,10 +3,8 @@
 import unittest
 
 import xarray as xr
-from data.transformers.geojson import (WrongNumberOfDimensionsError,
-                                       data_array_to_geojson)
+from data.transformers.geojson import data_array_to_geojson
 from geojson import FeatureCollection
-from numpy.testing._private.utils import assert_raises
 
 
 class GeoJSONTest(unittest.TestCase):
@@ -19,14 +17,29 @@ class GeoJSONTest(unittest.TestCase):
         self.data_array.close()
 
     def test_data_array_to_geojson_builds_correct_feature_collection(self) -> None:
-        expected = {"features": [{"geometry": {"coordinates": [56.799999, 310.399994], "type": "Point"}, "properties": {"data": 3.1, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.0, 310.600006], "type": "Point"}, "properties": {"data": 3.084, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.200001, 310.799988], "type": "Point"}, "properties": {
-            "data": 3.193, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.400002, 311.0], "type": "Point"}, "properties": {"data": 3.357, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}, {"geometry": {"coordinates": [57.599998, 311.200012], "type": "Point"}, "properties": {"data": 3.459, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"}, "type": "Feature"}], "type": "FeatureCollection"}
+        expected = {
+            "features": [
+                {"geometry": {"coordinates": [56.799999, 310.399994], "type": "Point"},
+                 "properties": {"data": 3.1, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"},
+                 "type": "Feature"},
+                {"geometry": {"coordinates": [57.0, 310.600006], "type": "Point"},
+                 "properties": {"data": 3.084, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"},
+                 "type": "Feature"},
+                {"geometry": {"coordinates": [57.200001, 310.799988], "type": "Point"},
+                 "properties": {"data": 3.193, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"},
+                 "type": "Feature"},
+                {"geometry": {"coordinates": [57.400002, 311.0], "type": "Point"},
+                 "properties": {"data": 3.357, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"},
+                 "type": "Feature"},
+                {"geometry": {"coordinates": [57.599998, 311.200012], "type": "Point"},
+                 "properties": {"data": 3.459, "long_name": "Temperature", "short_name": "votemper", "units": "degrees_C"},
+                 "type": "Feature"}], "type": "FeatureCollection"}
 
         result = data_array_to_geojson(self.data_array.votemper[0, 0, :5, :5], "latitude", "longitude")
 
-        self.assertEqual(FeatureCollection, type(result))
+        self.assertIsInstance(result, FeatureCollection)
         self.assertEqual(expected, result)
 
     def test_data_array_to_geojson_raises_when_data_not_2d(self) -> None:
-        with self.assertRaises(WrongNumberOfDimensionsError):
+        with self.assertRaises(ValueError):
             data_array_to_geojson(self.data_array.votemper[:, 0, :5, :5], "latitude", "longitude")

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -4,11 +4,11 @@ import datetime
 import unittest
 
 import numpy as np
+import numpy.testing as npt
 import pytz
-
 from data.utils import (datetime_to_timestamp, find_ge, find_le,
                         get_data_vars_from_equation, roll_time,
-                        time_index_to_datetime)
+                        time_index_to_datetime, trunc)
 
 
 class TestDataUtils(unittest.TestCase):
@@ -74,3 +74,17 @@ class TestDataUtils(unittest.TestCase):
             "sspeed(depth, nav_lat, votemper - 273.15, vosaline)", ["vosaline", "votemper", "vozocrtx", "vomecrty"]))
 
         self.assertEqual(expected, result)
+
+    def test_trunc_truncates_one_value(self):
+        expected = 3.14
+
+        result = trunc(3.14444444444444444444, 2)
+
+        npt.assert_allclose(result, expected, 0)
+
+    def test_trunc_truncates_all_values(self):
+        expected = np.array([3.141, 1.234])
+
+        result = trunc(np.array([3.1414141414, 1.23456789]))
+
+        npt.assert_allclose(result, expected)


### PR DESCRIPTION
## Background

Prerequisite for getting the `/data` API endpoint back up and running (#808)

* Provides functionality to serialize an xarray data array into a valid geojson dictionary.
* Added new `trunc` helper function to correctly truncate floating-point values to a given number of decimal places.
* Added relevant tests.

## Why did you take this approach?
I decided to implement this as a free function to start instead of dumping it into `Data` as a virtual function for the sake of faster iteration....just wanna get #808 out before end of fiscal.

Ultimately I'd like to see syntax like `my_mercator_instance[0, 0, 5:10, 5:10].to_geojson()`, `...to_netcdf(nc_file_type)`, `...to_csv()`, etc... but `Data` is also missing `__getitem__` for proper slicing (so we can ditch `get_point`, `get_area`, etc, and simply keep the helper functions like `get_line`, `get_profile).

On the other hand, this free-function style could stay and allow us to keep `Data` subclasses lean....up for discussion another time.

## Anything in particular that should be highlighted?
Nope.

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
