### PR TITLE
Bugfix: make `get_dataset_variable` return `xarray.DataArray` instead of `xarray.Variable`

### DIFF
--- a/data/calculated.py
+++ b/data/calculated.py
@@ -59,7 +59,7 @@ class CalculatedData(NetCDFData):
                                    attrs,
                                    self.url)
         else:
-            return self.dataset.variables[key]
+            return super().get_dataset_variable(key)
 
     @property
     def variables(self):

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -691,11 +691,11 @@ class NetCDFData(Data):
 
         return y_dim, x_dim
 
-    def get_dataset_variable(self, key: str):
+    def get_dataset_variable(self, key: str) -> xarray.DataArray:
         """
-        Returns the value of a given variable name from the dataset
+        Returns the xarray.DataArray for a given variable key
         """
-        return self.dataset.variables[key]
+        return self.dataset[key]
 
     @property
     def variables(self) -> VariableList:

--- a/tests/test_calculated_data.py
+++ b/tests/test_calculated_data.py
@@ -22,6 +22,7 @@ class TestCalculatedData(unittest.TestCase):
             self.assertEqual(len(data.variables), 1)
 
             v = data.get_dataset_variable("votemper")
+            self.assertEqual(xr.DataArray, type(v))
             self.assertAlmostEqual(v[0, 0, 17, 816].values, 271.1796875)
 
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -379,6 +379,12 @@ class TestNetCDFData(unittest.TestCase):
             nc_data.get_nc_file_list(nc_data._dataset_config)
             self.assertIsNone(nc_data._nc_files)
 
+    def test_get_dataset_variable_returns_dataarray(self):
+        with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:
+            res = nc_data.get_dataset_variable('votemper')
+
+            self.assertEqual(xarray.DataArray, type(res))
+
     def test_get_dataset_variable_raises_on_unknown_variable(self):
         with NetCDFData("tests/testdata/nemo_test.nc") as nc_data:
             with self.assertRaises(KeyError):


### PR DESCRIPTION
## Background

While working on #829, I ended up discovering a nasty bug I introduced a few years ago (classic), where `CalculatedData.get_dataset_variable()` and `NetCDFData.get_dataset_variable()` were grabbing the wrong representation of the variable in a dataset, by returning a low-level `xarray.Variable`. I discovered this when I tried to do things like `my_variable['latitude']` and I was greeted with a nice old `TypeError: invalid indexer array, does not have integer dtype`. By playing around in `ipython` is when I realized my data types were different (because the `DataArray` allowed me to do `my_variable['latitude']`). Then I looked up the differences between a DataArray and a Variable and found these docs:

![image](https://user-images.githubusercontent.com/5572045/114279259-4bfca400-9a0e-11eb-9a34-0832567bd5df.png)


https://xarray.pydata.org/en/stable/terminology.html#term-DataArray

* Fixed bug.
* Added test coverage in relevant spots.

## Why did you take this approach?
Followed the xarray docs.

Since this touches how we extract data from our files, I did some extra testing on my local website to make sure no side effects were introduced.

## Anything in particular that should be highlighted?

Surprised I didn't encounter this bug sooner.

## Screenshot(s)
Calculated path:
![image](https://user-images.githubusercontent.com/5572045/114306239-e5cb5c00-9ab5-11eb-8d3c-d6f2781794e2.png)

Non-calculated path:
![image](https://user-images.githubusercontent.com/5572045/114306290-0e535600-9ab6-11eb-8e3d-22d920314c23.png)

Random plot:
![image](https://user-images.githubusercontent.com/5572045/114306434-99345080-9ab6-11eb-9bd1-55b54e361d06.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
