### PR TITLE
Issue/784 816 fixing start date of vm

### DIFF
--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -124,15 +124,6 @@ export default class OceanNavigator extends React.Component {
     this.get_variables_promise = this.get_variables_promise.bind(this);
     this.get_timestamp_promise = this.get_timestamp_promise.bind(this);
     this.setStartTime = this.setStartTime.bind(this);
-    // Setting the starttime and time variable default value
-    const time_promise = this.get_timestamp_promise("giops_day", "votemper");
-      $.when(time_promise).done(function(time) {
-        let newTime = time[time.length-1].id;
-        let newStarttime = time[0].id;
-        this.state.time = newTime;
-        this.state.starttime = newStarttime;
-        this.setState(state);
-      }.bind(this));
   }
   
   //Updates the page language upon user request
@@ -524,6 +515,15 @@ export default class OceanNavigator extends React.Component {
     } else {
       window.history.back();
     }
+  }
+  componentDidMount(){
+    // Setting the starttime and time variable default value
+    const time_promise = this.get_timestamp_promise("giops_day", "votemper");
+      $.when(time_promise).done(function(time) {
+        const newTime = time[time.length-1].id;
+        const newStarttime = time[0].id;
+        this.setState({time: newTime, starttime: newStarttime});
+      }.bind(this));
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -123,6 +123,15 @@ export default class OceanNavigator extends React.Component {
     this.updateScale = this.updateScale.bind(this);
     this.get_variables_promise = this.get_variables_promise.bind(this);
     this.get_timestamp_promise = this.get_timestamp_promise.bind(this);
+    // Setting the starttime and time variable default value
+    const time_promise = this.get_timestamp_promise("giops_day", "votemper");
+      $.when(time_promise).done(function(time) {
+        let newTime = time[time.length-1].id;
+        let newStarttime = time[0].id;
+        this.state.time = newTime;
+        this.state.starttime = newStarttime;
+        this.setState(state);
+      }.bind(this));
   }
   
   //Updates the page language upon user request
@@ -272,16 +281,22 @@ export default class OceanNavigator extends React.Component {
 
 
       let newTime = 0;
+      let newStarttime = 0;
       const time_promise = this.get_timestamp_promise(dataset, newVariable);
       $.when(time_promise).done(function(time) {
         newTime = time[time.length-1].id;
-
+        // check the length of the timestamp array and set the start time according to that
+        if (time.length > 24)
+          newStarttime = time[time.length-25].id;
+        else
+          newStarttime = time[0].id;
         if (state === undefined) {
           state = {};
         }
         state.dataset = dataset;
         state.variable = newVariable;
         state.time = newTime;
+        state.starttime = newStarttime;
         state.busy = false;
 
         this.setState(state);

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -293,7 +293,6 @@ export default class OceanNavigator extends React.Component {
       const time_promise = this.get_timestamp_promise(dataset, newVariable);
       $.when(time_promise).done(function(time) {
         newTime = time[time.length-1].id;
-        // check the length of the timestamp array and set the start time according to that
         newStarttime = this.setStartTime(time);
         if (state === undefined) {
           state = {};

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -123,6 +123,7 @@ export default class OceanNavigator extends React.Component {
     this.updateScale = this.updateScale.bind(this);
     this.get_variables_promise = this.get_variables_promise.bind(this);
     this.get_timestamp_promise = this.get_timestamp_promise.bind(this);
+    this.setStartTime = this.setStartTime.bind(this);
     // Setting the starttime and time variable default value
     const time_promise = this.get_timestamp_promise("giops_day", "votemper");
       $.when(time_promise).done(function(time) {
@@ -262,12 +263,19 @@ export default class OceanNavigator extends React.Component {
       variable
     ).promise();
   }
+  setStartTime(time){
+    if (time.length > 24)
+      return time[time.length-25].id;
+    else
+      return time[0].id;
+  }
 
   changeDataset(dataset, state) {
     // Busy modal
     this.setState({
       busy: true,
     });
+    
 
     // When dataset changes, so does time & variable list
     const var_promise = this.get_variables_promise(dataset);
@@ -286,10 +294,7 @@ export default class OceanNavigator extends React.Component {
       $.when(time_promise).done(function(time) {
         newTime = time[time.length-1].id;
         // check the length of the timestamp array and set the start time according to that
-        if (time.length > 24)
-          newStarttime = time[time.length-25].id;
-        else
-          newStarttime = time[0].id;
+        newStarttime = this.setStartTime(time);
         if (state === undefined) {
           state = {};
         }

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -44,7 +44,6 @@ export default class PointWindow extends React.Component {
       depth: props.depth,
       showmap: false,
       colormap: "default",
-      //starttime: Math.max(props.time - 24, 0),
       starttime: props.starttime,
       variables: [],
       variable: [props.variable],
@@ -53,8 +52,6 @@ export default class PointWindow extends React.Component {
       dpi: 144,
       plotTitles: Array(7).fill(""),
     };
-    //console.log("State [Starttime] "+this.state.starttime);
-    //console.log("Props [Time] "+ props.starttime);
 
     if (props.init !== null) {
       $.extend(this.state, props.init);

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -44,7 +44,8 @@ export default class PointWindow extends React.Component {
       depth: props.depth,
       showmap: false,
       colormap: "default",
-      starttime: Math.max(props.time - 24, 0),
+      //starttime: Math.max(props.time - 24, 0),
+      starttime: props.starttime,
       variables: [],
       variable: [props.variable],
       observation_variable: [0],
@@ -52,6 +53,8 @@ export default class PointWindow extends React.Component {
       dpi: 144,
       plotTitles: Array(7).fill(""),
     };
+    //console.log("State [Starttime] "+this.state.starttime);
+    //console.log("Props [Time] "+ props.starttime);
 
     if (props.init !== null) {
       $.extend(this.state, props.init);


### PR DESCRIPTION
## Background
When VM tab is selected upon selecting a point, the Point Window component was showing the loading animation and the start time is loaded as NaN. And also in the backend it shows **IndexError: index 0 is out of bounds for axis 0 with size 0** as seen in [Issue 816](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/816). There was a flaw in the calculation of the _starttime_ state variable in _PointWindow.jsx:Line47_, which was causing _netcdf_data.timestamp_to_time_index()_ to face an indexerror. 
## Why did you take this approach?
Instead of calculating the starttime state variable from props.time, we can use the props.starttime as the starttime for PointWindow component. We can pass the starttime from the parent OceanNavigator component as the props for PointWindow (Which we are already doing, but not trying to access that from PointWindow component).

On each time we change the dataset, and call changeDataset() method OceanNavigator.jsx: Line 257, we can change the global state.starttime to id of first element of the result from the call to /api/v1.0/timestamps/?dataset=[DATASET]&variable=[VARIABLE]. This call returns an array of the available timestamps and setting starttime to the first element's id of this returned array, sets the starttime to the earliest available timestamp on that selected dataset. This starttime value is then passed to the PointWindow component and can be used to perform the starttime calculation on various context, including the VM plot.

Although, this method will set the starttime value when user changed the dataset once (As the code steps in the changeDataset() function after user changes a dataset). So, I have also set the OceanNavigator component so that, it gets the timestamps for "giops_day" dataset and "votemper" variable as it is the default first selected dataset and variable. 



## Anything in particular that should be highlighted?

But for long time-series datasets like SalishSeaCast (hourly since 2007-01-01, so >100,000 timestamps). Setting _starttime_ to its first available timestamp would result in a large amount of backend task, so the _starttime_ is set to first element of the timestamp array if the length of timestamp array is less than 24. If it is larger than 24, it is set as the 24th element from the end of the timestamp array. 


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
I checked different datasets' VM tab after selecting a point on the global map, and the start time is properly set in my developer environment. 

