### PR TITLE
Re-enable main map quiver arrows

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -578,6 +578,7 @@ export default class AreaWindow extends React.Component {
             state={this.state.dataset_0} 
             onUpdate={this.onLocalUpdate}
             depth={true}
+            showQuiverSelector={false}
           />
 
           <div style={{"display": this.state.currentTab == 1 ? "block" : "none"}}>
@@ -622,8 +623,11 @@ export default class AreaWindow extends React.Component {
               <DatasetSelector
                 key='dataset_1'
                 id='dataset_1'
+                multiple={this.state.currentTab === 2}
                 state={this.props.dataset_1}
                 onUpdate={this.props.onUpdate}
+                depth={true}
+                showQuiverSelector={false}
               />
 
               <Range

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -140,13 +140,26 @@ export default class DatasetSelector extends React.Component {
       ];  
     }
 
-    let quiverVariables = [];
-    if (this.props.datasetVariables) {
-      quiverVariables = this.props.datasetVariables.filter((variable) => {
-        return variable.id.includes("mag") && variable.id.includes("vel");
-      })
+    let quiverSelector = null;
+    if (this.props.showQuiverSelector) {
+      let quiverVariables = [];
+      if (this.props.datasetVariables) {
+        quiverVariables = this.props.datasetVariables.filter((variable) => {
+          return variable.id.includes("mag") && variable.id.includes("vel");
+        });
+      }
+      quiverVariables.unshift({ id: "none", value: "None" });
+  
+      quiverSelector = <SelectBox
+        id={`dataset-selector-quiver-selector-${this.props.id}`}
+        name="quiverVariable"
+        label={_("Quiver Variable")}
+        placeholder={_("Quiver Variable")}
+        options={quiverVariables}
+        onChange={this.onUpdate}
+        selected={this.props.state.quiverVariable}
+      />;
     }
-    quiverVariables.unshift({ id: 'none', value: 'None' });
 
     return (
       <div className='DatasetSelector'>
@@ -171,6 +184,8 @@ export default class DatasetSelector extends React.Component {
         ><h1>{_("Variable")}</h1></ComboBox>
 
         {velocity_selector}
+
+        {quiverSelector}
 
         {this.props.depth && <ComboBox
           id='depth'
@@ -209,5 +224,10 @@ DatasetSelector.propTypes = {
   updateSelectedPlots: PropTypes.func,
   compare: PropTypes.bool,
   availableDatasets: PropTypes.arrayOf(PropTypes.object),
-  datasetVariables: PropTypes.arrayOf(PropTypes.object)
+  datasetVariables: PropTypes.arrayOf(PropTypes.object),
+  showQuiverSelector: PropTypes.bool,
+};
+
+DatasetSelector.defaultProps = {
+  showQuiverSelector: true,
 };

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -323,6 +323,7 @@ export default class LineWindow extends React.Component {
             line={true}
             updateSelectedPlots={this.updateSelectedPlots}
             compare={this.props.dataset_compare}
+            showQuiverSelector={false}
           />
 
           <Range
@@ -368,6 +369,7 @@ export default class LineWindow extends React.Component {
               depth={this.state.selected == 2}
               variables={this.state.selected == 2 ? "all" : "3d"}
               time={this.state.selected == 2 ? "range" : "single"}
+              showQuiverSelector={false}
             />
             <Range
               auto

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -100,6 +100,8 @@ export default class MapInputs extends React.Component {
                 state={this.props.state.dataset_1}
                 onUpdate={this.props.changeHandler}
                 depth={true}
+                availableDatasets={this.props.availableDatasets}
+                datasetVariables={this.props.datasetVariables}
               />
               <Range
                 key='scale_1'

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -74,6 +74,7 @@ export default class OceanNavigator extends React.Component {
         time: -1,
         starttime: -2,  // Start time for Right Map
         variable_scale: [-5,30], // Default variable range for Right Map
+        quiverVariable: "none",
       },
       syncRanges: false, // Clones the variable range from one view to the other when enabled
       sidebarOpen: true, // Controls sidebar opened/closed status
@@ -298,6 +299,7 @@ export default class OceanNavigator extends React.Component {
         state.variable = newVariable;
         state.time = newTime;
         state.starttime = newStarttime;
+        state.quiverVariable = "none";
         state.busy = false;
 
         this.setState(state);

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -360,8 +360,8 @@ def get_data_v1_0():
 
         lat_var, lon_var = ds.nc_data.latlon_variables
 
-        lat_slice = slice(0, lat_var.size, 8)
-        lon_slice = slice(0, lon_var.size, 8)
+        lat_slice = slice(0, lat_var.size, 4)
+        lon_slice = slice(0, lon_var.size, 4)
 
         time_index = ds.nc_data.timestamp_to_time_index(result['time'])
         


### PR DESCRIPTION
## Background
Fixed the bug in the datasetconfig which caused the velocity arrows to point the wrong way. https://github.com/DFO-Ocean-Navigator/configurations/pull/27

## Why did you take this approach?
Only way.

## Anything in particular that should be highlighted?
Did a bit of cleaning to hide the quiver selector in the point, line, and area windows since it's useless there.

## Screenshot(s)
Notice the arrows lining up with the area window plot. 

Main map (double resolution...every second point...this pr will deploy every fourth point):
![image](https://user-images.githubusercontent.com/5572045/128637284-d57aeb2e-4841-4a5d-846b-81a1c19f0f0b.png)


Area window:
![image](https://user-images.githubusercontent.com/5572045/128637224-d6171366-8b4e-476a-9018-5e8363c134b8.png)


If you zoom out you can really see the current structure. really cool stuff
![image](https://user-images.githubusercontent.com/5572045/128637342-f6215086-0205-47fb-a578-4523b4f97aa8.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
