### PR TITLE
Stop duplicate API calls for Variables dropdown

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -576,10 +576,10 @@ class AreaWindow extends React.Component {
             multiple={this.state.currentTab === 2}
             state={this.state.dataset_0} 
             onUpdate={this.onLocalUpdate}
-            onUpdateOptions={this.props.onUpdateOptions}
             depth={true}
             showQuiverSelector={false}
             datasetDepths={this.props.datasetDepths}
+            datasetVariables={this.props.datasetVariables}
           />
 
           <div style={{"display": this.state.currentTab == 1 ? "block" : "none"}}>
@@ -627,10 +627,10 @@ class AreaWindow extends React.Component {
                 multiple={this.state.currentTab === 2}
                 state={this.props.dataset_1}
                 onUpdate={this.props.onUpdate}
-                onUpdateOptions={this.props.onUpdateOptions}
                 depth={true}
                 showQuiverSelector={false}
                 datasetDepths={this.props.datasetDepths}
+                datasetVariables={this.props.datasetVariables}
               />
 
               <Range
@@ -774,6 +774,7 @@ AreaWindow.propTypes = {
   scale_1: PropTypes.string,
   options: PropTypes.object,
   datasetDepths: PropTypes.arrayOf(PropTypes.object),
+  datasetVariables: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withTranslation()(AreaWindow);

--- a/oceannavigator/frontend/src/components/ComboBox.jsx
+++ b/oceannavigator/frontend/src/components/ComboBox.jsx
@@ -77,18 +77,9 @@ class ComboBox extends React.Component {
           values.push(dataset[key]);
         }
       }
-      //Check if this is a combobox is for variable
-      if(this.props.id === "variable"){
-        const variableConfig = this.state.data[e.target.selectedIndex];
-        keys.push("options");
-        values.push(variableConfig.interp);
-      }
 
       // Update OceanNavigator state
       this.props.onUpdate(keys, values);
-      if (this.props.onUpdateOptions && keys.includes("options")){
-        this.props.onUpdateOptions(values[keys.indexOf("options")]); 
-      }
     }
   }
 
@@ -105,11 +96,6 @@ class ComboBox extends React.Component {
         url: props.url,
         dataType: "json",
         cache: true,
-        
-        //If server returns status code of 200 / it worked - Ajax call successful
-        //
-        // data filled by ajax
-        //
         success: function (data) {
           if (this._mounted) {  //Combobox is mounted
 

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -10,7 +10,7 @@ import SelectBox from "./lib/SelectBox.jsx";
 import { withTranslation } from "react-i18next";
 
 // Default properties for a dataset-state
-const DATA_ELEMS = [
+const DATA_ELEMS = Object.freeze([
   "dataset",
   "dataset_attribution",
   "dataset_quantum",
@@ -20,20 +20,14 @@ const DATA_ELEMS = [
   "time",
   "starttime",
   "quiverVariable",
-];
+]);
 
 class DatasetSelector extends React.Component {
   constructor(props) {
     super(props);
 
     // Function bindings
-    this.variableUpdate = this.variableUpdate.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
-  }
-
-  variableUpdate(key, value) {
-    this.props.onUpdate("setDefaultScale", true);
-    this.onUpdate(key, value);
   }
 
   onUpdate(key, value) {
@@ -179,7 +173,7 @@ class DatasetSelector extends React.Component {
     }
 
     let variableSelector = null;
-    if (this.props.datasetVariables && !this.props.multiple && null == "edoops") {
+    if (this.props.datasetVariables) {
       variableSelector = <SelectBox 
         id={`dataset-selector-variable-selector-${this.props.id}`}
         name={"variable"}
@@ -189,10 +183,6 @@ class DatasetSelector extends React.Component {
         onChange={this.onUpdate}
         selected={this.props.state.variable}
       />;
-    }
-    
-    if (this.props.datasetVariables && this.props.multiple) {
-      // do something for multi select
     }
 
     return (
@@ -205,18 +195,6 @@ class DatasetSelector extends React.Component {
           onUpdate={this.onUpdate}
           url='/api/v1.0/datasets/'
           title={_("Dataset")}></ComboBox>
-
-        <ComboBox
-          id='variable'
-          multiple={this.props.multiple}
-          state={this.props.state.variable}
-          def={"defaults.dataset"}
-          onUpdate={this.variableUpdate}
-          onUpdateOptions={this.props.onUpdateOptions}
-          url={"/api/v1.0/variables/?dataset=" + this.props.state.dataset + variables
-          }
-          title={_("Variable")}
-        ><h1>{_("Variable")}</h1></ComboBox>
 
         {variableSelector}
 

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -54,15 +54,6 @@ class DatasetSelector extends React.Component {
     _("Time (UTC)");
     _("Quiver Variable");
 
-    let variables = "";
-    switch (this.props.variables) {
-      case "3d":
-        variables = "&3d_only";
-        break;
-      default:
-        break;
-    }
-
     // Determine which timepicker we need
     let time = "";
     switch (this.props.time) {
@@ -174,12 +165,22 @@ class DatasetSelector extends React.Component {
 
     let variableSelector = null;
     if (this.props.datasetVariables) {
+      let options = [];
+      if (this.props.variables === "3d") {
+        options = this.props.datasetVariables.filter(v => {
+          return v.two_dimensional === false;
+        });
+      }
+      else {
+        options = this.props.datasetVariables;
+      }
+
       variableSelector = <SelectBox 
         id={`dataset-selector-variable-selector-${this.props.id}`}
         name={"variable"}
         label={_("Variable")}
         placeholder={_("Variable")}
-        options={this.props.datasetVariables}
+        options={options}
         onChange={this.onUpdate}
         selected={this.props.state.variable}
       />;

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -178,6 +178,23 @@ class DatasetSelector extends React.Component {
       />;
     }
 
+    let variableSelector = null;
+    if (this.props.datasetVariables && !this.props.multiple && null == "edoops") {
+      variableSelector = <SelectBox 
+        id={`dataset-selector-variable-selector-${this.props.id}`}
+        name={"variable"}
+        label={_("Variable")}
+        placeholder={_("Variable")}
+        options={this.props.datasetVariables}
+        onChange={this.onUpdate}
+        selected={this.props.state.variable}
+      />;
+    }
+    
+    if (this.props.datasetVariables && this.props.multiple) {
+      // do something for multi select
+    }
+
     return (
       <div className='DatasetSelector'>
 
@@ -200,6 +217,8 @@ class DatasetSelector extends React.Component {
           }
           title={_("Variable")}
         ><h1>{_("Variable")}</h1></ComboBox>
+
+        {variableSelector}
 
         {velocity_selector}
 

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -324,6 +324,7 @@ class LineWindow extends React.Component {
             compare={this.props.dataset_compare}
             showQuiverSelector={false}
             datasetDepths={this.props.datasetDepths}
+            datasetVariables={this.props.datasetVariables}
           />
 
           <Range
@@ -371,6 +372,7 @@ class LineWindow extends React.Component {
               time={this.state.selected == 2 ? "range" : "single"}
               showQuiverSelector={false}
               datasetDepths={this.props.datasetDepths}
+              datasetVariables={this.props.datasetVariables}
             />
             <Range
               auto
@@ -498,6 +500,7 @@ LineWindow.propTypes = {
   swapViews: PropTypes.func,
   showHelp: PropTypes.func,
   datasetDepths: PropTypes.arrayOf(PropTypes.object),
+  datasetVariables: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withTranslation()(LineWindow);

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -170,6 +170,10 @@ export default class Map extends React.PureComponent {
       location: [0, 90],
     };
 
+    this.scaleViewer = new app.ScaleViewer({
+      image: "/api/v1.0/scale/giops_day/votemper/-5,30.png",
+    });
+
     this.loader = function (extent, resolution, projection) {
       if (this.props.state.vectortype) {
         let url = "";
@@ -671,6 +675,7 @@ export default class Map extends React.PureComponent {
         }),
       ])
     });
+    this.map.addControl(this.scaleViewer);
     this.map.on("moveend", this.refreshFeatures.bind(this));
     this.map.on("moveend", function () {
       const c = olproj.transform(this.mapView.getCenter(), this.props.state.projection, "EPSG:4326").map(function (c) { return c.toFixed(4); });
@@ -1318,8 +1323,8 @@ export default class Map extends React.PureComponent {
   }
 
   shouldUpdateScaleViewer(currentDataset, prevDataset,
-                          currentVariable, prevVariable,
-                           currentScale, prevScale)
+    currentVariable, prevVariable,
+    currentScale, prevScale)
   {
     return (currentDataset !== prevDataset)
           || (currentVariable !== prevVariable)
@@ -1330,11 +1335,17 @@ export default class Map extends React.PureComponent {
     if (this.scaleViewer != null) {
       this.map.removeControl(this.scaleViewer);
     }
+
+    let scale = currentScale;
+    if (Array.isArray(scale)) {
+      scale = scale.join(",");
+    }
+
     this.scaleViewer = new app.ScaleViewer({
       image: (
         `/api/v1.0/scale/${currentDataset}` +
         `/${currentVariable}` +
-        `/${currentScale}.png`
+        `/${scale}.png`
       )
     });
     this.map.addControl(this.scaleViewer);
@@ -1404,6 +1415,12 @@ export default class Map extends React.PureComponent {
     const datalayer = this.map.getLayers().getArray()[1];
     const old = datalayer.getSource();
     const props = old.getProperties();
+
+    let scale = this.props.scale;
+    if (Array.isArray(scale)) {
+      scale = scale.join(",");
+    }
+
     props.url = "/api/v1.0/tiles" +
       `/${this.props.options.interpType}` +
       `/${this.props.options.interpRadius}` +
@@ -1413,7 +1430,7 @@ export default class Map extends React.PureComponent {
       `/${this.props.state.variable}` +
       `/${this.props.state.time}` +
       `/${this.props.state.depth}` +
-      `/${this.props.scale}` +
+      `/${scale}` +
       "/{z}/{x}/{y}.png";
     props.projection = this.props.state.projection;
     props.attributions = [
@@ -1435,7 +1452,7 @@ export default class Map extends React.PureComponent {
                                      this.props.scale,
                                      prevProps.scale))
     {
-      this.updateScaleViewer(this.props.state.dataset, this.props.state.variable, this.props.state.scale);
+      this.updateScaleViewer(this.props.state.dataset, this.props.state.variable, this.props.scale);
     }
 
     if (this.shouldUpdateBathymetryLayer(this.props.state.projection,

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -36,6 +36,57 @@ class MapInputs extends React.Component {
     _("Variable Range");
     _("Show Bathymetry Contours");
 
+    let mainRange = null;
+    if (this.props.datasetVariables) {
+      mainRange = <Range
+        id='scale'
+        state={this.props.state.variable_scale}
+        onUpdate={this.props.changeHandler}
+        onSubmit={this.props.changeHandler}
+        title={_("Variable Range")}
+        autourl={"/api/v1.0/range/" +
+                  this.props.state.dataset + "/" + 
+                  this.props.state.variable + "/" +
+                  this.props.options.interpType + "/" +
+                  this.props.options.interpRadius + "/" +
+                  this.props.options.interpNeighbours + "/" +
+                  this.props.state.projection + "/" +
+                  this.props.state.extent.join(",") + "/" +
+                  this.props.state.depth + "/" +
+                  this.props.state.time +  ".json"
+        }
+        dataset_compare={this.props.state.dataset_compare}
+        default_scale={this.props.datasetVariables
+          .find(v => v.id === this.props.state.variable).scale
+        }
+      />;
+    }
+
+    let compareRange = null;
+    if (this.props.state.dataset_compare && this.props.datasetVariables) {
+      compareRange = <Range
+        key='scale_1'
+        id='scale_1'
+        state={this.props.state.dataset_1.variable_scale}
+        onUpdate={this.props.changeHandler}
+        title={_("Variable Range")}
+        autourl={"/api/v1.0/range/" +
+                    this.props.state.dataset_1.dataset + "/" +
+                    this.props.state.dataset_1.variable + "/" +
+                    this.props.options.interpType + "/" +
+                    this.props.options.interpRadius + "/" +
+                    this.props.options.interpNeighbours + "/" +
+                    this.props.state.projection + "/" +
+                    this.props.state.extent.join(",") + "/" +
+                    this.props.state.dataset_1.depth + "/" +
+                    this.props.state.dataset_1.time + ".json"
+        }
+        default_scale={this.props.datasetVariables
+          .find(v => v.id === this.props.state.variable).scale
+        }
+      />;
+    }
+
     //Creates Main Map Panel
     const inputs = [
       <Panel
@@ -52,34 +103,14 @@ class MapInputs extends React.Component {
               id='dataset_0'
               state={this.props.state}
               onUpdate={this.props.changeHandler}
-              onUpdateOptions={this.props.updateOptions}
               depth={true}
               availableDatasets={this.props.availableDatasets}
               datasetVariables={this.props.datasetVariables}
               datasetDepths={this.props.datasetDepths}
             />
-            <Range
-              id='scale'
-              state={this.props.state.scale}
-              setDefaultScale={this.props.state.setDefaultScale}
-              def=''
-              onUpdate={this.props.changeHandler}
-              onSubmit={this.props.changeHandler}
-              title={_("Variable Range")}
-              autourl={"/api/v1.0/range/" +
-                      this.props.state.dataset + "/" + 
-                      this.props.state.variable + "/" +
-                      this.props.options.interpType + "/" +
-                      this.props.options.interpRadius + "/" +
-                      this.props.options.interpNeighbours + "/" +
-                      this.props.state.projection + "/" +
-                      this.props.state.extent.join(",") + "/" +
-                      this.props.state.depth + "/" +
-                      this.props.state.time +  ".json"
-              }
-              dataset_compare={this.props.state.dataset_compare}
-              default_scale={this.props.state.variable_scale}
-            ></Range>
+            
+            {mainRange}
+
           </Panel.Body>
         </Panel.Collapse>
       </Panel>
@@ -106,27 +137,9 @@ class MapInputs extends React.Component {
                 datasetVariables={this.props.datasetVariables}
                 datasetDepths={this.props.datasetDepths}
               />
-              <Range
-                key='scale_1'
-                id='scale_1'
-                state={this.props.state.scale_1}
-                setDefaultScale={this.props.state.setDefaultScale}
-                def=''
-                onUpdate={this.props.changeHandler}
-                title={_("Variable Range")}
-                autourl={"/api/v1.0/range/" +
-                        this.props.state.dataset_1.dataset + "/" +
-                        this.props.state.dataset_1.variable + "/" +
-                        this.props.options.interpType + "/" +
-                        this.props.options.interpRadius + "/" +
-                        this.props.options.interpNeighbours + "/" +
-                        this.props.state.projection + "/" +
-                        this.props.state.extent.join(",") + "/" +
-                        this.props.state.dataset_1.depth + "/" +
-                        this.props.state.dataset_1.time + ".json"
-                }
-                default_scale={this.props.state.dataset_1.variable_scale}
-              ></Range>
+              
+              {compareRange}
+
             </Panel.Body>
           </Panel.Collapse>
         </Panel>
@@ -137,7 +150,6 @@ class MapInputs extends React.Component {
 
     return (
       <div className={className}>
-
         
         <Tabs //Creates Tabs Container
           activeKey={this.state.currentTab}

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -346,6 +346,7 @@ class PointWindow extends React.Component {
           state={this.props.variable}
           def=''
           onUpdate={this.props.onUpdate}
+          onUpdateOptions={this.props.onUpdateOptions}
           url={"/api/v1.0/variables/?dataset="+this.props.dataset}
           title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
 

--- a/oceannavigator/frontend/src/components/Range.jsx
+++ b/oceannavigator/frontend/src/components/Range.jsx
@@ -18,7 +18,7 @@ class Range extends React.Component {
 
     // Parse scale tuple
     let scale = this.props.state;
-    if (typeof (this.props.state.split) === "function") {
+    if (typeof this.props.state === "string" || this.props.state instanceof String) {
       scale = this.props.state.split(",");
     }
     const min = parseFloat(scale[0]);
@@ -47,16 +47,10 @@ class Range extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-
-    //Sets scale to default on variable change
-    if (this.props.setDefaultScale == true) {
-      this.handleDefaultButton();  //Changes Scale
-      this.props.onUpdate("setDefaultScale", false); //Resets set to default flag
-    }
     if (stringify(this.props) !== stringify(nextProps)) {
 
       let scale = nextProps.state;
-      if (typeof (scale.split) === "function") {
+      if (typeof scale === "string" || scale instanceof String) {
         scale = scale.split(",");
       }
       if (scale.length > 1) {
@@ -102,7 +96,7 @@ class Range extends React.Component {
     });
 
     var scale = this.props.state;
-    if (typeof (this.props.state.split) === "function") {
+    if (typeof this.props.state === "string" || this.props.state instanceof String) {
       scale = this.props.state.split(",");
     }
 
@@ -124,7 +118,7 @@ class Range extends React.Component {
       cache: false,
       success: function (data) {
         if (this._mounted) {
-          this.props.onUpdate(this.props.id, data.min + "," + data.max);
+          this.props.onUpdate(this.props.id, [data.min, data.max]);
         }
       }.bind(this),
       
@@ -144,7 +138,7 @@ class Range extends React.Component {
       </Checkbox>
     );
 
-    var autobuttons = <div></div>;
+    let autobuttons = <div></div>;
     if (this.props.autourl) {
       autobuttons = (
         <ButtonToolbar style={{ display: "inline-block", "float": "right" }}>
@@ -206,9 +200,8 @@ Range.propTypes = {
   auto: PropTypes.bool,
   title: PropTypes.string,
   onUpdate: PropTypes.func,
-  setDefaultScale: PropTypes.bool,
   default_scale: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  state: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  state: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
   autourl: PropTypes.string,
 };
 

--- a/oceannavigator/frontend/src/components/lib/SelectBox.jsx
+++ b/oceannavigator/frontend/src/components/lib/SelectBox.jsx
@@ -37,6 +37,7 @@ export default class SelectBox extends React.Component {
           onChange={(e) => this.props.onChange(e.target.name, e.target.value)}
           disabled={disabled}
           value={this.props.selected}
+          multiple={this.props.multiple}
         >
           {options}
         </FormControl>
@@ -53,6 +54,13 @@ SelectBox.propTypes = {
   placeholder: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
-  selected: PropTypes.oneOfType([PropTypes.string,
-  PropTypes.number,]).isRequired,
+  selected: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
+  multiple: PropTypes.bool,
+};
+
+SelectBox.defaultProps = {
+  multiple: false,
 };


### PR DESCRIPTION
## Background

* Re-jigged the state update logic in `OceanNavigator` to be more understandable.
* Moved the update interpolation options code to the `OceanNavigator` component to keep our `SelectBox` component as generic as possible.
* Added a new field (`two_dimensional`) to the `variables` API response to allow the front end to filter 3D or 2D variables without requiring another API call.
* Small refactor of the variables API endpoint to simplify conditional logic and remove code duplication.
* Fixed a bug in the `Map` component where the colourmap bar wouldn't be created when the website first loads. This bug was introduced when I simplified the state update logic in `OceanNavigator` to follow React best practices, so technically the fact the colourmap bar was showing before my refactor is actually a bug.
* Untangled some crap with the Range` component being tied to multiple variable scales in the React state which broke the variable dropdown for some reason.

## Why did you take this approach?

Similar approach as #880 

## Anything in particular that should be highlighted?

nope

## Screenshot(s)
![image](https://user-images.githubusercontent.com/5572045/135760642-35e5d95b-dc61-4ebf-b989-c075dbf30ab1.png)

![image](https://user-images.githubusercontent.com/5572045/135761045-f797956c-7095-445c-a789-9504414b3a1f.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
