### PR TITLE
Changing the colormap for sub-surface channel variable

### DIFF
--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -169,7 +169,7 @@ colormaps = {
         _c('#000000')
     ]),
     'potential sub surface channel': mcolors.ListedColormap(
-        ['#9F3822','#082A81']
+        ['#ecf0f1','#f57732']
         ),
     'thermal': cmocean.cm.thermal,
     'neo_sst': mcolors.ListedColormap(


### PR DESCRIPTION
## Background
The colormap for the Potential Sub-surface channel has been changed.
## Why did you take this approach?

## Screenshot(s)
![CS5](https://user-images.githubusercontent.com/12777798/117150620-e1cbea80-ad92-11eb-8826-454d56a7a091.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
