### PR TITLE
Restore 2D dataset functionality

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -157,7 +157,7 @@ class DatasetSelector extends React.Component {
     }
 
     let depthSelector = null;
-    if (this.props.depth && this.props.datasetDepths) {
+    if (this.props.depth && this.props.datasetDepths && this.props.datasetDepths.length > 0) {
       depthSelector = <SelectBox 
         id={`dataset-selector-depth-selector-${this.props.id}`}
         name={"depth"}


### PR DESCRIPTION
## Background
When working through the pre-release checks yesterday I found that the Navigator crashed with this error when trying to review datasets 5 and 8:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'id')
    at DatasetSelector.render (DatasetSelector.jsx:117)
    at finishClassComponent (react-dom.development.js:17160)
    at updateClassComponent (react-dom.development.js:17110)
    at beginWork (react-dom.development.js:18620)
    at HTMLUnknownElement.callCallback (react-dom.development.js:188)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237)
    at invokeGuardedCallback (react-dom.development.js:292)
    at beginWork$1 (react-dom.development.js:23203)
    at performUnitOfWork (react-dom.development.js:22154)
    at workLoopSync (react-dom.development.js:22130)
``` 

Testing with other 2D datasets gives the same result. 

It looks like the 2D datasets have an empty array for the `datasetDepths` prop. This allows them to pass the `if (this.props.depth && this.props.datasetDepths) {` conditional on line 160 of DatasetSelector.jsx but causes an error when trying to filter that array which crashes the navigator during the `SelectBox` component creation. 

To prevent 2D datasets from passing the conditional I added another conditional to check the length of `props.datasetDepths`.

## Why did you take this approach?
This check ensures that the `datasetDepths` isn't empty before trying to create the depth `SelectBox`. The `this.props.datasetDepths` check ensure that we don't try to create a `SelectBox` before the depths have been initialised (which would also cause a crash) and the `if this.props.datasetDepths.length > 0` ensures that the empty arrays of 2D datasets skip this block. Because JS uses 'short-circuit' evaluation we can apply both in this order without having to worry about trying to get the length of an undefined array. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
