### PR TITLE
Explicitly set projection of hi-res bathy layer in Map `componentDidUpdate`

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -1490,6 +1490,7 @@ export default class Map extends React.PureComponent {
           tileGrid: this.vectorTileGrid,
           tilePixelRatio: 8,
           url: `/api/v1.0/mbt/${this.props.state.projection}/bath/{z}/{x}/{y}`,
+          projection: this.props.state.projection
         })
       );
 
@@ -1535,6 +1536,7 @@ export default class Map extends React.PureComponent {
             tileGrid: this.vectorTileGrid,
             tilePixelRatio: 8,
             url: `/api/v1.0/mbt/${this.props.state.projection}/bath/{z}/{x}/{y}`,
+            projection: this.props.state.projection
           })
         );
 


### PR DESCRIPTION
## Background

Resolves a crash in OpenLayers where error 68 was thrown in the javascript console and a black map screen was displayed for Arctic and Antarctic projections.

https://openlayers.org/en/latest/doc/errors/#68


## Why did you take this approach?

Only way to fix this. Guessed that this argument is now explicit and guess I was right lmfao.

## Anything in particular that should be highlighted?
Nope.

## Screenshot(s)
Arctic:
![image](https://user-images.githubusercontent.com/5572045/128438283-e415fb82-cf67-43aa-9c18-0fb34a959955.png)


Antarctic:
![image](https://user-images.githubusercontent.com/5572045/128438205-7b02337a-feb7-4b9f-9e88-370fd5c5195f.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
