### PR TITLE
Update `ol` from 6.5.0 to latest 6.6.1 & conditionally force a refresh of map's vector source

### DIFF
--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -34,7 +34,7 @@
     "jquery": "~3.5.0",
     "jquery-ui": "^1.12.1",
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",
-    "ol": "^6.5.0",
+    "ol": "^6.6.1",
     "papaparse": "^5.2.0",
     "proj4": "~2.4.3",
     "prop-types": "^15.5.10",

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -1394,6 +1394,13 @@ export default class Map extends React.PureComponent {
     this.layer_quiver.setSource(source);
   }
 
+  shouldRefreshVectorSource(currentVectorType, prevVectorType, 
+    currentVectorId, prevVectorId) 
+  {
+    return (currentVectorType !== prevVectorType) || 
+            (currentVectorId !== prevVectorId);
+  }
+
   componentDidUpdate(prevProps, prevState) {
     const datalayer = this.map.getLayers().getArray()[1];
     const old = datalayer.getSource();
@@ -1554,15 +1561,25 @@ export default class Map extends React.PureComponent {
     this.layer_bath.setOpacity(this.props.options.mapBathymetryOpacity);
     this.layer_bath.setVisible(this.props.options.bathymetry);
 
+    if (this.shouldRefreshVectorSource(
+      this.props.state.vectortype,
+      prevProps.state.vectortype,
+      this.props.state.vectorid,
+      prevProps.state.vectorid
+    )) 
+    {
+      this.vectorSource.refresh();
+    }
+
     this.map.render();
   }
 
   refreshFeatures(e) {
-    var extent = this.mapView.calculateExtent(this.map.getSize());
-    var resolution = this.mapView.getResolution();
+    const extent = this.mapView.calculateExtent(this.map.getSize());
+    const resolution = this.mapView.getResolution();
 
     if (this.vectorSource.getState() == "ready") {
-      var dorefresh = this.vectorSource.forEachFeatureIntersectingExtent(
+      const dorefresh = this.vectorSource.forEachFeatureIntersectingExtent(
         extent,
         function (f) {
           return f.get("resolution") > Math.round(resolution);
@@ -1570,7 +1587,7 @@ export default class Map extends React.PureComponent {
       );
 
       if (dorefresh) {
-        var projection = this.mapView.getProjection();
+        const projection = this.mapView.getProjection();
         this.loader(extent, resolution, projection);
       }
     }

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -85,10 +85,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
 
-"@mapbox/mapbox-gl-style-spec@^13.14.0":
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.0.tgz#232ab247cf43f3b4b9a9116e00f45c2c2878aa77"
-  integrity sha512-66d9vIPuKDI5IKq/l6s+oTD2DIufo+ONyQ9TZ5muGPJ/scO7ZJ+aWOLUjV1RUsgRqgJCq3a4Ba8Z0fDOWRcxKQ==
+"@mapbox/mapbox-gl-style-spec@^13.20.1":
+  version "13.20.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.1.tgz#bcf7c42836025a831a76a1e1348ea549c36daf55"
+  integrity sha512-xVCJ3IbKoPwcPrxxtGAxUqHEVxXi1hnJtLIFqgkuZfnzj0KeRbk3dZlDr/KNo1/doJjIoFgPFUO/HMOT+wXGPA==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "~2.0.2"
     "@mapbox/point-geometry" "^0.1.0"
@@ -4383,21 +4383,21 @@ object.values@^1.1.4:
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
 
-ol-mapbox-style@^6.1.1:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/ol-mapbox-style/-/ol-mapbox-style-6.3.2.tgz#5cd1cbb41ecd697d3488fd928976def108a41d3b"
-  integrity sha512-itWZuwZHilztRM9983WmJ+ounaXIS0PdXF8h5xJd7cJhSv02M27w4RQkhiUw35/VLlUdTT/ei3KYi0w2TGDw2A==
+ol-mapbox-style@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz#3c0dd674430670d00fa98f9a291026e17fa47664"
+  integrity sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==
   dependencies:
-    "@mapbox/mapbox-gl-style-spec" "^13.14.0"
+    "@mapbox/mapbox-gl-style-spec" "^13.20.1"
     mapbox-to-css-font "^2.4.0"
     webfont-matcher "^1.1.0"
 
-ol@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/ol/-/ol-6.5.0.tgz#d9cd59081ac34dc4caf0509c3f667748a8207a21"
-  integrity sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==
+ol@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/ol/-/ol-6.6.1.tgz#eba3b2bd5c2f6d4f24f4ddcb713523bd3a13234f"
+  integrity sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==
   dependencies:
-    ol-mapbox-style "^6.1.1"
+    ol-mapbox-style "^6.4.1"
     pbf "3.2.1"
     rbush "^3.0.1"
 


### PR DESCRIPTION
to ensure pre-defined points, lines, and areas are rendered when clicked

## Background
Justin and Sourav noticed recently that when a user clicks on an item in the pre-defined point, line, and area menus, nothing is rendered on the main map unless the user pans/drags the map with their mouse (i.e. telling OpenLayers to refresh all map layers based on a request for an "animation frame"). At some point in the past, OpenLayers implemented an optimization to perform conditional map updates based on some arbitrary conditions, so when we updated to ol 6, we silently inherited this behaviour :facepalm: 

This PR restores the initial functionality we had where data is immediately drawn on the map when clicked.
* Also updates `ol` to it's latest version. The updates include some performance improvements to vector tile rendering and some other internal bugfixes: https://github.com/openlayers/openlayers/releases/tag/v6.6.1

## Why did you take this approach?
Found inspiration here after a boat load of debugging and stack tracing :facepalm: : https://stackoverflow.com/a/60731286/2231969

Followed a similar pattern of conditional updates that I used with other map features in `componentDidUpdate`. If `shouldRefreshVectorSource` is not there, we'd infinite loop.


## Anything in particular that should be highlighted?
I don't like how OpenLayers just randomly changes underlying behaviour without telling us in the release notes.

## Screenshot(s)
Upon clicking a pre-defined item, the map is immediately updated to display the data.

![image](https://user-images.githubusercontent.com/5572045/127774455-507cb456-4a23-4068-97cb-5364e2f674cf.png)

![image](https://user-images.githubusercontent.com/5572045/127774424-2d5e7ec1-cb6e-419e-9d3d-a89a6e7cf847.png)

![image](https://user-images.githubusercontent.com/5572045/127774438-2e8bf551-6284-4ea8-8274-135ee7656508.png)




## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
