### PR TITLE
Select JS packages have been updated due to security alerts

### DIFF
--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -21,6 +21,7 @@
     "babel-preset-react-optimize": "1.0.1",
     "bootstrap": "^3.3.7",
     "bower": "^1.8.8",
+    "css-what": "^5.0.1",
     "dateformat": "^2.0.0",
     "deep-equal": "^2.0.1",
     "detect-browser": "^1.7.0",
@@ -30,6 +31,7 @@
     "font-awesome": "^4.7.0",
     "i18next": "^8.4.2",
     "i18next-browser-languagedetector": "^2.0.0",
+    "is-svg": "^4.2.2",
     "jquery": "~3.5.0",
     "jquery-ui": "^1.12.1",
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",
@@ -49,7 +51,9 @@
     "react-ga": "^2.5.3",
     "react-iframe": "1.0.7",
     "react-numeric-input": "^2.2.3",
-    "webfontloader": "^1.6.28"
+    "trim-newlines": "^3.0.1",
+    "webfontloader": "^1.6.28",
+    "yargs-parser": "^5.0.0-security.0"
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -1800,6 +1800,11 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css-what@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
+
 css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -2590,6 +2595,11 @@ fast-stable-stringify@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz#5c5543462b22aeeefd36d05b34e51c78cb86d313"
   integrity sha1-XFVDRisiru79NtBbNOUceMuG0xM=
+
+fast-xml-parser@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
 fastparse@^1.1.1, fastparse@^1.1.2:
   version "1.1.2"
@@ -3414,6 +3424,13 @@ is-svg@^2.0.0:
   integrity sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=
   dependencies:
     html-comment-regex "^1.1.0"
+
+is-svg@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
+  integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
+  dependencies:
+    fast-xml-parser "^3.19.0"
 
 is-symbol@^1.0.2:
   version "1.0.3"
@@ -6293,6 +6310,11 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
+trim-newlines@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -6754,6 +6776,14 @@ yargs-parser@^4.2.0:
   integrity sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=
   dependencies:
     camelcase "^3.0.0"
+
+yargs-parser@^5.0.0-security.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.1.tgz#7ede329c1d8cdbbe209bd25cdb990e9b1ebbb394"
+  integrity sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==
+  dependencies:
+    camelcase "^3.0.0"
+    object.assign "^4.1.0"
 
 yargs@^6.0.0:
   version "6.6.0"


### PR DESCRIPTION
The following JS packages have been updated due to security alerts;
 
  * css-what@2.1 ==> css-what@^5.0.1
   * is-svg@^2.0.0 ==> is-svg@^4.2.2
   * trim-newlines@^1.0.0 ==> trim-newlines@^3.0.1
   * yargs-parser@^4.2.0 ==> yargs-parser@^5.0.0-security.0