### PR TITLE
Fixes #893

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -24,7 +24,12 @@ class Mercator(Model):
         self.nc_data.__enter__()
 
         if self.latvar is None:
-            self.latvar, self.lonvar = self.nc_data.latlon_variables
+            try:
+                self.latvar, self.lonvar = self.nc_data.latlon_variables
+            except KeyError:
+                print("Warning: No variables with latitude or longitude are loaded in this NetCDF dataset.")
+
+
 
         return self
 


### PR DESCRIPTION
When making an API call like `/api/v1.0/variables/?dataset=giops_fc_10d_2dll` we want to return a list of variable but we don't actually need any particular variable's data loaded from the disk.

For Mercator models, there was an implicit assumption that there would *always* be a latitude/longitude variable available.  However, if we have haven't selected any particular variables (like during this API call that is concerned with the dataset level and not anything about a particular variable).

This PR handles the KeyError exception when no latitude/longitude variable is available and prints out an warning/information message instead.

