### PR TITLE
Add ONC & STRATOGEM stations to Points menu

### DIFF
--- a/kml/point/ONC_Stations.kml
+++ b/kml/point/ONC_Stations.kml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>ONC_Stations.kml</name>
+	<Folder>
+		<name>ONC Stations</name>
+		<Placemark><name>SCVIP</name><Point><coordinates>-123.425825,49.040066666</coordinates></Point></Placemark>	
+		<Placemark><name>SEVIP</name><Point><coordinates>-123.316836666,49.04316</coordinates></Point></Placemark>	
+		<Placemark><name>LSBBL</name><Point><coordinates>-123.339633,49.074766</coordinates></Point></Placemark>	
+		<Placemark><name>USDDL</name><Point><coordinates>-123.32972,49.08495</coordinates></Point></Placemark>				
+	</Folder>
+</Document>
+</kml>

--- a/kml/point/Offshore_Oil_Operations.kml
+++ b/kml/point/Offshore_Oil_Operations.kml
@@ -2,105 +2,12 @@
 <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
 <Document>
 	<name>Offshore_Oil_Operations.kml</name>
-	<Style id="s_ylw-pushpin_hl">
-		<IconStyle>
-			<scale>1.3</scale>
-			<Icon>
-				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
-			</Icon>
-			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
-		</IconStyle>
-	</Style>
-	<StyleMap id="m_ylw-pushpin">
-		<Pair>
-			<key>normal</key>
-			<styleUrl>#s_ylw-pushpin</styleUrl>
-		</Pair>
-		<Pair>
-			<key>highlight</key>
-			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
-		</Pair>
-	</StyleMap>
-	<Style id="s_ylw-pushpin">
-		<IconStyle>
-			<scale>1.1</scale>
-			<Icon>
-				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
-			</Icon>
-			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
-		</IconStyle>
-	</Style>
 	<Folder>
 		<name>Offshore Oil Operations</name>
-		<open>1</open>
-		<Placemark>
-			<name>Hibernia</name>
-			<LookAt>
-				<longitude>-94.99999790916823</longitude>
-				<latitude>59.99999606701344</latitude>
-				<altitude>0</altitude>
-				<heading>1.810713307515297e-06</heading>
-				<tilt>0</tilt>
-				<range>11008610.2279107</range>
-				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
-			</LookAt>
-			<styleUrl>#m_ylw-pushpin</styleUrl>
-			<Point>
-				<gx:drawOrder>1</gx:drawOrder>
-				<coordinates>-48.78305556,46.750556,0</coordinates>
-			</Point>
-		</Placemark>
-		<Placemark>
-			<name>Terra Nova</name>
-			<LookAt>
-				<longitude>-47.98487220826905</longitude>
-				<latitude>46.22804859646565</latitude>
-				<altitude>0</altitude>
-				<heading>-8.778807817565832</heading>
-				<tilt>0</tilt>
-				<range>1224863.475486017</range>
-				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
-			</LookAt>
-			<styleUrl>#m_ylw-pushpin</styleUrl>
-			<Point>
-				<gx:drawOrder>1</gx:drawOrder>
-				<coordinates>-48.47944444,46.475,0</coordinates>
-			</Point>
-		</Placemark>
-		<Placemark>
-			<name>White Rose</name>
-			<LookAt>
-				<longitude>-47.98487220826905</longitude>
-				<latitude>46.22804859646565</latitude>
-				<altitude>0</altitude>
-				<heading>-8.778807817565832</heading>
-				<tilt>0</tilt>
-				<range>1224863.475486017</range>
-				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
-			</LookAt>
-			<styleUrl>#m_ylw-pushpin</styleUrl>
-			<Point>
-				<gx:drawOrder>1</gx:drawOrder>
-				<coordinates>-48.015,46.78861100000001,0</coordinates>
-			</Point>
-		</Placemark>
-		<Placemark>
-			<name>ESRF Reference Station</name>
-			<LookAt>
-				<longitude>-47.98487038365727</longitude>
-				<latitude>46.22805125493088</latitude>
-				<altitude>0</altitude>
-				<heading>-8.778806500015504</heading>
-				<tilt>0</tilt>
-				<range>1224997.006138645</range>
-				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
-			</LookAt>
-			<styleUrl>#m_ylw-pushpin</styleUrl>
-			<Point>
-				<gx:drawOrder>1</gx:drawOrder>
-				<coordinates>-48.25849999999999,46.97996,0</coordinates>
-			</Point>
-		</Placemark>
+		<Placemark><name>Hibernia</name><Point><coordinates>-48.78305556,46.750556</coordinates></Point></Placemark>
+		<Placemark><name>Terra Nova</name><Point><coordinates>-48.47944444,46.475</coordinates></Point></Placemark>
+		<Placemark><name>White Rose</name><Point><coordinates>-48.015,46.78861100000001</coordinates></Point></Placemark>
+		<Placemark><name>ESRF Reference Station</name><Point><coordinates>-48.25849999999999,46.97996</coordinates></Point></Placemark>
 	</Folder>
 </Document>
 </kml>

--- a/kml/point/STRATOGEM_Stations.kml
+++ b/kml/point/STRATOGEM_Stations.kml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>STRATOGEM_Stations.kml</name>
+	<Folder>
+		<name>STRATOGEM Stations</name>
+		<Placemark><name>S1</name><Point><coordinates>-123.25416666666666,48.916666666666664</coordinates></Point></Placemark>
+		<Placemark><name>S2-1</name><Point><coordinates>-123.4875,48.98</coordinates></Point></Placemark>
+		<Placemark><name>S2-2</name><Point><coordinates>-123.425,49.025</coordinates></Point></Placemark>
+		<Placemark><name>S2-3</name><Point><coordinates>-123.35,49.083333333333336</coordinates></Point></Placemark>
+		<Placemark><name>S3</name><Point><coordinates>-123.55833333333334,49.125</coordinates></Point></Placemark>		
+		<Placemark><name>S4-1</name><Point><coordinates>-123.74833333333333,49.25</coordinates></Point></Placemark>	
+		<Placemark><name>S4-2</name><Point><coordinates>-123.58333333333333,49.233333333333334</coordinates></Point></Placemark>	
+		<Placemark><name>S4-3</name><Point><coordinates>-123.38333333333334,49.25</coordinates></Point></Placemark>	
+		<Placemark><name>S5</name><Point><coordinates>-123.85,49.358333333333334</coordinates></Point></Placemark>						
+	</Folder>
+</Document>
+</kml>


### PR DESCRIPTION
## Background
Users request points from STRATOGEM and Ocean Networks Canada (ONC) stations in Salish Sea to be added to the Navigator's Points menu. These locations are frequently used for model vs. observation comparisons and are to be listed as 'ONC Stations' and "STRATOGEM Stations' in the menu.

'ONC_Stations.kml' and 'STRATOGEM_Stations.kml' files containing the lat/lon coordinates and name of each station were added to the /kml/points directory.  Also removed unused code from 'Offshore_Oil_Operations.kml' which does not provide any functionality for the Navigator. 

resolves #700, resolves #701 

## Why did you take this approach?
kml files are found via functions in misc.py and the API so adding the kml files mentioned above to the /kml/points directory is all that is needed to include the station locations in the Navigator's points menu. 


## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

