### PR TITLE
Revert "881 fix netcdf context default variables"

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -52,25 +52,22 @@ class NetCDFData(Data):
         # Don't decode times since we do it anyways.
         decode_times = False
 
-        if (self.url.endswith(".sqlite3") if not isinstance(self.url, list) else False):
-            if self._nc_files:
-                try:
-                    if len(self._nc_files) > 1:
-                        self.dataset = xarray.open_mfdataset(
-                            self._nc_files,
-                            decode_times=decode_times
-                        )
-                    else:
-                        self.dataset = xarray.open_dataset(
-                            self._nc_files[0],
-                            decode_times=decode_times,
-                        )
-                except xarray.core.variable.MissingDimensionsError:
-                    # xarray won't open FVCOM files due to dimension/coordinate/variable label
-                    # duplication issue, so fall back to using netCDF4.Dataset()
-                    self.dataset = netCDF4.MFDataset(self._nc_files)
-            else:
-                self.dataset = xarray.Dataset()
+        if self._nc_files:
+            try:
+                if len(self._nc_files) > 1:
+                    self.dataset = xarray.open_mfdataset(
+                        self._nc_files,
+                        decode_times=decode_times
+                    )
+                else:
+                    self.dataset = xarray.open_dataset(
+                        self._nc_files[0],
+                        decode_times=decode_times,
+                    )
+            except xarray.core.variable.MissingDimensionsError:
+                # xarray won't open FVCOM files due to dimension/coordinate/variable label
+                # duplication issue, so fall back to using netCDF4.Dataset()
+                self.dataset = netCDF4.MFDataset(self._nc_files)
 
         elif (self.url.endswith(".zarr") if not isinstance(self.url, list) else False):
             ds_zarr = xarray.open_zarr(self.url, decode_times=decode_times)
@@ -833,15 +830,11 @@ class NetCDFData(Data):
         try:
             variables = kwargs['variable']
         except KeyError:
-            variables = set()
-            
+            variables = datasetconfig.variables[0]
         variables = {variables} if isinstance(variables, str) else set(variables)
         calculated_variables = datasetconfig.calculated_variables
         with SQLiteDatabase(self.url) as db:
             variables_to_load = self.__get_variables_to_load(db, variables, calculated_variables)
-
-            if len(variables_to_load) == 0:
-                return []
 
             timestamp = self.__get_requested_timestamps(
                 db, variables_to_load[0], kwargs.get('timestamp', -1),


### PR DESCRIPTION
Reverts DFO-Ocean-Navigator/Ocean-Data-Map-Project#882

Following behaviour is present on public site (and my local machine). 

Was trying to select other datasets (numbers 2, 4, 5, 8, 21) to test out the quiver arrows, but I noticed these kinds of errors popping up on my console preventing the new selected datasets from being loaded.

```sh
2021-08-29 18:22:54 +0000] [4913] [ERROR] Error handling request /api/v1.0/variables/?dataset=riops_fc_2dll
Traceback (most recent call last):
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/gunicorn/workers/gthread.py", line 271, in handle
    keepalive = self.handle_request(req, conn)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/gunicorn/workers/gthread.py", line 320, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/sentry_sdk/integrations/flask.py", line 90, in sentry_patched_wsgi_app
    environ, start_response
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/sentry_sdk/integrations/wsgi.py", line 131, in __call__
    reraise(*_capture_exception(hub))
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/sentry_sdk/_compat.py", line 54, in reraise
    raise value
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/sentry_sdk/integrations/wsgi.py", line 127, in __call__
    _sentry_start_response, start_response, transaction
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/sentry_sdk/integrations/flask.py", line 89, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/ubuntu/tools/miniconda/3/amd64/envs/navigator/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py", line 219, in variables_query_v1_0
    with open_dataset(config) as ds:
  File "/home/ubuntu/Ocean-Data-Map-Project/data/mercator.py", line 27, in __enter__
    self.latvar, self.lonvar = self.nc_data.latlon_variables
  File "/home/ubuntu/Ocean-Data-Map-Project/data/netcdf_data.py", line 643, in latlon_variables
    self.__find_variable(['nav_lat', 'latitude']),
  File "/home/ubuntu/Ocean-Data-Map-Project/data/netcdf_data.py", line 136, in __find_variable
    raise KeyError(f"None of {candidates} were found in {self.dataset}")
KeyError: "None of ['nav_lat', 'latitude'] were found in <xarray.Dataset>\nDimensions:    (xc: 1770, yc: 1610)\nDimensions without coordinates: xc, yc\nData variables:\n    alpha      (yc, xc) float32 ...\n    cos_alpha  (yc, xc) float32 ...\n    sin_alpha  (yc, xc) float32 ...

```

Looks to me the `NetCDFData.dataset` variable isn't being loaded with model data with is what's causing `NetCDFData__find_variable` to blow up.
![image](https://user-images.githubusercontent.com/5572045/131262203-37ef93a9-d93e-4cec-b26c-b8ad37ed65ac.png)


Production state
![image](https://user-images.githubusercontent.com/5572045/131262062-620dabfd-7a84-4476-b971-cd6fde0a78d8.png)


Reverting avoids this issue on my local machine:
![image](https://user-images.githubusercontent.com/5572045/131262114-aca59810-e8c7-4098-a198-14f126edf43e.png)


Given users are unable to select any datasets other than the default one at this time, I figure this revert should be pushed through pending an investigation.