### PR TITLE
Skip broken kmls

### DIFF
--- a/kml/area/SAR_Areas.kml
+++ b/kml/area/SAR_Areas.kml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3718ec2d876b3425159050ce0355a86ab8cea239dec216db4d44a130c134ae3
-size 117738269
+oid sha256:218a9d2371ebb1e5e5b56e4d544b58d6ddf914568603faa0fba361e2dc4480ce
+size 117738263

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -21,10 +21,14 @@ def list_kml_files(subdir):
 
     files = []
     for f in os.listdir(DIR):
+        print(f)
         name = None
         if not f.endswith(".kml"):
             continue
-        root = ET.parse(DIR + "/" + f).getroot()
+        try:
+            root = ET.parse(DIR + "/" + f).getroot()
+        except:
+            continue
         nsmap = root.tag.split("}", 1)[0] + "}"
         for folder in root.iter(nsmap + "Folder"):
             for filename in folder.iter(nsmap + "name"):

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -21,7 +21,6 @@ def list_kml_files(subdir):
 
     files = []
     for f in os.listdir(DIR):
-        print(f)
         name = None
         if not f.endswith(".kml"):
             continue

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -26,7 +26,7 @@ def list_kml_files(subdir):
             continue
         try:
             root = ET.parse(DIR + "/" + f).getroot()
-        except:
+        except ET.ParseError:
             continue
         nsmap = root.tag.split("}", 1)[0] + "}"
         for folder in root.iter(nsmap + "Folder"):


### PR DESCRIPTION
## Background
If the Navigator encounters an error when parsing a kml file it currently results in the point/line/area menu not being populated. Now that we have a kml file hosted on LFS this is more likely to happen to users if they try to run the Navigator without LFS on their system or before the file is downloaded. Adding a try statement to `list_kml_files` in `misc.py` allows the Navigator to skip kml files when it encounters a parse error and continue to populate the relevant menu.  

Also removed 'Final' from SAR Areas name.

## Why did you take this approach?
Seemed to be the easiest way to ensure that the Navigator will continue to read in kml files in the event of an error.

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
