### PR TITLE
Fix mis-named integration test

### DIFF
--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -298,7 +298,7 @@ class TestAPIv1(unittest.TestCase):
 
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
-    def test_plot_timeseries_endpoint_all_depths(self, patch_get_data_vars, patch_get_dataset_config):
+    def test_plot_timeseries_endpoint_bottom_depth(self, patch_get_data_vars, patch_get_dataset_config):
 
         patch_get_data_vars.return_value = self.patch_data_vars_ret_val
         patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val


### PR DESCRIPTION
it was testing bottom depth but was named all_depths...copy paste error from a couple years back

## Background


## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
