### PR TITLE
Removed references to 'scale_factor'

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -326,22 +326,6 @@ class VariableConfig:
             return [0, 100]
 
     @property
-    def scale_factor(self) -> float:
-        """
-        Returns variable scale factor from dataset config file
-        """
-
-        try:
-            scale_factor = self.__get_attribute("scale_factor")
-        except KeyError:
-            scale_factor = None
-
-        if scale_factor is not None:
-            return scale_factor
-        else:
-            return 1.0
-
-    @property
     def is_hidden(self) -> bool:
         """
         Is the given variable marked as hidden in the dataset config file

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -71,11 +71,9 @@ class HovmollerPlotter(LinePlotter):
                 dataset, self.variables)[0]
 
             variable_units = self.get_variable_units(dataset, self.variables)
-            scale_factors = self.get_variable_scale_factors(
-                dataset, self.variables)
 
             self.variable_unit = variable_units[0]
-            self.data = np.multiply(data, scale_factors[0]).T
+            self.data = data.T
             self.iso_timestamps = times
 
             # Get colourmap
@@ -110,11 +108,9 @@ class HovmollerPlotter(LinePlotter):
 
                 variable_units = self.get_variable_units(
                     dataset, self.compare['variables'])
-                scale_factors = self.get_variable_scale_factors(
-                    dataset, self.compare['variables'])
 
                 self.compare['variable_unit'] = variable_units[0]
-                self.compare['data'] = np.multiply(data, scale_factors[0]).T
+                self.compare['data'] = data.T
                 self.compare['times'] = times
 
     # Render Hovmoller graph(s)

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -203,9 +203,6 @@ class MapPlotter(Plotter):
             self.variable_name = self.get_variable_names(
                 dataset, self.variables
             )[0]
-            scale_factor = self.get_variable_scale_factors(
-                dataset, self.variables
-            )[0]
 
             if self.cmap is None:
                 self.cmap = colormap.find_colormap(self.variable_name)
@@ -241,8 +238,6 @@ class MapPlotter(Plotter):
                     self.radius,
                     self.neighbours
                 )
-
-            d = np.multiply(d, scale_factor)
 
             data.append(d)
             if self.filetype not in ['csv', 'odv', 'txt']:
@@ -355,8 +350,6 @@ class MapPlotter(Plotter):
                 vc = self.dataset_config.variable[self.contour['variable']]
                 contour_unit = vc.unit
                 contour_name = vc.name
-                contour_factor = vc.scale_factor
-                d = np.multiply(d, contour_factor)
                 contour_data.append(d)
                 self.contour_unit = contour_unit
                 self.contour_name = contour_name

--- a/plotting/observation.py
+++ b/plotting/observation.py
@@ -133,8 +133,6 @@ class ObservationPlotter(PointPlotter):
             )
             point_data = np.ma.array(point_data)
 
-            point_data = self.apply_scale_factors(point_data)
-
         self.data = point_data
         self.observation_time = observation_time
         self.observation_times = observation_times

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -32,7 +32,6 @@ class Plotter(metaclass=ABCMeta):
         self.variable_names = None
         self.variable_units = None
         self.scale = None
-        self.scale_factors = None
         self.date_formatter = None
         # Init interpolation stuff
         self.interp: str = "gaussian"
@@ -219,8 +218,6 @@ class Plotter(metaclass=ABCMeta):
     def load_misc(self, dataset, variables):
         self.variable_names = self.get_variable_names(dataset, variables)
         self.variable_units = self.get_variable_units(dataset, variables)
-        self.scale_factors = self.get_variable_scale_factors(
-            dataset, variables)
 
     def plot(self, fig=None):
 
@@ -378,33 +375,6 @@ class Plotter(metaclass=ABCMeta):
         """
         v = ",".join(variables)
         return self.dataset_config.variable[v].unit
-
-    def get_variable_scale_factors(self, dataset, variables):
-        """Returns a list of scale factors for the variables.
-
-        Parameters:
-        dataset -- the dataset
-        variables -- a list of strings, each of which is the key for a
-                     variable
-        """
-        factors = []
-
-        for idx, v in enumerate(variables):
-            factors.append(
-                self.dataset_config.variable[dataset.variables[v]].scale_factor)
-
-        return factors
-
-    def get_vector_variable_scale_factor(self, dataset, variables):
-        """Returns a scaling factor for the vector version of the variables.
-
-        Parameters:
-        dataset -- the dataset
-        variables -- a list of strings, each of which is the key for a
-                     variable
-        """
-        v = ",".join(variables)
-        return self.dataset_config.variable[v].scale_factor
 
     def clip_value(self, input_value, variable):
         output = input_value

--- a/plotting/point.py
+++ b/plotting/point.py
@@ -83,13 +83,6 @@ class PointPlotter(Plotter):
 
         return data
 
-    def apply_scale_factors(self, data):
-        for idx, factor in enumerate(self.scale_factors):
-            if factor != 1.0:
-                data[idx] = np.multiply(data[idx], factor)
-
-        return data
-
     @property
     def figuresize(self):
         figuresize = list(map(float, self.size.split("x")))

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -30,7 +30,6 @@ class ProfilePlotter(PointPlotter):
 
             point_data, point_depths = self.get_data(
                 ds, self.variables, self.time)
-            point_data = self.apply_scale_factors(point_data)
 
             self.iso_timestamp = ds.nc_data.timestamp_to_iso_8601(self.time)
 

--- a/plotting/stats.py
+++ b/plotting/stats.py
@@ -103,7 +103,6 @@ class Stats:
 
                 variable_name = config.variable[var].name
                 variable_unit = config.variable[var].unit
-                scale_factor = config.variable[var].scale_factor
 
                 lat, lon, d = dataset.get_raw_point(
                     lat.ravel(),
@@ -112,9 +111,6 @@ class Stats:
                     time,
                     v
                 )
-
-                if scale_factor != 1.0:
-                    d = np.multiply(d, scale_factor)
 
                 lon[np.where(lon > 180)] -= 360
 

--- a/plotting/stick.py
+++ b/plotting/stick.py
@@ -57,11 +57,6 @@ class StickPlotter(PointPlotter):
             point_data = np.ma.array(point_data)
             point_depth = np.ma.array(point_depth)
 
-            for idx, factor in enumerate(self.scale_factors):
-                if factor != 1.0:
-                    point_data[:, idx] = np.multiply(
-                        point_data[:, idx], factor)
-
         self.data = self.subtract_other(point_data)
         self.data_depth = point_depth
         self.timestamp = timestamp

--- a/plotting/tile.py
+++ b/plotting/tile.py
@@ -189,17 +189,12 @@ def plot(projection, x, y, z, args):
         vc = config.variable[dataset.variables[variable[0]]]
         variable_name = vc.name
         variable_unit = vc.unit
-        scale_factor = vc.scale_factor
         cmap = colormap.find_colormap(variable_name)
 
         if depth != 'bottom':
             depthm = dataset.depths[depth]
         else:
             depthm = 0
-
-    if scale_factor != 1.0:
-        for idx, val in enumerate(data):
-            data[idx] = np.multiply(val, scale_factor)
 
     if len(data) == 1:
         data = data[0]

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -99,9 +99,6 @@ class TimeseriesPlotter(PointPlotter):
                 point_data.append(np.ma.array(data))
 
             point_data = np.ma.array(point_data)
-            for idx, factor in enumerate(self.scale_factors):
-                if factor != 1.0:
-                    point_data[idx] = np.multiply(point_data[idx], factor)
 
             starttime_idx = dataset.nc_data.timestamp_to_time_index(self.starttime)
             endtime_idx = dataset.nc_data.timestamp_to_time_index(self.endtime)

--- a/plotting/track.py
+++ b/plotting/track.py
@@ -209,17 +209,12 @@ class TrackPlotter(Plotter):
 
                 variable_units = []
                 variable_names = []
-                scale_factors = []
                 cmaps = []
                 for v in self.variables:
                     vc = self.dataset_config.variable[v]
                     variable_units.append(vc.unit)
                     variable_names.append(vc.name)
-                    scale_factors.append(vc.scale_factor)
                     cmaps.append(colormap.find_colormap(vc.name))
-
-                for idx, sf in enumerate(scale_factors):
-                    model_data[idx, :] = np.multiply(model_data[idx, :], sf)
 
                 self.model_data = model_data
                 self.model_dist = model_dist

--- a/plotting/transect.py
+++ b/plotting/transect.py
@@ -75,8 +75,6 @@ class TransectPlotter(LinePlotter):
 
             variable_names = self.get_variable_names(dataset, self.variables)
             variable_units = self.get_variable_units(dataset, self.variables)
-            scale_factors = self.get_variable_scale_factors(
-                dataset, self.variables)
 
             # Load data sent from primary/Left Map
             if len(self.variables) > 1:
@@ -88,14 +86,11 @@ class TransectPlotter(LinePlotter):
                 distances, times, lat, lon, bearings = geo.path_to_points(
                     self.points, 100
                 )
+                # Calculate vector components
                 transect_pts, distance, x, dep = dataset.get_path_profile(
                     self.points, self.variables[0], self.time, numpoints=100)
                 transect_pts, distance, y, dep = dataset.get_path_profile(
                     self.points, self.variables[1], self.time, numpoints=100)
-
-                # Calculate vector components
-                x = np.multiply(x, scale_factors[0])
-                y = np.multiply(y, scale_factors[1])
 
                 r = np.radians(np.subtract(90, bearings))
                 theta = np.arctan2(y, x) - r
@@ -108,8 +103,6 @@ class TransectPlotter(LinePlotter):
                 # Get data for one variable
                 transect_pts, distance, value, dep = dataset.get_path_profile(
                     self.points, self.variables[0], self.time)
-
-                value = np.multiply(value, scale_factors[0])
 
             if len(self.variables) == 2:
                 variable_names = [self.get_vector_variable_name(dataset,
@@ -149,7 +142,6 @@ class TransectPlotter(LinePlotter):
                 vc = self.dataset_config.variable[dataset.variables[self.surface]]
                 surface_unit = vc.unit
                 surface_name = vc.name
-                surface_factor = vc.scale_factor
                 surface_value = np.multiply(surface_value, surface_factor)
 
                 self.surface_data = {

--- a/plotting/ts.py
+++ b/plotting/ts.py
@@ -34,10 +34,6 @@ class TemperatureSalinityPlotter(PointPlotter):
         self.load_misc(dataset, [temp_var, sal_var])
         self.data = data
 
-        for idx, factor in enumerate(self.scale_factors):
-            if factor != 1.0:
-                data[:, idx, :] = np.multiply(data[:, idx, :], factor)
-
     def load_data(self):
         variables = self.dataset_config.variables
         temp_var_key = self.__find_var_key(variables, r'^(.*temp.*|thetao.*)$')


### PR DESCRIPTION
## Background
A 'scale_factor' attribute is given for many variables within the datasetconfig.json file which scales the data as needed for the presentation layer. While an important function it can be replaced by an equation which will provide the same functionality with more efficiency. 

References to 'scale_factor' were removed from datasetconfig.json, dataset_confi.py, and several plotting classes. In some instances where the scale factor was applied to the data along with other operations. For these cases the code was appropriately modified to preserve the necessary operations. 

closes #729 
 
## Why did you take this approach?
Though 'scale_factor' can be depreciated just by removing references in datasetconfig.json, references in the calculation layer were also removed to help reduce the total amount of code in the Navigator. 

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
