### PR TITLE
Add schema to generatescript endpoint

### DIFF
--- a/routes/schemas/__init__.py
+++ b/routes/schemas/__init__.py
@@ -2,3 +2,4 @@ from .get_data_schema import GetDataSchema
 from .quantum_schema import QuantumSchema
 from .depth_schema import DepthSchema
 from .timestamps_schema import TimestampsSchema
+from .generate_script_schema import GenerateScriptSchema

--- a/routes/schemas/generate_script_schema.py
+++ b/routes/schemas/generate_script_schema.py
@@ -1,0 +1,16 @@
+from marshmallow import Schema, fields
+from marshmallow.validate import OneOf
+
+class GenerateScriptSchema(Schema):
+    """
+    Defines the schema for the `/api/v1.0/generatescript?...`
+    endpoint.
+
+    * query: URI encoded string for the API script
+    * lang: target language (python or r)
+    * scriptType: type of requested script (PLOT or CSV)
+    """
+
+    query = fields.Str(required=True)
+    lang = fields.Str(required=True, validate=OneOf({"python", "r"}))
+    scriptType = fields.Str(required=True, validate=OneOf({"PLOT", "CSV"}))

--- a/tests/routes/schemas/test_generate_script_schema.py
+++ b/tests/routes/schemas/test_generate_script_schema.py
@@ -1,0 +1,40 @@
+"""Unit tests for routes.schemas.generate_script_schema
+"""
+import unittest
+
+from routes.schemas.generate_script_schema import GenerateScriptSchema
+
+
+class GenerateScriptSchemaTest(unittest.TestCase):
+
+    def test_generate_script_schema_validate_input(self) -> None:
+        valid_inputs = {
+            "query": "adsfasdf",
+            "lang": "python",
+            "scriptType": "PLOT"
+        }
+
+        errors = GenerateScriptSchema().validate(valid_inputs)
+
+        self.assertFalse(errors)
+
+    def test_generate_script_schema_returns_errors_with_missing_args(self) -> None:
+
+        errors = GenerateScriptSchema().validate({})
+
+        self.assertTrue(errors)
+        self.assertEqual(3, len(errors))
+    
+    def test_generate_script_schema_returns_errors_with_wrong_values(self) -> None:
+        args = {
+            "query": "asddasf",
+            "lang": "c++",
+            "scriptType": "stats_table"
+        }
+
+        errors = GenerateScriptSchema().validate(args)
+
+        self.assertTrue(errors)
+        self.assertEqual(2, len(errors))
+        self.assertTrue('lang' in errors)
+        self.assertTrue('scriptType' in errors)

--- a/tests/routes/test_api_v_1_0_generatescript.py
+++ b/tests/routes/test_api_v_1_0_generatescript.py
@@ -1,0 +1,43 @@
+"""Integration tests for API v1.0 endpoint /generatescript
+"""
+import unittest
+
+from oceannavigator import create_app
+
+app = create_app(testing=True)
+
+class TestApiv10GenerateScript(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.app = app.test_client()
+
+        self.langs: list = ['python', 'r']
+
+    def test_generatescript_endpoint_for_plot_script_type(self) -> None:
+
+        for l in self.langs:
+            res = self.app.get(
+                '/api/v1.0/generatescript/',
+                query_string= {
+                    "query": {"dataset":"giops_day","names":[],"plotTitle":"","quantum":"day","showmap":False,"station":[[48.26684109261785,-45.12499928474428]],"time":2257761600,"type":"profile","variable":["votemper"]},
+                    "lang": l,
+                    "scriptType": "PLOT"
+                }
+            )
+        
+            self.assertEqual(res.status_code, 200)
+
+    @unittest.skip('Missing CSV template for R...')
+    def test_generatescript_endpoint_for_csv_script_type(self) -> None:
+
+        for l in self.langs:
+            res = self.app.get(
+                '/api/v1.0/generatescript/',
+                query_string= {
+                    "query": {"dataset":"giops_day","names":[],"plotTitle":"","quantum":"day","showmap":False,"station":[[48.26684109261785,-45.12499928474428]],"time":2257761600,"type":"profile","variable":["votemper"]},
+                    "lang": l,
+                    "scriptType": "CSV"
+                }
+            )
+        
+            self.assertEqual(res.status_code, 200)

--- a/tests/test_api_v_1_0.py
+++ b/tests/test_api_v_1_0.py
@@ -174,15 +174,6 @@ class TestAPIv1(unittest.TestCase):
         res = self.app.get('/api/v1.0/')
         self.assertEqual(res.status_code, 400)
 
-
-    @patch.object(DatasetConfig, "_get_dataset_config")
-    @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
-    def test_generatescript_endpoint(self, patch_get_data_vars, patch_get_dataset_config):
-        patch_get_data_vars.return_value = self.patch_data_vars_ret_val
-        patch_get_dataset_config.return_value = self.patch_dataset_config_ret_val
-        res = self.app.get(self.apiLinks['generatescript'])
-        self.assertEqual(res.status_code, 200)
-
     @patch.object(DatasetConfig, "_get_dataset_config")
     @patch('data.sqlite_database.SQLiteDatabase.get_data_variables')
     def test_range_endpoint(self, patch_get_data_vars, patch_get_dataset_config):


### PR DESCRIPTION
## Background

Building on the work in #853 

* As the title says.

* Re-write integration test for this endpoint too (`python -m unittest tests/routes/test_api_v_1_0_generatescript.py`)

## Why did you take this approach?
Same as #857 

## Anything in particular that should be highlighted?
* One test in `tests/routes/test_api_v_1_0_generatescript.py` is skipped because @BaruaSourav is working on the template for R CSV downloads.

## Screenshot(s)

Checked download buttons for python and R:

![image](https://user-images.githubusercontent.com/5572045/125001712-d795c900-e02d-11eb-9ff9-f97119b23b6b.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
