### PR TITLE
Replace negative bearing values in quiver tooltip

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -71,10 +71,7 @@ def bearing(north_vel: xr.DataArray, east_vel: xr.DataArray) -> xr.DataArray:
 
     bearing = np.arctan2(north_vel, east_vel)
     bearing = np.pi / 2.0 - bearing
-
-    negative_bearings = np.nonzero(bearing < 0)
-    bearing.values[negative_bearings] += 2 * np.pi
-    
+    bearing = xr.where(bearing < 0, bearing + 2*np.pi, bearing)
     bearing *= 180.0 / np.pi
 
     # Deal with undefined angles (where velocity is 0 or very close)


### PR DESCRIPTION
## Background
Nancy found that bearings in the north-west quadrant (270-360 deg) were displayed as negative values in quiver arrow tool tips (Issue #907). 

It looks like the line `bearing.values[negative_bearings] += 2 * np.pi` wasn't updating the bearing xarray.variable object so I replaced it with an xr.where function:`bearing = xr.where(bearing < 0, bearing + 2*np.pi, bearing)`. This gives us positive values for all quivers regardless of direction.

Fixes #907

## Why did you take this approach?
The built-in where function can replace directly replace values in an xarray object based on a conditional. This seems like a good use case for it.

## Screenshot(s)

![before](https://user-images.githubusercontent.com/79917349/134398422-9fb9aa2a-ac23-4bd0-b32a-e5397ddb3d15.png)
![after](https://user-images.githubusercontent.com/79917349/134398418-a54b39ea-6e9f-48fa-a9e4-d0599ebd44b4.png)

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
