### PR TITLE
Add updateOptions to AreaWindow props

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -577,6 +577,7 @@ export default class AreaWindow extends React.Component {
             multiple={this.state.currentTab === 2}
             state={this.state.dataset_0} 
             onUpdate={this.onLocalUpdate}
+            onUpdateOptions={this.props.updateOptions}
             depth={true}
             showQuiverSelector={false}
           />
@@ -626,6 +627,7 @@ export default class AreaWindow extends React.Component {
                 multiple={this.state.currentTab === 2}
                 state={this.props.dataset_1}
                 onUpdate={this.props.onUpdate}
+                onUpdateOptions={this.props.updateOptions}
                 depth={true}
                 showQuiverSelector={false}
               />

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -642,6 +642,7 @@ export default class OceanNavigator extends React.Component {
             depth={this.state.depth}
             projection={this.state.projection}
             onUpdate={this.updateState}
+            updateOptions={this.updateOptions}
             init={this.state.subquery}
             dataset_compare={this.state.dataset_compare}
             dataset_1={this.state.dataset_1}


### PR DESCRIPTION
## Background
As described in Issue #896, the interpolation settings are not updated when the variable is changed from the Area Window. As a result, the area plot does not use the correct settings when PSSC is selected.  The `updateOptions` function used to track changes to the interpolation and bathymetry settings was not being passed to the `AreaWindow` component, preventing the Navigator from updating the interpolation type when variables are selected from the Area Window.  

## Why did you take this approach?
Adding `updateOptions` to the AreaWindow's properties allows the DatasetSelector component to pass the interpolation options back and draw the area plot with the correct settings. This fixes #896. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
