### PR TITLE
Fix variable selector in virtual mooring tab

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -577,7 +577,7 @@ export default class AreaWindow extends React.Component {
             multiple={this.state.currentTab === 2}
             state={this.state.dataset_0} 
             onUpdate={this.onLocalUpdate}
-            onUpdateOptions={this.props.updateOptions}
+            onUpdateOptions={this.props.onUpdateOptions}
             depth={true}
             showQuiverSelector={false}
           />
@@ -627,7 +627,7 @@ export default class AreaWindow extends React.Component {
                 multiple={this.state.currentTab === 2}
                 state={this.props.dataset_1}
                 onUpdate={this.props.onUpdate}
-                onUpdateOptions={this.props.updateOptions}
+                onUpdateOptions={this.props.onUpdateOptions}
                 depth={true}
                 showQuiverSelector={false}
               />

--- a/oceannavigator/frontend/src/components/ComboBox.jsx
+++ b/oceannavigator/frontend/src/components/ComboBox.jsx
@@ -86,7 +86,7 @@ export default class ComboBox extends React.Component {
 
       // Update OceanNavigator state
       this.props.onUpdate(keys, values);
-      if (keys.includes("options")){
+      if (this.props.onUpdateOptions && keys.includes("options")){
         this.props.onUpdateOptions(values[keys.indexOf("options")]); 
       }
     }

--- a/oceannavigator/frontend/src/components/ComboBox.jsx
+++ b/oceannavigator/frontend/src/components/ComboBox.jsx
@@ -86,6 +86,9 @@ export default class ComboBox extends React.Component {
 
       // Update OceanNavigator state
       this.props.onUpdate(keys, values);
+      if (keys.includes("options")){
+        this.props.onUpdateOptions(values[keys.indexOf("options")]); 
+      }
     }
   }
 

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -34,11 +34,6 @@ export default class DatasetSelector extends React.Component {
   variableUpdate(key, value) {
     this.props.onUpdate("setDefaultScale", true);
     this.onUpdate(key, value);
-    if(Array.isArray(key)){
-      if (key.includes("options")){
-        this.props.onUpdateOptions(value[key.indexOf("options")]); 
-      }
-    }
   }
 
   onUpdate(key, value) {
@@ -178,6 +173,7 @@ export default class DatasetSelector extends React.Component {
           state={this.props.state.variable}
           def={"defaults.dataset"}
           onUpdate={this.variableUpdate}
+          onUpdateOptions={this.props.onUpdateOptions}
           url={"/api/v1.0/variables/?dataset=" + this.props.state.dataset + variables
           }
           title={_("Variable")}

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -590,7 +590,7 @@ export default class OceanNavigator extends React.Component {
             colormap={this.state.colormap}
             names={this.state.names}
             onUpdate={this.updateState}
-            updateOptions={this.updateOptions}
+            onUpdateOptions={this.updateOptions}
             init={this.state.subquery}
             dataset_compare={this.state.dataset_compare}
             dataset_1={this.state.dataset_1}
@@ -643,7 +643,7 @@ export default class OceanNavigator extends React.Component {
             depth={this.state.depth}
             projection={this.state.projection}
             onUpdate={this.updateState}
-            updateOptions={this.updateOptions}
+            onUpdateOptions={this.updateOptions}
             init={this.state.subquery}
             dataset_compare={this.state.dataset_compare}
             dataset_1={this.state.dataset_1}

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -590,6 +590,7 @@ export default class OceanNavigator extends React.Component {
             colormap={this.state.colormap}
             names={this.state.names}
             onUpdate={this.updateState}
+            updateOptions={this.updateOptions}
             init={this.state.subquery}
             dataset_compare={this.state.dataset_compare}
             dataset_1={this.state.dataset_1}

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -333,6 +333,7 @@ export default class PointWindow extends React.Component {
         state={this.props.variable}
         def=''
         onUpdate={this.props.onUpdate}
+        onUpdateOptions={this.props.updateOptions}
         url={"/api/v1.0/variables/?dataset="+this.props.dataset}
         title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
 

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -333,7 +333,7 @@ export default class PointWindow extends React.Component {
         state={this.props.variable}
         def=''
         onUpdate={this.props.onUpdate}
-        onUpdateOptions={this.props.updateOptions}
+        onUpdateOptions={this.props.onUpdateOptions}
         url={"/api/v1.0/variables/?dataset="+this.props.dataset}
         title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
 


### PR DESCRIPTION
## Background
The Navigator has been crashing when changing variables from the Virtual Mooring tab in the Point Window. This underlying error occurs in the MapInput component which is getting passed an empty 'options' object which should contain updated interpolation settings for the newly selected variable. Initially, these settings were passed back from the variable ComboBox via the onUpdate callback but this function wasn't updating the 'options' state. To correct this we now pass the updateOptions callback to the variable ComboBox via the AreaWindow and PointWindow components so that they can directly update the `options` object. The DatasetSelector contained similar functionality but since this component also relies on ComboBoxes to select variables this was removed to avoid redundancy.  This fixes Issue #898.

## Why did you take this approach?
Passing the updateOptions callback through to the variable ComboBox component allows the Navigator to update the current interpolation settings of point and area variables using the same code path. 

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
