### PR TITLE
Fix images loaded via webpack failing to load

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -22,19 +22,19 @@ require("ol/ol.css");
 
 const i18n = require("../i18n.js");
 const SmartPhone = require("detect-mobile-browser")(false);
-const X_IMAGE = require("../images/x.png");
+const X_IMAGE = require("../images/x.png").default;
 
 // CHS S111 standard arrows for quiver layer
-const I0 = require("../images/s111/I0.svg"); // lgtm [js/unused-local-variable]
-const I1 = require("../images/s111/I1.svg");
-const I2 = require("../images/s111/I2.svg");
-const I3 = require("../images/s111/I3.svg");
-const I4 = require("../images/s111/I4.svg");
-const I5 = require("../images/s111/I5.svg");
-const I6 = require("../images/s111/I6.svg");
-const I7 = require("../images/s111/I7.svg");
-const I8 = require("../images/s111/I8.svg");
-const I9 = require("../images/s111/I9.svg");
+const I0 = require("../images/s111/I0.svg").default; // lgtm [js/unused-local-variable]
+const I1 = require("../images/s111/I1.svg").default;
+const I2 = require("../images/s111/I2.svg").default;
+const I3 = require("../images/s111/I3.svg").default;
+const I4 = require("../images/s111/I4.svg").default;
+const I5 = require("../images/s111/I5.svg").default;
+const I6 = require("../images/s111/I6.svg").default;
+const I7 = require("../images/s111/I7.svg").default;
+const I8 = require("../images/s111/I8.svg").default;
+const I9 = require("../images/s111/I9.svg").default;
 
 function knotsToMetersPerSecond(knots) {
   return knots * 0.514444;

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -23,7 +23,7 @@ import {
 
 const i18n = require("../i18n.js");
 const stringify = require("fast-stable-stringify");
-const LOADING_IMAGE = require("../images/bar_loader.gif");
+const LOADING_IMAGE = require("../images/bar_loader.gif").default;
 
 function formatLatLon(latitude, longitude) {
   let formatted = "";

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -14,7 +14,7 @@ import PropTypes from "prop-types";
 const i18n = require("../i18n.js");
 const stringify = require("fast-stable-stringify");
 const FAIL_IMAGE = require("./fail.js");
-const LOADING_IMAGE = require("../images/spinner.gif");
+const LOADING_IMAGE = require("../images/spinner.gif").default;
 
 export default class PlotImage extends React.PureComponent {
   constructor(props) {

--- a/oceannavigator/frontend/src/components/fail.js
+++ b/oceannavigator/frontend/src/components/fail.js
@@ -4,11 +4,11 @@
 var fail;
 
 if (process.env.NODE_ENV == "production") {
-  fail = require("../images/sad-computer.png");
+  fail = require("../images/sad-computer.png").default;
 } 
 else {
   // We're in dev environment.
-  fail = require("../images/failure.gif");
+  fail = require("../images/failure.gif").default;
 }
 
 module.exports = fail;


### PR DESCRIPTION
## Background
A change to the interaction between Babel and Webpack caused our images loaded via require to break silently.

## Why did you take this approach?
Only way.

## Anything in particular that should be highlighted?
JS sucks

## Screenshot(s)

Images show up again:
![image](https://user-images.githubusercontent.com/5572045/128439905-4bdafde5-3460-4182-a5ce-4c54f97334bd.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
