### PR TITLE
Restore-2D-Dataset-Virutal-Mooring-functionality

### DIFF
--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -319,8 +319,9 @@ class PointWindow extends React.Component {
 
     // Only show depth and scale selector for Mooring tab.
     const showDepthVariableScale = this.state.selected === TabEnum.MOORING;
-    const depthVariableScale = showDepthVariableScale && 
-      this.props.datasetDepths ? <div>
+    const depthScale = showDepthVariableScale && 
+      this.props.datasetDepths &&
+      this.props.datasetDepths.length > 0 ? <div>
         <SelectBoxAlias 
           id={"depth-selector-point-window"}
           name={"depth"}
@@ -339,7 +340,9 @@ class PointWindow extends React.Component {
             })[0].id
           }
         />
+       </div> : null;
 
+    const variableRangeScale = <div>
         <ComboBox
           key='variable'
           id='variable'
@@ -357,7 +360,7 @@ class PointWindow extends React.Component {
           def={""}
           onUpdate={this.onLocalUpdate}
           title={_("Variable Range")} />
-      </div> : null;
+      </div>;
 
     // Show multidepth selector on for Stick tab
     const showMultiDepthAndVector = this.state.selected === TabEnum.STICK;
@@ -502,7 +505,7 @@ class PointWindow extends React.Component {
         plot_query.colormap = this.state.colormap;
         plot_query.scale = this.state.scale;
 
-        inputs = [global, timeRange, depthVariableScale];
+        inputs = [global, timeRange, depthScale, variableRangeScale];
         if (this.state.depth == "all") {
           // Add Colormap selector
           inputs.push(


### PR DESCRIPTION
## Background
I missed it when working on #913 but this same issue is present in the `PointWindow` component. Here it causes a crash when the users selects the Virtual Mooring tab for a 2D dataset. 

## Why did you take this approach?
As before, checking the length of `props.datasetDepths` ensures that the dataset is 3D before trying to create a depth `SelectBox` component. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
