### PR TITLE
Add script to pre-gen tiles

### DIFF
--- a/scripts/pregen_tiles.py
+++ b/scripts/pregen_tiles.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import argparse
+import multiprocessing
+from itertools import product
+
+import requests
+
+parser = argparse.ArgumentParser(description='Warm up the tile cache.')
+parser.add_argument('--url', type=str, required=True,
+                    help='Root URL to Navigator instance. Ex: https://navigator.oceansdata.ca or http://10.5.166.251:5000')
+args = parser.parse_args()
+
+base_url = f"{args.url}/api/v1.0"
+
+
+def get_tile(dataset: str, variable: str, time: int, depth: int, scale: str, x: int, y: int, z: int) -> None:
+    res = requests.get(
+        f"{base_url}/tiles/gaussian/25/10/EPSG:3857/{dataset}/{variable}/{time}/{depth}/{scale}/{z}/{x}/{y}.png", timeout=25)
+
+    if res.status_code != 200:
+        print(
+            f"Error getting tile {res.status_code} -- {res.url}")
+    else:
+        print(f"Fetched {res.url}")
+
+
+if __name__ == "__main__":
+    print(f"Starting with {multiprocessing.cpu_count()} processes...")
+
+    datasets = list(
+        filter(lambda d: "riops" in d or "giops" in d,
+               map(lambda d: d['id'], requests.get(
+                   f"{base_url}/datasets").json())
+               )
+    )
+
+    timestamps = list(
+        map(lambda t: int(t['id']), requests.get(
+            f"{base_url}/timestamps/?dataset=giops_day&variable=votemper").json())
+    )
+
+    zoom_levels = [z for z in range(1, 8)]
+    x_range = [x for x in range(0, 8)]
+    y_range = [y for y in range(0, 8)]
+
+    nc_timestamp = [timestamps[0]]
+
+    print(f"Fetching tiles for {nc_timestamp}")
+
+    time = nc_timestamp
+    depth = [0]
+
+    with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
+        res1 = pool.starmap_async(get_tile, product(datasets, [
+                                  "vozocrtx", "vomecrty"], time, depth, ["-3,3"], x_range, y_range, zoom_levels))
+        res2 = pool.starmap_async(get_tile, product(
+            datasets, ["magwatervel"], time, depth, ["0,3"], x_range, y_range, zoom_levels))
+        res3 = pool.starmap_async(get_tile, product(
+            datasets, ["votemper"], time, depth, ["-5,30"], x_range, y_range, zoom_levels))
+        res4 = pool.starmap_async(get_tile, product(
+            datasets, ["vosaline"], time, depth, ["30,40"], x_range, y_range, zoom_levels))
+
+        res1.get()
+        res2.get()
+        res3.get()
+        res4.get()
+
+    print("Done!")


### PR DESCRIPTION
## Background
Applicable to all GIOPS and RIOPS datasets, at the surface, for the first timestamp found for each dataset (so for forecasts, today), for temp salinity water x water y and magnitude variables

Bit slow but I'm not sitting on top of the data. May take a couple of hours so best run during the night. We're paying for the electricity so might as well use it LOL.

## Why did you take this approach?
We've got lots of RAM so let's warm up the cache to make stuff fast.

## Anything in particular that should be highlighted?

Invoked by `python scripts/pregen_tiles.py --url <url>`

* `python scripts/pregen_tiles.py --url http://10.5.166.251:5000`
* `python scripts/pregen_tiles.py --url https://navigator.oceansdata.ca`

Will be expanded in the future for other datasets, variables, depths, and times. Just getting some hack out quickly for a fast win.

Will execute remote requests in batches of whatever the number of vCPUs is available...8 on my system

## Screenshot(s)
n/a

## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
