### PR TITLE
Some performance tweaks

### DIFF
--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -3,9 +3,9 @@
 # Usage: ./runserver.sh <port> <optional_dataset_config_file.json>
 # <optional_dataset_config_file.json>:  Specify a non-default dataset config file to load the Navigator with.
 #                                       Argument not required.
-WORKER_THREADS=5
+WORKER_THREADS=2
 
-[[ x"$1" == x"" ]] && PORT=5000 || PORT=$1
+[[ "$1" == "" ]] && PORT=5000 || PORT=$1
 
 if [ ! -e /usr/bin/nproc ] ; then
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -58,7 +58,6 @@ class NetCDFData(Data):
                     self.dataset = xarray.open_mfdataset(
                         self._nc_files,
                         decode_times=decode_times,
-                        chunks=200,
                     )
                 else:
                     self.dataset = xarray.open_dataset(
@@ -569,8 +568,7 @@ class NetCDFData(Data):
             # Interpolation with gaussian weighting
             if self.interp == "gaussian":
                 return pyresample.kd_tree.resample_gauss(input_def, data,
-                                                         output_def, radius_of_influence=float(self.radius), sigmas=self.radius / 2, fill_value=None,
-                                                         nprocs=8)
+                                                         output_def, radius_of_influence=float(self.radius), sigmas=self.radius / 2, fill_value=None)
 
             # Bilinear weighting
             elif self.interp == "bilinear":


### PR DESCRIPTION
## Background

* Remove `chunks` parameter from open_mfdataset.
* Removed `num_procs` parameter from `resample_gauss`.
* Reduce `WORKER_THREADS` in `runserver.py` from 5 to 2.
* Configure global dask settings on startup to conditionally read vars from cfg file or set sane default otherwise

Related to https://github.com/DFO-Ocean-Navigator/configurations/pull/23

## Why did you take this approach?
Just following Doug's findings.

## Anything in particular that should be highlighted?

Total system thread count has dropped by about by ~15% with these changes with no perceivable difference in website loading speed.

## Screenshot(s)
n/a

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
