### PR TITLE
Add bearing to water velocity timeseries csv and ensure timeseries data is ordered

### DIFF
--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -3,9 +3,9 @@
 # Usage: ./runserver.sh <port> <optional_dataset_config_file.json>
 # <optional_dataset_config_file.json>:  Specify a non-default dataset config file to load the Navigator with.
 #                                       Argument not required.
-WORKER_THREADS=5
+WORKER_THREADS=2
 
-[[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
+[[ "$1" == "" ]] && PORT=5000 || PORT=$1
 
 if [ ! -e /usr/bin/nproc ] ; then
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -58,7 +58,6 @@ class NetCDFData(Data):
                     self.dataset = xarray.open_mfdataset(
                         self._nc_files,
                         decode_times=decode_times,
-                        chunks=200,
                     )
                 else:
                     self.dataset = xarray.open_dataset(
@@ -569,8 +568,7 @@ class NetCDFData(Data):
             # Interpolation with gaussian weighting
             if self.interp == "gaussian":
                 return pyresample.kd_tree.resample_gauss(input_def, data,
-                                                         output_def, radius_of_influence=float(self.radius), sigmas=self.radius / 2, fill_value=None,
-                                                         nprocs=8)
+                                                         output_def, radius_of_influence=float(self.radius), sigmas=self.radius / 2, fill_value=None)
 
             # Bilinear weighting
             elif self.interp == "bilinear":

--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -3,7 +3,6 @@
 import itertools
 import re
 import sqlite3
-import numpy as np
 from typing import List
 
 from data.variable import Variable
@@ -51,7 +50,6 @@ class SQLiteDatabase:
         """
 
         file_list = []
-        timestamp_list = []
 
         query = """
         SELECT
@@ -69,16 +67,9 @@ class SQLiteDatabase:
             for v in variable:
                 self.c.execute(query, (v, ts))
                 file_list.append(self.__flatten_list(self.c.fetchall()))
-                timestamp_list.append(str(ts))
 
-        # check if list is properly ordered if it contains multiple nc files:
-        if len(timestamp_list) > 1:       
-            file_list = [f for _,f in sorted(zip(timestamp_list,file_list))]
-
-        # funky way to remove duplicates from the list: https://stackoverflow.com/a/7961390/2231969
-            file_list = list(set(self.__flatten_list(file_list)))
-
-        return file_list 
+        # funky way to remove duplicates while preserving order: https://stackoverflow.com/a/39835527
+        return list(dict.fromkeys(self.__flatten_list(file_list))) 
 
     def get_all_dimensions(self) -> List[str]:
         """Returns a list of all the dimensions in the Dimensions table.

--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -3,6 +3,7 @@
 import itertools
 import re
 import sqlite3
+import numpy as np
 from typing import List
 
 from data.variable import Variable
@@ -50,6 +51,7 @@ class SQLiteDatabase:
         """
 
         file_list = []
+        timestamp_list = []
 
         query = """
         SELECT
@@ -67,9 +69,16 @@ class SQLiteDatabase:
             for v in variable:
                 self.c.execute(query, (v, ts))
                 file_list.append(self.__flatten_list(self.c.fetchall()))
+                timestamp_list.append(str(ts))
+
+        # check if list is properly ordered if it contains multiple nc files:
+        if len(timestamp_list) > 1:       
+            file_list = [f for _,f in sorted(zip(timestamp_list,file_list))]
 
         # funky way to remove duplicates from the list: https://stackoverflow.com/a/7961390/2231969
-        return list(set(self.__flatten_list(file_list)))
+            file_list = list(set(self.__flatten_list(file_list)))
+
+        return file_list 
 
     def get_all_dimensions(self) -> List[str]:
         """Returns a list of all the dimensions in the Dimensions table.

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -3829,9 +3829,9 @@ lodash.words@^3.0.0:
     lodash._root "^3.0.0"
 
 lodash@^4.0.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@~4.17.12:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 longest@^1.0.1:
   version "1.0.1"

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -3000,9 +3000,9 @@ home-or-tmp@^2.0.0:
     os-tmpdir "^1.0.1"
 
 hosted-git-info@^2.1.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 html-comment-regex@^1.1.0:
   version "1.1.2"

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -108,9 +108,9 @@ class TimeseriesPlotter(PointPlotter):
             
             if 'mag' in variable and self.depth != 'all':
                 # Under the current API this indicates that velocity data is being
-                # loaded. Save each velocity component (X and Y) for possible CSV
-                # export later. Only provides velocity components for a single
-                # depth. 
+                # loaded. Save each velocity vectorcomponent (X and Y) for possible 
+                # CSV export later. Currently, we only provide velocity components 
+                # for a single depth. 
 
                 vector_variables = [
                     self.dataset_config.vector_variables[variable]['east_vector_component'],
@@ -164,7 +164,7 @@ class TimeseriesPlotter(PointPlotter):
         have_quiver = hasattr(self, 'quiver_data')
 
         if self.depth != 'all':
-            if isinstance(self.depth, str) or isinstance(self.depth, str):
+            if isinstance(self.depth, str):
                 header.append(["Depth", self.depth])
             else:
                 header.append(

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -119,7 +119,7 @@ class TimeseriesPlotter(PointPlotter):
                     for p in self.points:
                         velocity_data = []
                         if self.depth == 'all':
-                            d, depths = dataset.get_timeseries_profile(
+                            d, velocity_depths = dataset.get_timeseries_profile(
                                 float(p[0]),
                                 float(p[1]),
                                 self.starttime,
@@ -141,16 +141,6 @@ class TimeseriesPlotter(PointPlotter):
 
                     self.quiver_data = velocity_point_data
 
-                """
-                self.quiver_data = [point_data[:, 0, :], point_data[:, 1, :]]
-
-                point_data = np.ma.expand_dims(
-                    np.sqrt(
-                        point_data[:, 0, :] ** 2 + point_data[:, 1, :] ** 2
-                    ), 1
-                )
-                """
-
             self.times = times
             self.data = point_data
             self.depths = depths
@@ -169,17 +159,11 @@ class TimeseriesPlotter(PointPlotter):
             "Time",
         ]
         
+        # Check to see if the quiver attribute is present. If so the CSV export will 
+        # also include X and Y velocity components (pulled from the quiver_data attribute) 
+        # and bearing information (to be calculated below).
         have_quiver = hasattr(self, 'quiver_data')
 
-        # if len(self.variables) > 1:
-        #     # Under the current API this indicates that velocity has been
-        #     # selected, which actually is derived from two variables: X and Y
-        #     # velocities. As such, the CSV export will also include X and Y
-        #     # velocity components (pulled from the quiver_data attribute) and
-        #     # bearing information (to be calculated below).
-        #     have_quiver = hasattr(self, 'quiver_data')
-        # else:
-        #     have_quiver = False
 
         if self.depth != 'all':
             if isinstance(self.depth, str) or isinstance(self.depth, str):
@@ -194,12 +178,8 @@ class TimeseriesPlotter(PointPlotter):
                                         self.variable_unit))
             if have_quiver:
                 columns.extend([
-                    # "%s (%s)" % (self.variable_names[0],
-                    #              self.variable_units[0]),
-                    # "%s (%s)" % (self.variable_names[1],
-                    #              self.variable_units[1]),
-                    " Water East Velocity (m/s)",
-                    " Water North Velocity (m/s)",
+                    "Water East Velocity (m/s)",
+                    "Water North Velocity (m/s)",
                     "Bearing (degrees clockwise positive from North)"
                 ])
         else:
@@ -212,15 +192,15 @@ class TimeseriesPlotter(PointPlotter):
             else:
                 header_text = "%s (%s) %s (%s) %s (%s) %s" % (
                     self.variable_name, self.variable_unit,
-                    # self.variable_names[0], self.variable_units[0],
-                    # self.variable_names[1], self.variable_units[1],
-                    " Water East Velocity", "(m/s)",
-                    " Water North Velocity", "(m/s)",
+                    "Water East Velocity", "(m/s)",
+                    "Water North Velocity", "(m/s)",
                     "Bearing (degrees clockwise positive from North)"
                 )
                 header.append(["Variables", header_text])
-                for var_name in [self.variable_name, self.variable_names[0],
-                                 self.variable_names[1], "Bearing"]:
+                for var_name in [self.variable_name, 
+                                 "Water East Velocity", 
+                                 "Water North Velocity",
+                                 "Bearing"]:
                     for dep in self.depths[:max_dep_idx + 1]:
                         columns.append(
                             "%s at %d%s" % (

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -105,47 +105,46 @@ class TimeseriesPlotter(PointPlotter):
             times = dataset.nc_data.timestamps[starttime_idx: endtime_idx + 1]
             if self.query.get('dataset_quantum') == 'month':
                 times = [datetime.date(x.year, x.month, 1) for x in times]
-
-            if 'mag' in variable:
+            
+            if 'mag' in variable and self.depth != 'all':
                 # Under the current API this indicates that velocity data is being
                 # loaded. Save each velocity component (X and Y) for possible CSV
-                # export later.
+                # export later. Only provides velocity components for a single
+                # depth. 
 
-                velocity_variables = ['vozocrtx', 'vomecrty']
+                vector_variables = [
+                    self.dataset_config.vector_variables[variable]['east_vector_component'],
+                    self.dataset_config.vector_variables[variable]['north_vector_component']
+                ]
 
-                velocity_point_data = []
-                velocity_depths = []
-                for vel_variable in velocity_variables:
+                self.vector_variable_names = self.get_variable_names(dataset, vector_variables)
+                self.vector_variable_units = self.get_variable_units(dataset, vector_variables)
+                                
+                d = []
+                vector_point_data = []
+                for vv in vector_variables:
                     for p in self.points:
-                        velocity_data = []
-                        if self.depth == 'all':
-                            d, velocity_depths = dataset.get_timeseries_profile(
-                                float(p[0]),
-                                float(p[1]),
-                                self.starttime,
-                                self.endtime,
-                                vel_variable
-                            )
-                        else:
-                            d, velocity_depths = dataset.get_timeseries_point(
-                                float(p[0]),
-                                float(p[1]),
-                                self.depth,
-                                self.starttime,
-                                self.endtime,
-                                vel_variable,
-                                return_depth=True
-                            )
-                    velocity_data.append(d)
-                    velocity_point_data.append(np.ma.array(velocity_data))
-
-                    self.quiver_data = velocity_point_data
+                        vector_data = []
+                        
+                        d,_ = dataset.get_timeseries_point(
+                            float(p[0]),
+                            float(p[1]),
+                            self.depth,
+                            self.starttime,
+                            self.endtime,
+                            vv,
+                            return_depth=True
+                        )
+                    
+                    vector_data.append(d)
+                    vector_point_data.append(np.ma.array(vector_data))
+                
+                self.quiver_data = vector_point_data
 
             self.times = times
             self.data = point_data
             self.depths = depths
             self.depth_unit = "m"
-
 
     def csv(self):
         header = [
@@ -164,7 +163,6 @@ class TimeseriesPlotter(PointPlotter):
         # and bearing information (to be calculated below).
         have_quiver = hasattr(self, 'quiver_data')
 
-
         if self.depth != 'all':
             if isinstance(self.depth, str) or isinstance(self.depth, str):
                 header.append(["Depth", self.depth])
@@ -178,8 +176,10 @@ class TimeseriesPlotter(PointPlotter):
                                         self.variable_unit))
             if have_quiver:
                 columns.extend([
-                    "Water East Velocity (m/s)",
-                    "Water North Velocity (m/s)",
+                    "%s (%s)" % (self.vector_variable_names[0],
+                                 self.vector_variable_units[0]),
+                    "%s (%s)" % (self.vector_variable_names[1],
+                                 self.vector_variable_units[1]),
                     "Bearing (degrees clockwise positive from North)"
                 ])
         else:
@@ -192,14 +192,14 @@ class TimeseriesPlotter(PointPlotter):
             else:
                 header_text = "%s (%s) %s (%s) %s (%s) %s" % (
                     self.variable_name, self.variable_unit,
-                    "Water East Velocity", "(m/s)",
-                    "Water North Velocity", "(m/s)",
+                    self.vector_variable_names[0], self.vector_variable_units[0],
+                    self.vector_variable_names[1], self.vector_variable_units[1],
                     "Bearing (degrees clockwise positive from North)"
                 )
                 header.append(["Variables", header_text])
                 for var_name in [self.variable_name, 
-                                 "Water East Velocity", 
-                                 "Water North Velocity",
+                                 self.vector_variable_names[0], 
+                                 self.vector_variable_names[1],
                                  "Bearing"]:
                     for dep in self.depths[:max_dep_idx + 1]:
                         columns.append(

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -110,6 +110,37 @@ class TimeseriesPlotter(PointPlotter):
                 # Under the current API this indicates that velocity data is being
                 # loaded. Save each velocity component (X and Y) for possible CSV
                 # export later.
+
+                velocity_variables = ['vozocrtx', 'vomecrty']
+
+                velocity_point_data = []
+                velocity_depths = []
+                for vel_variable in velocity_variables:
+                    for p in self.points:
+                        velocity_data = []
+                        if self.depth == 'all':
+                            d, depths = dataset.get_timeseries_profile(
+                                float(p[0]),
+                                float(p[1]),
+                                self.starttime,
+                                self.endtime,
+                                vel_variable
+                            )
+                        else:
+                            d, velocity_depths = dataset.get_timeseries_point(
+                                float(p[0]),
+                                float(p[1]),
+                                self.depth,
+                                self.starttime,
+                                self.endtime,
+                                vel_variable,
+                                return_depth=True
+                            )
+                    velocity_data.append(d)
+                    velocity_point_data.append(np.ma.array(velocity_data))
+
+                    self.quiver_data = velocity_point_data
+
                 """
                 self.quiver_data = [point_data[:, 0, :], point_data[:, 1, :]]
 
@@ -137,23 +168,25 @@ class TimeseriesPlotter(PointPlotter):
             "Longitude",
             "Time",
         ]
+        
+        have_quiver = hasattr(self, 'quiver_data')
 
-        if len(self.variables) > 1:
-            # Under the current API this indicates that velocity has been
-            # selected, which actually is derived from two variables: X and Y
-            # velocities. As such, the CSV export will also include X and Y
-            # velocity components (pulled from the quiver_data attribute) and
-            # bearing information (to be calculated below).
-            have_quiver = hasattr(self, 'quiver_data')
-        else:
-            have_quiver = False
+        # if len(self.variables) > 1:
+        #     # Under the current API this indicates that velocity has been
+        #     # selected, which actually is derived from two variables: X and Y
+        #     # velocities. As such, the CSV export will also include X and Y
+        #     # velocity components (pulled from the quiver_data attribute) and
+        #     # bearing information (to be calculated below).
+        #     have_quiver = hasattr(self, 'quiver_data')
+        # else:
+        #     have_quiver = False
 
         if self.depth != 'all':
             if isinstance(self.depth, str) or isinstance(self.depth, str):
                 header.append(["Depth", self.depth])
             else:
                 header.append(
-                    ["Depth", "%.4f%s" % (self.depths,
+                    ["Depth", "%.4f%s" % (self.depth,
                                         self.depth_unit)]
                 )
 
@@ -161,10 +194,12 @@ class TimeseriesPlotter(PointPlotter):
                                         self.variable_unit))
             if have_quiver:
                 columns.extend([
-                    "%s (%s)" % (self.variable_names[0],
-                                 self.variable_units[0]),
-                    "%s (%s)" % (self.variable_names[1],
-                                 self.variable_units[1]),
+                    # "%s (%s)" % (self.variable_names[0],
+                    #              self.variable_units[0]),
+                    # "%s (%s)" % (self.variable_names[1],
+                    #              self.variable_units[1]),
+                    " Water East Velocity (m/s)",
+                    " Water North Velocity (m/s)",
                     "Bearing (degrees clockwise positive from North)"
                 ])
         else:
@@ -177,8 +212,10 @@ class TimeseriesPlotter(PointPlotter):
             else:
                 header_text = "%s (%s) %s (%s) %s (%s) %s" % (
                     self.variable_name, self.variable_unit,
-                    self.variable_names[0], self.variable_units[0],
-                    self.variable_names[1], self.variable_units[1],
+                    # self.variable_names[0], self.variable_units[0],
+                    # self.variable_names[1], self.variable_units[1],
+                    " Water East Velocity", "(m/s)",
+                    " Water North Velocity", "(m/s)",
                     "Bearing (degrees clockwise positive from North)"
                 )
                 header.append(["Variables", header_text])

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -298,7 +298,7 @@ class TestAPIv1(unittest.TestCase):
 
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
-    def test_plot_timeseries_endpoint_all_depths(self, patch_get_data_vars, patch_get_dataset_config):
+    def test_plot_timeseries_endpoint_bottom_depth(self, patch_get_data_vars, patch_get_dataset_config):
 
         patch_get_data_vars.return_value = self.patch_data_vars_ret_val
         patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val


### PR DESCRIPTION
## Background
CCG requested that we include water velocity bearing in timeseries csv's. When working on adding this data to the csv output I also found two other problems that are addressed here:

1. The  `Save Image - CSV` function on the Virtual Mooring window gives an Internal Server Error in all instances.
2. The order of point data in the Virtual Mooring timeseries changed each time I restarted my local Navigator instance which lead to concerns about the integrity of VM data. This was also observed when comparing VM plots on the production and staging sites - recreating the same plot on each produced different results - and when changing the start and end times of the timeseries plots. 

It looks like work on including bearing in the water velocity csv output was started in the past so I built on the existing unfinished code pieces to complete the feature. In the `load_data` function  there was a check for 'mag' in the variable name to see if we were plotting water velocity. Here I added functionality to pull the `vozocrtx` and `vomecrty` data using the `get_timeseries_profile` and 
 `get_timeseries_point` functions then adding it as `self.quiver_data`. When the `csv` function is called it checks for this attribute and if present adds the additional "Water East Velocity", "(m/s)", "Water North Velocity", "(m/s)", "Bearing (degrees clockwise positive from North)" columns to the csv. The code for the calculation work was already present so I leveraged that to create the data.

There other issues turned out to be quick fixes. 1 above was resolved by changing `self.depths` to `self.depth` on line 173. Issue 2 was caused by our use of `list(set(self.__flatten_list(file_list)))` to remove duplicates from the list. Apparently this doesn't preserve the list order (TIL!). As of python 3.5 dictionaries maintain their order so this was changed to `list(dict.fromkeys(self.__flatten_list(file_list)))` which appears to produce nc file lists in a consistent order for the tests that I've run.

## Why did you take this approach?
For the bulk of this work I expanded on a couple areas in the code that appear to be intended for this feature. From there I used our existing functionality to pull the water velocity east and north components so that the bearing could be calculated. 

## Anything in particular that should be highlighted?
I'm assuming that the water velocity vector components will always be `vozocrtx` and `vomecrty`, then hard-coding the additional csv headers as "Water East Velocity (m/s)" and "Water North Velocity (m/s)". This doesn't feel like a good practice but I didn't see a clean way to pull that data from somewhere else. If there's a better way to do this let me know.


## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
