### PR TITLE
Add schemas to some endpoints

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -46,7 +46,7 @@ from plotting.ts import TemperatureSalinityPlotter
 from shapely.geometry import LinearRing, Point, Polygon
 from utils.errors import APIError, ClientError, ErrorBase
 
-from .schemas import GetDataSchema
+from .schemas import GetDataSchema, QuantumSchema
 
 bp_v1_0 = Blueprint('api_v1_0', __name__)
 
@@ -153,20 +153,19 @@ def quantum_query_v1_0():
 
     API Format: /api/v1.0/quantum/
 
-    Raises:
-        APIError: If `dataset` is not present in API arguments.
+    Required parameters:
+    * dataset       : Dataset key (e.g. giops_day) - can be found using /api/v1.0/datasets/
 
     Returns:
         Response -- Response object containing the dataset quantum string as JSON.
     """
 
-    args = request.args
+    try:
+        result = QuantumSchema().load(request.args)
+    except ValidationError as e:
+        abort(400, str(e))
 
-    if 'dataset' not in args:
-        raise APIError("Please specify a dataset Using ?dataset='...' ")
-
-    dataset = args.get('dataset')
-    config = DatasetConfig(dataset)
+    config = DatasetConfig(result['dataset'])
 
     quantum = config.quantum
 

--- a/routes/schemas/__init__.py
+++ b/routes/schemas/__init__.py
@@ -1,1 +1,2 @@
 from .get_data_schema import GetDataSchema
+from .quantum_schema import QuantumSchema

--- a/routes/schemas/__init__.py
+++ b/routes/schemas/__init__.py
@@ -1,2 +1,3 @@
 from .get_data_schema import GetDataSchema
 from .quantum_schema import QuantumSchema
+from .depth_schema import DepthSchema

--- a/routes/schemas/__init__.py
+++ b/routes/schemas/__init__.py
@@ -1,3 +1,4 @@
 from .get_data_schema import GetDataSchema
 from .quantum_schema import QuantumSchema
 from .depth_schema import DepthSchema
+from .timestamps_schema import TimestampsSchema

--- a/routes/schemas/depth_schema.py
+++ b/routes/schemas/depth_schema.py
@@ -1,0 +1,14 @@
+from marshmallow import Schema, fields
+
+class DepthSchema(Schema):
+    """
+    Defines the schema for the `/api/v1.0/depth?...`
+    endpoint.
+
+    * dataset: dataset key (e.g. giops_day)
+    * variable: variable key (e.g. votemper)
+    """
+
+    dataset = fields.Str(required=True)
+    variable = fields.Str(required=True)
+    all = fields.Str(required=False)

--- a/routes/schemas/quantum_schema.py
+++ b/routes/schemas/quantum_schema.py
@@ -1,0 +1,11 @@
+from marshmallow import Schema, fields
+
+class QuantumSchema(Schema):
+    """
+    Defines the schema for the `/api/v1.0/quantum?...`
+    endpoint.
+
+    * dataset: dataset key (e.g. giops_day)
+    """
+
+    dataset = fields.Str(required=True)

--- a/routes/schemas/timestamps_schema.py
+++ b/routes/schemas/timestamps_schema.py
@@ -1,0 +1,13 @@
+from marshmallow import Schema, fields
+
+class TimestampsSchema(Schema):
+    """
+    Defines the schema for the `/api/v1.0/timestamps?...`
+    endpoint.
+
+    * dataset: dataset key (e.g. giops_day)
+    * variable: variable key (e.g. votemper)
+    """
+
+    dataset = fields.Str(required=True)
+    variable = fields.Str(required=True)

--- a/tests/routes/schemas/test_depth_schema.py
+++ b/tests/routes/schemas/test_depth_schema.py
@@ -1,0 +1,26 @@
+"""Unit tests for routes.schemas.depth_schema
+"""
+import unittest
+
+from routes.schemas.depth_schema import DepthSchema
+
+
+class DepthSchemaTest(unittest.TestCase):
+
+    def test_depth_schema_validates_inputs(self) -> None:
+        valid_inputs = {
+            "dataset": "some_dataset",
+            "variable": "my_var",
+            "all": "yes"
+        }
+
+        errors = DepthSchema().validate(valid_inputs)
+
+        self.assertFalse(errors)
+
+    def test_depth_schema_returns_errors_with_missing_args(self) -> None:
+
+        errors = DepthSchema().validate({})
+
+        self.assertTrue(errors)
+        self.assertEqual(2, len(errors))

--- a/tests/routes/schemas/test_quantum_schema.py
+++ b/tests/routes/schemas/test_quantum_schema.py
@@ -1,0 +1,25 @@
+"""Unit tests for routes.schemas.get_data_schema
+"""
+import unittest
+from operator import le
+
+from routes.schemas.quantum_schema import QuantumSchema
+
+
+class QuantumSchemaTest(unittest.TestCase):
+
+    def test_quantum_schema_validates_inputs(self) -> None:
+        valid_inputs = {
+            "dataset": "some_dataset"
+        }
+
+        errors = QuantumSchema().validate(valid_inputs)
+
+        self.assertFalse(errors)
+
+    def test_quantum_schema_returns_errors_with_missing_args(self) -> None:
+
+        errors = QuantumSchema().validate({})
+
+        self.assertTrue(errors)
+        self.assertEqual(1, len(errors))

--- a/tests/routes/schemas/test_quantum_schema.py
+++ b/tests/routes/schemas/test_quantum_schema.py
@@ -1,7 +1,6 @@
-"""Unit tests for routes.schemas.get_data_schema
+"""Unit tests for routes.schemas.quantum_schema
 """
 import unittest
-from operator import le
 
 from routes.schemas.quantum_schema import QuantumSchema
 

--- a/tests/routes/schemas/test_timestamps_schema.py
+++ b/tests/routes/schemas/test_timestamps_schema.py
@@ -1,0 +1,25 @@
+"""Unit tests for routes.schemas.timestamps_schema
+"""
+import unittest
+
+from routes.schemas.timestamps_schema import TimestampsSchema
+
+
+class TimestampsSchemaTest(unittest.TestCase):
+
+    def test_timestamps_schema_validates_inputs(self) -> None:
+        valid_inputs = {
+            "dataset": "some_dataset",
+            "variable": "my_var"
+        }
+
+        errors = TimestampsSchema().validate(valid_inputs)
+
+        self.assertFalse(errors)
+
+    def test_timestamps_schema_returns_errors_with_missing_args(self) -> None:
+
+        errors = TimestampsSchema().validate({})
+
+        self.assertTrue(errors)
+        self.assertEqual(2, len(errors))


### PR DESCRIPTION
## Background

Make our API self-documenting.

Builds on the work of the first schema-ed API endpoint being `/data`.

Adds `marshmallow` schemas to the following API endpoints:
* `quantum`
* `timestamps`
* `depth`

## Why did you take this approach?
* There are other query-based endpoints but they're not as easy to apply a schema too since I'm not 100% sure what they're types are supposed to be.
* Followed the same approach as I did in the `/data` endpoint.

## Anything in particular that should be highlighted?
These schemas will auto-generate and return helpful error messages to the user in the event they mess up:
![image](https://user-images.githubusercontent.com/5572045/124849726-e02cc780-df79-11eb-9f94-9f6168aeaaea.png)


## Screenshot(s)
No change to user-facing website:
![image](https://user-images.githubusercontent.com/5572045/124849702-d2774200-df79-11eb-85c6-f6d0014eb02f.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
