### PR TITLE
Add SAR_Areas.kml to kml/area

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+kml/area/SAR_Areas.kml filter=lfs diff=lfs merge=lfs -text

--- a/kml/area/SAR_Areas.kml
+++ b/kml/area/SAR_Areas.kml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3718ec2d876b3425159050ce0355a86ab8cea239dec216db4d44a130c134ae3
+size 117738269


### PR DESCRIPTION
## Background
SAR requested 40 areas be included in the Ocean Navigator. A kml file containing the metadata for these areas was provided by the SAR group which was cleaned up before being added to the 'kml/area' directory of this branch.

## Why did you take this approach?
The Navigator scans the 'kml/area' directory and populates the Area menu based on the files found.

## Anything in particular that should be highlighted?


## Screenshot(s)
![sar_areas](https://user-images.githubusercontent.com/79917349/116133050-d862c400-a6a8-11eb-816f-9d319623501d.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
