### PR TITLE
Modified bearing equation to correct order of east_vel and north_vel

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -57,7 +57,7 @@ def magnitude(a, b):
     return np.sqrt(a ** 2 + b ** 2)
 
 
-def bearing(east_vel: xr.DataArray, north_vel: xr.DataArray) -> xr.DataArray:
+def bearing(north_vel: xr.DataArray, east_vel: xr.DataArray) -> xr.DataArray:
     """
     Calculates the bearing (degrees clockwise positive from North) from
     component East and North vectors.
@@ -69,7 +69,7 @@ def bearing(east_vel: xr.DataArray, north_vel: xr.DataArray) -> xr.DataArray:
     east_vel = np.squeeze(east_vel)
     north_vel = np.squeeze(north_vel)
 
-    bearing = np.arctan2(east_vel, north_vel)
+    bearing = np.arctan2(north_vel, east_vel)
     bearing = np.pi / 2.0 - bearing
 
     negative_bearings = np.nonzero(bearing < 0)


### PR DESCRIPTION
* Corrected the order of east_vel and north_vel in the call to np.arctan2()
* Modified the order of north_vel and east_vel in bearing function definition to match how it is currently being called in datasetconfig.json

## Background
The bearing calculation uses the function ```np.arctan2(y, x)``` where the order of the arguments matters - that is the north_vel (or y-like) variable must be first. This pull request corrects the original implementation which passed the east_vel (or x-like) variable first. 

This error did not appear to cause an issue because the order of the east_vel and north_vel was swapped in the call to  bearing() in datasetconfig.json. 

This change will improve debugging and code readability.

## Why did you take this approach?
It is correct.

## Anything in particular that should be highlighted?
In calls to bearing(), the order of the variables matters!
When working in datasetconfig.json we must ensure that we use ```bearing(north_vel, east_vel)```. 
We also must ensure that the variables are northward and eastward velocities. 

Unfortunately, this pull request will not resolve the negative bearings issue #907 

## Checks
- [ ] I ran unit tests. NO
- [ ] I've tested the relevant changes from a user POV. NO

Important: I did not have an opportunity to test these changes.