### PR TITLE
Add onUpdateOptions to Variable selectors

### DIFF
--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -316,6 +316,7 @@ class LineWindow extends React.Component {
             id='dataset_0'
             state={this.props.dataset_0}
             onUpdate={this.props.onUpdate}
+            onUpdateOptions={this.props.onUpdateOptions}
             depth={this.state.selected == 2}
             variables={this.state.selected == 2 ? "all" : "3d"}
             time={this.state.selected == 2 ? "range" : "single"}
@@ -366,6 +367,7 @@ class LineWindow extends React.Component {
               id='dataset_1'
               state={this.props.dataset_1}
               onUpdate={this.props.onUpdate}
+              onUpdateOptions={this.props.onUpdateOptions}
               depth={this.state.selected == 2}
               variables={this.state.selected == 2 ? "all" : "3d"}
               time={this.state.selected == 2 ? "range" : "single"}

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -642,6 +642,7 @@ class OceanNavigator extends React.Component {
             colormap={this.state.colormap}
             names={this.state.names}
             onUpdate={this.updateState}
+            onUpdateOptions={this.updateOptions}
             init={this.state.subquery}
             dataset_compare={this.state.dataset_compare}
             dataset_1={this.state.dataset_1}

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -349,6 +349,7 @@ class PointWindow extends React.Component {
           state={this.props.variable}
           def=''
           onUpdate={this.props.onUpdate}
+          onUpdateOptions={this.props.onUpdateOptions}
           url={"/api/v1.0/variables/?dataset="+this.props.dataset}
           title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
 


### PR DESCRIPTION
## Background
Changing the variable in the Point Window's Virtual Mooring tab and the Line Window causes the Navigator to crash. The variable's interpolation options were left undefined because the `onUpdateOptions` function was missing from the variable ComboBox and DatasetSelector components in these windows. This issue was previously addressed in PR #903 but the functionality was since broken. 

## Why did you take this approach?
Passing the `onUpdateOptions` function to these components fixes this problem by giving the Navigator a way to update the interpolation options when the variable is changed from within the Point and Line windows. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
