### PR TITLE
Exclude unknown fields in TimestampsSchema

### DIFF
--- a/routes/schemas/timestamps_schema.py
+++ b/routes/schemas/timestamps_schema.py
@@ -1,4 +1,5 @@
-from marshmallow import Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
+
 
 class TimestampsSchema(Schema):
     """
@@ -8,6 +9,9 @@ class TimestampsSchema(Schema):
     * dataset: dataset key (e.g. giops_day)
     * variable: variable key (e.g. votemper)
     """
+
+    class Meta:
+        unknown = EXCLUDE # workaround for hidden "_" field being sent by jQuery
 
     dataset = fields.Str(required=True)
     variable = fields.Str(required=True)


### PR DESCRIPTION
## Background

#857 exposed a frontend bug (surprise surprise) where jQuery is sending a hidden `_=1625711072192` parameter as part of the timestamps payload in `TimePicker.jsx`....not sure why it's doing that. Anyway there's no further security risk as we just silently ignore this unknown value. 

By default `marshmallow` raises an error when it encounters a URL parameter that hasn't been explicitly defined in the schema...a security feature. We've been accepting anything and everything up to this point so this bug has probably been around for several years...

## Why did you take this approach?

* Followed: https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields

## Anything in particular that should be highlighted?
Tests would have never caught this anyway because this might be a jQuery bug...

## Screenshot(s)
Works now (note the `_` field on the right side of the URL):
![image](https://user-images.githubusercontent.com/5572045/124853900-32bdb200-df81-11eb-987e-fe01802421a4.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
