### PR TITLE
Add bearing to magnitude timeseries csv and ensure timeseries data is ordered 

### DIFF
--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -63,13 +63,13 @@ class SQLiteDatabase:
             variable = ?
             AND timestamp = ?;
         """
-        for ts in timestamp:
+        for ts in sorted(timestamp):
             for v in variable:
                 self.c.execute(query, (v, ts))
                 file_list.append(self.__flatten_list(self.c.fetchall()))
 
-        # funky way to remove duplicates from the list: https://stackoverflow.com/a/7961390/2231969
-        return list(set(self.__flatten_list(file_list)))
+        # funky way to remove duplicates while preserving order: https://stackoverflow.com/a/39835527
+        return list(dict.fromkeys(self.__flatten_list(file_list))) 
 
     def get_all_dimensions(self) -> List[str]:
         """Returns a list of all the dimensions in the Dimensions table.

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -126,7 +126,7 @@ class TimeseriesPlotter(PointPlotter):
                     for p in self.points:
                         vector_data = []
                         
-                        d,_ = dataset.get_timeseries_point(
+                        d, _ = dataset.get_timeseries_point(
                             float(p[0]),
                             float(p[1]),
                             self.depth,
@@ -161,7 +161,7 @@ class TimeseriesPlotter(PointPlotter):
         # Check to see if the quiver attribute is present. If so the CSV export will 
         # also include X and Y velocity components (pulled from the quiver_data attribute) 
         # and bearing information (to be calculated below).
-        have_quiver = hasattr(self, 'quiver_data')
+        has_quiver = hasattr(self, 'quiver_data')
 
         if self.depth != 'all':
             if isinstance(self.depth, str):
@@ -174,7 +174,7 @@ class TimeseriesPlotter(PointPlotter):
 
             columns.append("%s (%s)" % (self.variable_name,
                                         self.variable_unit))
-            if have_quiver:
+            if has_quiver:
                 columns.extend([
                     "%s (%s)" % (self.vector_variable_names[0],
                                  self.vector_variable_units[0]),
@@ -184,7 +184,7 @@ class TimeseriesPlotter(PointPlotter):
                 ])
         else:
             max_dep_idx = np.where(~self.data[:, 0, 0, :].mask)[1].max()
-            if not have_quiver:
+            if not has_quiver:
                 header.append(["Variable", "%s (%s)" % (self.variable_name,
                                                         self.variable_unit)])
                 for dep in self.depths[:max_dep_idx + 1]:
@@ -198,8 +198,7 @@ class TimeseriesPlotter(PointPlotter):
                 )
                 header.append(["Variables", header_text])
                 for var_name in [self.variable_name, 
-                                 self.vector_variable_names[0], 
-                                 self.vector_variable_names[1],
+                                 *self.vector_variable_names, 
                                  "Bearing"]:
                     for dep in self.depths[:max_dep_idx + 1]:
                         columns.append(
@@ -208,7 +207,7 @@ class TimeseriesPlotter(PointPlotter):
                             )
                         )
 
-        if have_quiver:
+        if has_quiver:
             # Calculate bearings.
             bearing = np.arctan2(self.quiver_data[1][:],
                                  self.quiver_data[0][:])
@@ -238,7 +237,7 @@ class TimeseriesPlotter(PointPlotter):
                 if self.depth == 'all':
                     entry.extend(
                         ["%0.3f" % f for f in self.data[p, 0, t, :max_dep_idx + 1]])
-                    if have_quiver:
+                    if has_quiver:
                         entry.extend(
                             ["%0.3f" % f for f in self.quiver_data[0][p, t, :max_dep_idx + 1]])
                         entry.extend(
@@ -247,7 +246,7 @@ class TimeseriesPlotter(PointPlotter):
                             ["%0.3f" % f for f in bearing[p, t, :max_dep_idx + 1]])
                 else:
                     entry.append("%0.3f" % self.data[p, 0, t])
-                    if have_quiver:
+                    if has_quiver:
                         entry.extend([
                             "%0.3f" % self.quiver_data[0][p, t],
                             "%0.3f" % self.quiver_data[1][p, t],


### PR DESCRIPTION
**Resubmission of PR#843 to avoid messy commit history

## Background
CCG requested that we include water velocity bearing in timeseries csv's. When working on adding this data to the csv output I also found two other problems that are addressed here:

1. The  `Save Image - CSV` function on the Virtual Mooring window gives an Internal Server Error in all instances.
2. The order of point data in the Virtual Mooring timeseries changed each time I restarted my local Navigator instance which lead to concerns about the integrity of VM data. This was also observed when comparing VM plots on the production and staging sites - recreating the same plot on each produced different results - and when changing the start and end times of the timeseries plots. 

It looks like work on including bearing in the water velocity csv output was started in the past so I built on the existing unfinished code pieces to complete the feature. In the `load_data` function  there was a check for 'mag' in the variable name to see if we were plotting water velocity. Here I added functionality to pull the east and north velocity component data using the 
 `get_timeseries_point` function then adding it as `self.quiver_data`. When the `csv` function is called it checks for this attribute and if present adds additional columns for the east and north vector components and bearing data to the csv. The code for the calculation work was already present so I leveraged that to create the data. The csv output does not include the east and north vectors when saving a csv of the whole water column. We can reverse this in the future if requested by end-users pretty easily. 

There other issues turned out to be quick fixes. 1 above was resolved by changing `self.depths` to `self.depth` on line 173. Issue 2 was caused using unsorted timestamps to get the nc file list then applying `list(set(self.__flatten_list(file_list)))` to remove duplicates from the list. Apparently this doesn't preserve the list order (TIL!). As of python 3.5 dictionaries maintain their order so this was changed to `list(dict.fromkeys(self.__flatten_list(file_list)))` which appears to produce nc file lists in a consistent order for the tests that I've run.

## Why did you take this approach?
This gets the east and north vector components using 
`self.dataset_config.vector_variables[variable]['east_vector_component'], self.dataset_config.vector_variables[variable]['north_vector_component']` 
which should work for all magnitude variables since these attributes are given for all 'mag' varaibles. Once the additional data is collected I use the previously developed code to calculate the bearing for the csv output.  

## Anything in particular that should be highlighted?
I extracted timeseries data directly from the netCDF files to validate that the order is correct which it was for the datasets I tested against. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
