### PR TITLE
Eliminate duplicate API calls in `DatasetSelector` component

### DIFF
--- a/bin/launch-web-service.sh
+++ b/bin/launch-web-service.sh
@@ -17,4 +17,4 @@ echo " "
 echo "Use the following IP in your URL ${HOST_IP}:$((PORT))"
 echo " "
 echo "This will log information from the application to the screen and the logfile."
-exec bash runserver.sh $PORT &> >(tee -a ${HOME}/launch-on-web-service.log)
+exec bash runserver.sh $PORT 

--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -3,7 +3,7 @@
 # Usage: ./runserver.sh <port> <optional_dataset_config_file.json>
 # <optional_dataset_config_file.json>:  Specify a non-default dataset config file to load the Navigator with.
 #                                       Argument not required.
-WORKER_THREADS=2
+WORKER_THREADS=1
 
 [[ "$1" == "" ]] && PORT=5000 || PORT=$1
 
@@ -25,4 +25,4 @@ else
 
 fi
 
-gunicorn -w $((NUMBER_WORKERS)) --threads $((WORKER_THREADS)) --worker-class=gthread -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2
+gunicorn --error-log ${HOME}/gunicorn.log -w 4 --threads $((WORKER_THREADS)) --worker-class=gthread -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2 --daemon

--- a/data/calculated.py
+++ b/data/calculated.py
@@ -127,7 +127,18 @@ class CalculatedArray():
         data_array = self._parser.parse(
             self._expression, self._parent, key, self._dims)
 
-        return xr.DataArray(data_array, attrs=self.attrs)
+        if hasattr(data_array, 'dims'): 
+            dims = data_array.dims
+        else: 
+            dims = self._dims
+
+        key = [filter(lambda k: type(k) is slice, key)]
+        return xr.DataArray(
+                    data = np.reshape(data_array.data, [k.stop - k.start for k in key]), 
+                    dims = dims,
+                    coords = {str(d) : self._parent.coords[d][k] for d,k in zip(dims,key)},
+                    attrs = self.attrs
+                )
 
     def __calculate_var_shape(self) -> tuple:
         # Determine shape of calculated variable based on its

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -71,10 +71,7 @@ def bearing(north_vel: xr.DataArray, east_vel: xr.DataArray) -> xr.DataArray:
 
     bearing = np.arctan2(north_vel, east_vel)
     bearing = np.pi / 2.0 - bearing
-
-    negative_bearings = np.nonzero(bearing < 0)
-    bearing.values[negative_bearings] += 2 * np.pi
-    
+    bearing = xr.where(bearing < 0, bearing + 2*np.pi, bearing)
     bearing *= 180.0 / np.pi
 
     # Deal with undefined angles (where velocity is 0 or very close)

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -356,7 +356,7 @@ class NetCDFData(Data):
         # Filter out unwanted variables
         output_vars = query.get('variables').split(',')
         # Keep the coordinate variables
-        output_vars.extend([depth_var, time_var, lat_var, lon_var])
+        output_vars.extend(filter(None, [depth_var, time_var, lat_var, lon_var]))
         for variable in subset.data_vars:
             if variable not in output_vars:
                 subset = subset.drop(variable)

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -371,6 +371,8 @@ class NetCDFData(Data):
                                               y_coord: y_slice,
                                               x_coord: x_slice
                                           })})
+                # Convert 'dims' attr to string (allows exporting to NC3 formats)            
+                subset[variable].attrs['dims'] = "(" + ",".join(subset[variable].attrs['dims']) + ")"
 
         output_format = query.get('output_format')
         filename = dataset_name + "_" + "%dN%dW-%dN%dW" % (p0.latitude, p0.longitude, p1.latitude, p1.longitude) \

--- a/kml
+++ b/kml
@@ -1,0 +1,1 @@
+/data/kml

--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -15,6 +15,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "axios": "^0.21.2",
+    "axios-extensions": "^3.1.3",
     "bootstrap": "^3.3.7",
     "bower": "^1.8.8",
     "dateformat": "^2.0.0",
@@ -24,9 +25,9 @@
     "fast-deep-equal": "^3.1.3",
     "fast-stable-stringify": "1.0.0",
     "font-awesome": "^4.7.0",
+    "glob-parent": "^5.1.2",
     "i18next": "^20.3.5",
     "i18next-browser-languagedetector": "^6.1.2",
-    "glob-parent": "^5.1.2",
     "jquery": "~3.5.0",
     "jquery-ui": "^1.12.1",
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -178,13 +178,13 @@ class AreaWindow extends React.Component {
       queryString = "&min_range=" + min_range +
                       "&max_range=" + max_range;
     }
-
+    const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
     window.location.href = "/api/v1.0/subset/?" +
        "&output_format=" + this.state.output_format +
        "&dataset_name=" + this.state.dataset_0.dataset +
        "&variables=" + this.state.output_variables.join() +
         queryString +
-       "&time=" + [this.state.output_starttime, this.state.output_endtime].join() +
+       "&time=" + [this.state.output_starttime, output_endtime].join() +
        "&user_grid=" + (this.state.convertToUserGrid ? 1 : 0) +
        "&should_zip=" + (this.state.zip ? 1 : 0);
   }

--- a/oceannavigator/frontend/src/components/ComboBox.jsx
+++ b/oceannavigator/frontend/src/components/ComboBox.jsx
@@ -77,18 +77,9 @@ class ComboBox extends React.Component {
           values.push(dataset[key]);
         }
       }
-      //Check if this is a combobox is for variable
-      if(this.props.id === "variable"){
-        const variableConfig = this.state.data[e.target.selectedIndex];
-        keys.push("options");
-        values.push(variableConfig.interp);
-      }
 
       // Update OceanNavigator state
       this.props.onUpdate(keys, values);
-      if (this.props.onUpdateOptions && keys.includes("options")){
-        this.props.onUpdateOptions(values[keys.indexOf("options")]); 
-      }
     }
   }
 
@@ -105,11 +96,6 @@ class ComboBox extends React.Component {
         url: props.url,
         dataType: "json",
         cache: true,
-        
-        //If server returns status code of 200 / it worked - Ajax call successful
-        //
-        // data filled by ajax
-        //
         success: function (data) {
           if (this._mounted) {  //Combobox is mounted
 

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -1,55 +1,257 @@
-/* eslint react/no-deprecated: 0 */
-
 import React from "react";
-import ComboBox from "./ComboBox.jsx";
-import TimePicker from "./TimePicker.jsx";
 import PropTypes from "prop-types";
-import VelocitySelector from "./VelocitySelector.jsx";
+import { Modal, ProgressBar } from "react-bootstrap";
+
+import TimePicker from "./TimePicker.jsx";
+import Range from "./Range.jsx";
 import SelectBox from "./lib/SelectBox.jsx";
+
+import {
+  GetDatasetsPromise,
+  GetVariablesPromise,
+  GetTimestampsPromise,
+  GetDepthsPromise
+} from "../remote/OceanNavigator.js";
+
+import { DATASET_DEFAULTS } from "./Defaults.js";
 
 import { withTranslation } from "react-i18next";
 
-// Default properties for a dataset-state
-const DATA_ELEMS = [
+const PARENT_ATTRIBUTES_TO_UPDATE = Object.freeze([
   "dataset",
-  "dataset_attribution",
-  "dataset_quantum",
+  "quantum",
   "variable",
   "variable_scale", // Default range values for variable
   "depth",
   "time",
   "starttime",
   "quiverVariable",
-];
+]);
 
 class DatasetSelector extends React.Component {
   constructor(props) {
     super(props);
 
+    // TODO: Move these into Default.js
+    this.DEF_INTERP_TYPE = Object.freeze("gaussian");
+    this.DEF_INTERP_RADIUS_KM = Object.freeze(25);
+    this.DEF_INTERP_NUM_NEIGHBOURS = Object.freeze(10);
+
+    this.state = {
+      loading: false,
+      loadingPercent: 0,
+      loadingTitle: "",
+      datasetVariables: [],
+      datasetTimestamps: [],
+      datasetDepths: [],
+      options: {
+        ...props.options,
+      },
+      ...DATASET_DEFAULTS,
+    };
+
     // Function bindings
-    this.variableUpdate = this.variableUpdate.bind(this);
     this.onUpdate = this.onUpdate.bind(this);
   }
 
-  variableUpdate(key, value) {
-    this.props.onUpdate("setDefaultScale", true);
-    this.onUpdate(key, value);
+  changeDataset(newDataset, currentVariable) {
+    const currentDataset = this.state.availableDatasets.filter((d) => {
+      return d.id === newDataset;
+    })[0];
+
+    this.setState({
+      loading: true,
+      loadingPercent: 10,
+      loadingTitle: `${currentDataset.value}`
+    });
+
+    const quantum = currentDataset.quantum;
+
+    GetVariablesPromise(newDataset).then(variableResult => {
+      this.setState({ loadingPercent: 33 });
+
+      // Carry the currently selected variable to the new
+      // dataset if said variable exists in the new dataset.
+      let newVariable = currentVariable;
+      let newVariableScale = this.state.variable_scale;
+      let interpType = this.state.options.interpType;
+      let interpRadius = this.state.options.interpRadius;
+      let interpNeighbours = this.state.options.interpNeighbours;
+      const variableIds = variableResult.data.map(v => { return v.id; });
+      if (!variableIds.includes(currentVariable)) {
+        newVariable = variableResult.data[0].id;
+        newVariableScale = variableResult.data[0].scale;
+        interpType = variableResult.data[0].interp?.interpType || this.DEF_INTERP_TYPE;
+        interpRadius = variableResult.data[0].interp?.interpRadius || this.DEF_INTERP_RADIUS_KM;
+        interpNeighbours = variableResult.data[0].interp?.interpNeighbours || this.DEF_INTERP_NUM_NEIGHBOURS;
+      }
+
+      // eslint-disable-next-line max-len
+      GetTimestampsPromise(newDataset, newVariable).then(timeResult => {
+        this.setState({ loadingPercent: 75 });
+        
+        const timeData = timeResult.data;
+
+        const newTime = timeData[timeData.length - 1].id;
+        const newStarttime = timeData[0].id;
+
+        // eslint-disable-next-line max-len
+        GetDepthsPromise(newDataset, newVariable).then(depthResult => {
+          this.setState({ loadingPercent: 90 });
+
+          // Update everything in one shot/
+          // transaction
+          // if ALL API requests succeed.
+          // Avoids many small state updates
+          // which leads to bad performance,
+          // increases risk of race
+          // conditions, and having the UI
+          // in a bad state if one of the 
+          // API calls fail.
+          this.setState({
+            loading: false,
+            loadingPercent: 0,
+
+            dataset: newDataset,
+
+            quantum: quantum,
+
+            datasetVariables: variableResult.data,
+            variable: newVariable,
+            variable_scale: newVariableScale,
+            quiverVariable: "none",
+
+            time: newTime,
+            starttime: newStarttime,
+            datasetTimestamps: timeData,
+
+            datasetDepths: depthResult.data,
+            depth: 0, // Default to surface for simplicity but could change later
+
+            options: {
+              ...this.props.options,
+              interpType: interpType,
+              interpRadius: interpRadius,
+              interpNeighbours: interpNeighbours,
+            }
+          }, () => {
+
+            const parentState = {};
+            for (const attrib of PARENT_ATTRIBUTES_TO_UPDATE) {
+              parentState[attrib] = this.state[attrib];
+            }
+
+            this.props.onUpdate(this.props.id, parentState);
+          });
+
+        },
+          error => {
+            this.setState({ loading: false, loadingPercent: 0 });
+            console.error(error);
+          });
+
+      },
+        error => {
+          this.setState({ loading: false, loadingPercent: 0 });
+          console.error(error);
+        });
+
+    },
+      error => {
+        this.setState({ loading: false, loadingPercent: 0 });
+        console.error(error);
+      });
+  }
+
+  changeVariable(newVariable) {
+    let newState = {};
+    
+    // Multiple variables were selected
+    // so don't update everything else
+    if (newVariable instanceof HTMLCollection) {
+      newState = {
+        variable: Array.from(newVariable).map(o => o.value),
+      };
+    }
+    else {
+      const variable = this.state.datasetVariables.find(v => v.id === newVariable);
+
+      newState = {
+        variable: newVariable,
+        variable_scale: variable.scale,
+        options: {
+          ...this.state.options,
+          interpType: variable.interp?.interpType || this.DEF_INTERP_TYPE,
+          interpRadius: variable.interp?.interpRadius || this.DEF_INTERP_RADIUS_KM,
+          interpNeighbours: variable.interp?.interpNeighbours || this.DEF_INTERP_NUM_NEIGHBOURS,
+        }
+      };
+    }
+
+    this.setState(newState);
+
+    this.props.onUpdate(this.props.id, newState);
+  }
+
+  componentDidMount() {
+    GetDatasetsPromise().then(result => {
+      this.setState({
+        availableDatasets: result.data,
+      }, () => {
+        // This if-check passes when a point, line, or area window
+        // is first created by drawing something on the main map.
+        // We wish to copy the selected dataset and variable to 
+        // the pop up windows for convenience.
+        if (this.props.mountedDataset && this.props.mountedVariable) {
+          this.changeDataset(this.props.mountedDataset, this.props.mountedVariable);
+        }
+        else {
+          // Use defaults in DATASET_DEFAULTS
+          this.changeDataset(this.state.dataset, this.state.variable);
+        }
+      });
+    },
+      error => {
+        console.error(error);
+      });
+  }
+
+  nothingChanged(key, value) {
+    return this.state[key] === value;
+  }
+
+  datasetChanged(key) {
+    return key === "dataset";
+  }
+
+  variableChanged(key) {
+    return key === "variable";
   }
 
   onUpdate(key, value) {
-    const newState = DATA_ELEMS.reduce((a,b) => {
-      a[b] = this.props.state[b];
-      return a;
-    }, {});
-
-    if (typeof(key) === "string") {
-      newState[key] = value;
-    } 
-    else {
-      for (let i = 0; i < key.length; ++i) {
-        newState[key[i]] = value[i];
-      }
+    if (this.nothingChanged(key, value)) {
+      return;
     }
+
+    // There's extra logic involved with changing datasets
+    // and variables so delegate that to their own 
+    // functions.
+    if (this.datasetChanged(key)) {
+      this.changeDataset(value, this.state.variable);
+      return;
+    }
+
+    if (this.variableChanged(key)) {
+      this.changeVariable(value);
+      return;
+    }
+
+    const newState = {
+      [key]: value,
+    };
+
+    this.setState(newState);
+
     this.props.onUpdate(this.props.id, newState);
   }
 
@@ -58,93 +260,82 @@ class DatasetSelector extends React.Component {
     _("Variable");
     _("Depth");
     _("Time (UTC)");
+    _("Start Time (UTC)");
+    _("End Time (UTC)");
     _("Quiver Variable");
+    _("Variable Range");
 
-    let variables = "";
-    switch (this.props.variables) {
-      case "3d":
-        variables = "&3d_only";
-        break;
-      default:
-        break;
+    let datasetSelector = null;
+    // eslint-disable-next-line max-len
+    if (this.state.availableDatasets && this.state.availableDatasets.length > 0 && !this.state.loading) {
+      datasetSelector = <SelectBox
+        id={`dataset-selector-dataset-selector-${this.props.id}`}
+        name="dataset"
+        label={_("Dataset")}
+        placeholder={_("Dataset")}
+        options={this.state.availableDatasets.map(d => {
+          return { id: d.id, value: d.value };
+        })}
+        onChange={this.onUpdate}
+        selected={this.state.dataset}
+      />;
     }
 
-    // Determine which timepicker we need
-    let time = "";
-    switch (this.props.time) {
-      case "range":
-        time = (<div>
+    let timeSelector = null;
+    if (this.state.datasetTimestamps && !this.state.loading) {
+      if (this.props.showTimeRange) {
+        timeSelector = (<div>
           <TimePicker
             key='starttime'
             id='starttime'
-            state={this.props.state.starttime}
+            state={this.state.starttime}
             def=''
-            quantum={this.props.state.dataset_quantum}
-            url={"/api/v1.0/timestamps/?dataset=" +
-                this.props.state.dataset +
-                "&variable=" +
-                this.props.state.variable
-            }
-            title={_("Start Time")}
+            quantum={this.state.quantum}
+            title={_("Start Time (UTC)")}
             onUpdate={this.onUpdate}
-            max={this.props.state.time}
+            max={this.state.time}
+            dataset={this.state.dataset}
+            variable={this.state.variable}
           />
           <TimePicker
             key='time'
             id='time'
-            state={this.props.state.time}
+            state={this.state.time}
             def=''
-            quantum={this.props.state.dataset_quantum}
-            url={"/api/v1.0/timestamps/?dataset=" +
-                this.props.state.dataset +
-                "&variable=" +
-                this.props.state.variable
-            }
-            title={_("End Time")}
+            quantum={this.state.quantum}
+            title={_("End Time (UTC)")}
             onUpdate={this.onUpdate}
-            min={this.props.state.starttime}
+            min={this.state.starttime}
+            dataset={this.state.dataset}
+            variable={this.state.variable}
           />
         </div>);
-        break;
-      case "single":
-      default:
-        time = <TimePicker
+      }
+      else {
+        timeSelector = <TimePicker
           key='time'
           id='time'
-          state={this.props.state.time}
+          state={this.state.time}
           def={-1}
-          quantum={this.props.state.dataset_quantum}
+          quantum={this.state.quantum}
           onUpdate={this.onUpdate}
-          url={"/api/v1.0/timestamps/?dataset=" +
-            this.props.state.dataset +
-            "&variable=" +
-            this.props.state.variable
-          }
           title={_("Time (UTC)")}
+          dataset={this.state.dataset}
+          variable={this.state.variable}
         />;
-    }
-
-    let velocity_selector = null;
-    if(this.props.line && !this.props.compare && (this.props.state.variable === "vozocrtx,vomecrty" || this.props.state.variable === "east_vel,north_vel")) {
-      velocity_selector = [
-        <VelocitySelector
-          key='velocityType'
-          id='velocityType'
-          updateSelectedPlots={this.props.updateSelectedPlots}
-        />
-      ];  
+      }
     }
 
     let quiverSelector = null;
-    if (this.props.showQuiverSelector) {
+    if (this.props.showQuiverSelector && !this.state.loading) {
       let quiverVariables = [];
-      if (this.props.datasetVariables) {
-        quiverVariables = this.props.datasetVariables.filter((variable) => {
+      if (this.state.datasetVariables) {
+        quiverVariables = this.state.datasetVariables.filter((variable) => {
           return variable.id.includes("mag") && variable.id.includes("vel");
         });
       }
       quiverVariables.unshift({ id: "none", value: "None" });
-  
+
       quiverSelector = <SelectBox
         id={`dataset-selector-quiver-selector-${this.props.id}`}
         name="quiverVariable"
@@ -152,24 +343,25 @@ class DatasetSelector extends React.Component {
         placeholder={_("Quiver Variable")}
         options={quiverVariables}
         onChange={this.onUpdate}
-        selected={this.props.state.quiverVariable}
+        selected={this.state.quiverVariable}
       />;
     }
 
     let depthSelector = null;
-    if (this.props.depth && this.props.datasetDepths) {
-      depthSelector = <SelectBox 
+    // eslint-disable-next-line max-len
+    if (this.props.showDepthSelector && this.state.datasetDepths && this.state.datasetDepths.length > 0 && !this.state.loading) {    
+      depthSelector = <SelectBox
         id={`dataset-selector-depth-selector-${this.props.id}`}
         name={"depth"}
         label={_("Depth")}
         placeholder={_("Depth")}
-        options={this.props.datasetDepths.filter(d => d.id !== "all")}
+        options={this.props.showDepthsAll ? this.state.datasetDepths : this.state.datasetDepths.filter(d => d.id !== "all")}
         onChange={this.onUpdate}
         selected={
-          this.props.datasetDepths.filter(d => {
-            let depth = parseInt(this.props.state.depth);
+          this.state.datasetDepths.filter(d => {
+            let depth = parseInt(this.state.depth);
             if (isNaN(depth)) { // when depth == "bottom" or "all"
-              depth = this.props.state.depth;
+              depth = this.state.depth;
             }
 
             return d.id === depth;
@@ -178,66 +370,122 @@ class DatasetSelector extends React.Component {
       />;
     }
 
+    let variableSelector = null;
+    if (this.props.showVariableSelector && this.state.datasetVariables && this.state.datasetVariables.length > 0 && !this.state.loading) {
+      let options = [];
+      if (this.props.variables === "3d") {
+        options = this.state.datasetVariables.filter(v => {
+          return v.two_dimensional === false;
+        });
+      }
+      else {
+        options = this.state.datasetVariables;
+      }
+
+      // Work-around for when someone selected a plot that requires
+      // 3D variables, but the selected dataset doesn't have any LOL.
+      // This check prevents a white-screen crash.
+      const stillHasVariablesToShow = options.length > 0;
+
+      let selected = this.state.variable;
+      if (this.props.multipleVariables && !Array.isArray(selected)) {
+        selected = [selected];
+      }
+
+      variableSelector = stillHasVariablesToShow && <SelectBox
+        id={`dataset-selector-variable-selector-${this.props.id}`}
+        name={"variable"}
+        label={_("Variable")}
+        placeholder={_("Variable")}
+        options={options}
+        onChange={this.onUpdate}
+        selected={selected}
+        multiple={this.props.multipleVariables}
+      />;
+    }
+
+    let variableRange = null;
+    if (this.props.showVariableRange && this.state.datasetVariables && this.state.datasetVariables.length > 0 && !this.state.loading) {
+      variableRange = <Range
+        id='variable_scale'
+        state={this.state.variable_scale}
+        title={_("Variable Range")}
+        onUpdate={this.onUpdate}
+        default_scale={this.state.datasetVariables
+          .find(v => v.id === this.state.variable).scale
+        }
+        autourl={"/api/v1.0/range/" +
+                  this.state.dataset + "/" + 
+                  this.state.variable + "/" +
+                  this.props.options.interpType + "/" +
+                  this.props.options.interpRadius + "/" +
+                  this.props.options.interpNeighbours + "/" +
+                  this.props.projection + "/" +
+                  this.props.extent.join(",") + "/" +
+                  this.state.depth + "/" +
+                  this.state.time + ".json"
+        }
+      />;
+    }
+
     return (
-      <div className='DatasetSelector'>
+      <div id={`dataset-selector-${this.props.id}`} className='DatasetSelector'>
 
-        <ComboBox
-          id='dataset'
-          state={this.props.state.dataset}
-          def={"defaults.dataset"}
-          onUpdate={this.onUpdate}
-          url='/api/v1.0/datasets/'
-          title={_("Dataset")}></ComboBox>
+        {datasetSelector}
 
-        <ComboBox
-          id='variable'
-          multiple={this.props.multiple}
-          state={this.props.state.variable}
-          def={"defaults.dataset"}
-          onUpdate={this.variableUpdate}
-          onUpdateOptions={this.props.onUpdateOptions}
-          url={"/api/v1.0/variables/?dataset=" + this.props.state.dataset + variables
-          }
-          title={_("Variable")}
-        ><h1>{_("Variable")}</h1></ComboBox>
-
-        {velocity_selector}
+        {variableSelector}
 
         {quiverSelector}
 
         {depthSelector}
-        
-        {time}
 
+        {timeSelector}
+
+        {variableRange}
+
+        <Modal
+          show={this.state.loading}
+          backdrop
+          size="sm"
+          style={{top: '33%'}}
+        >
+          <Modal.Header>
+            <Modal.Title>Loading {this.state.loadingTitle}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <ProgressBar active now={this.state.loadingPercent} />
+          </Modal.Body>
+        </Modal>
       </div>
     );
   }
 }
 
+
 //***********************************************************************
 DatasetSelector.propTypes = {
-  state: PropTypes.object,
-  variable: PropTypes.string,
-  depth: PropTypes.bool,
-  dataset: PropTypes.string,
-  time: PropTypes.string,
-  dataset_quantum: PropTypes.string,
-  starttime: PropTypes.number,
-  onUpdate: PropTypes.func,
-  id: PropTypes.string,
+  onUpdate: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
   variables: PropTypes.string,
-  multiple: PropTypes.bool,
-  line: PropTypes.bool,
-  updateSelectedPlots: PropTypes.func,
-  compare: PropTypes.bool,
-  availableDatasets: PropTypes.arrayOf(PropTypes.object),
-  datasetVariables: PropTypes.arrayOf(PropTypes.object),
+  multipleVariables: PropTypes.bool,
   showQuiverSelector: PropTypes.bool,
-  datasetDepths: PropTypes.arrayOf(PropTypes.object),
+  showTimeRange: PropTypes.bool,
+  showDepthSelector: PropTypes.bool,
+  showVariableRange: PropTypes.bool,
+  showVariableSelector: PropTypes.bool,
+  showDepthsAll: PropTypes.bool,
+  mountedDataset: PropTypes.string,
+  mountedVariable: PropTypes.string,
 };
 
 DatasetSelector.defaultProps = {
   showQuiverSelector: true,
+  multipleVariables: false,
+  showTimeRange: false,
+  showDepthSelector: true,
+  showVariableRange: true,
+  showVariableSelector: true,
+  showDepthsAll: false,
 };
 
 export default withTranslation()(DatasetSelector);

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -350,7 +350,7 @@ class DatasetSelector extends React.Component {
     let depthSelector = null;
     // eslint-disable-next-line max-len
     if (this.props.showDepthSelector && this.state.datasetDepths && this.state.datasetDepths.length > 0 && !this.state.loading) {    
-      depthSelector = <SelectBox
+      depthSelector = <SelectBox 
         id={`dataset-selector-depth-selector-${this.props.id}`}
         name={"depth"}
         label={_("Depth")}
@@ -434,7 +434,7 @@ class DatasetSelector extends React.Component {
         {datasetSelector}
 
         {variableSelector}
-
+        
         {quiverSelector}
 
         {depthSelector}

--- a/oceannavigator/frontend/src/components/Defaults.js
+++ b/oceannavigator/frontend/src/components/Defaults.js
@@ -1,0 +1,25 @@
+
+const DATASET_DEFAULTS = Object.freeze({
+  dataset: "giops_day",
+  attribution: "",
+  quantum: "day",
+  depth: 0,
+  time: -1,
+  starttime: -2,
+  variable: "votemper",
+  quiverVariable: "none",
+  variable_scale: [-5, 30],
+});
+
+const DEFAULT_OPTIONS = Object.freeze({
+  interpType: "gaussian",
+  interpRadius: 25, // km
+  interpNeighbours: 10,
+
+  mapBathymetryOpacity: 0.75, // Opacity of bathymetry contours
+  topoShadedRelief: false,    // Show relief mapping on topography
+  bathymetry: true,           // Show bathymetry contours
+  bathyContour: "etopo1",
+});
+
+export { DATASET_DEFAULTS, DEFAULT_OPTIONS };

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -19,7 +19,6 @@ import CustomPlotLabels from "./CustomPlotLabels.jsx";
 
 
 import { withTranslation } from "react-i18next";
-const stringify = require("fast-stable-stringify");
 
 class LineWindow extends React.Component {
   constructor(props) {
@@ -30,8 +29,8 @@ class LineWindow extends React.Component {
     
     this.state = {
       selected: 1,
-      scale: props.scale + ",auto",
-      scale_1: props.scale_1 + ",auto",
+      scale: props.dataset_0.variable_scale + ",auto",
+      scale_1: props.dataset_1.variable_scale + ",auto",
       scale_diff: "-10,10,auto",
       colormap: "default",
       colormap_right: "default", // Colourmap for second (right) plot
@@ -63,29 +62,6 @@ class LineWindow extends React.Component {
 
   componentWillUnmount() {
     this._mounted = false;
-  }
-
-  componentWillReceiveProps(props) {
-
-    if (stringify(this.props) !== stringify(props) && this._mounted) {
-
-      if (props.depth !== this.props.depth) {
-        this.setState({
-          depth: props.depth,
-        });
-      }
-      if (props.scale !== this.props.scale) {
-        if (this.state.scale.indexOf("auto") !== -1) {
-          this.setState({
-            scale: props.scale + ",auto"
-          });
-        } else {
-          this.setState({
-            scale: props.scale,
-          });
-        }
-      }
-    }
   }
 
   //Updates Plot with User Specified Title
@@ -312,28 +288,17 @@ class LineWindow extends React.Component {
       <Panel.Collapse>
         <Panel.Body>
           <DatasetSelector
-            key='dataset_0'
+            key='line_window_dataset_0'
             id='dataset_0'
-            state={this.props.dataset_0}
             onUpdate={this.props.onUpdate}
-            depth={this.state.selected == 2}
             variables={this.state.selected == 2 ? "all" : "3d"}
-            time={this.state.selected == 2 ? "range" : "single"}
-            line={true}
-            updateSelectedPlots={this.updateSelectedPlots}
-            compare={this.props.dataset_compare}
             showQuiverSelector={false}
-            datasetDepths={this.props.datasetDepths}
-          />
-
-          <Range
-            auto
-            key='scale'
-            id='scale'
-            state={this.state.scale}
-            def={""}
-            onUpdate={this.onLocalUpdate}
-            title={_("Variable Range")}
+            showDepthSelector={this.state.selected == 2}
+            showTimeRange={this.state.selected == 2}
+            showVariableRange={false}
+            options={this.props.options}
+            mountedDataset={this.props.dataset_0.dataset}
+            mountedVariable={this.props.dataset_0.variable}
           />
 
           <ComboBox
@@ -362,24 +327,17 @@ class LineWindow extends React.Component {
         <Panel.Collapse>
           <Panel.Body>
             <DatasetSelector
-              key='dataset_1'
+              key='line_window_dataset_1'
               id='dataset_1'
-              state={this.props.dataset_1}
               onUpdate={this.props.onUpdate}
-              depth={this.state.selected == 2}
               variables={this.state.selected == 2 ? "all" : "3d"}
-              time={this.state.selected == 2 ? "range" : "single"}
+              updateSelectedPlots={this.updateSelectedPlots}
               showQuiverSelector={false}
-              datasetDepths={this.props.datasetDepths}
-            />
-            <Range
-              auto
-              key='scale_1'
-              id='scale_1'
-              state={this.state.scale_1}
-              def={""}
-              onUpdate={this.onLocalUpdate}
-              title={_("Variable Range")}
+              showDepthSelector={this.state.selected == 2}
+              showTimeRange={this.state.selected == 2}
+              showVariableRange={false}
+              mountedDataset={this.props.dataset_1.dataset}
+              mountedVariable={this.props.dataset_1.variable}
             />
             <ComboBox
               key='colormap_right'
@@ -404,8 +362,8 @@ class LineWindow extends React.Component {
     }
     const plot_query = {
       dataset: this.props.dataset_0.dataset,
-      quantum: this.props.quantum,
-      variable: this.props.variable,
+      quantum: this.props.dataset_0.quantum,
+      variable: this.props.dataset_0.variable,
       path: this.props.line[0],
       scale: this.state.scale,
       colormap: this.state.colormap,
@@ -419,7 +377,7 @@ class LineWindow extends React.Component {
     switch(this.state.selected) {
       case 1:
         plot_query.type = "transect";
-        plot_query.time = this.props.time;
+        plot_query.time = this.props.dataset_0.time;
         plot_query.surfacevariable = this.state.surfacevariable;
         plot_query.linearthresh = this.state.linearthresh;
         plot_query.depth_limit = this.state.depth_limit;
@@ -435,9 +393,9 @@ class LineWindow extends React.Component {
         break;
       case 2:
         plot_query.type = "hovmoller";
-        plot_query.endtime = this.props.time;
+        plot_query.endtime = this.props.dataset_0.time;
         plot_query.starttime = this.props.dataset_0.starttime;
-        plot_query.depth = this.props.depth;
+        plot_query.depth = this.props.dataset_0.depth;
         if (this.props.dataset_compare) {
           plot_query.compare_to = this.props.dataset_1;
           plot_query.compare_to.scale = this.state.scale_1;
@@ -481,23 +439,16 @@ class LineWindow extends React.Component {
 //***********************************************************************
 LineWindow.propTypes = {
   generatePermLink: PropTypes.func,
-  depth: PropTypes.number,
-  time: PropTypes.number,
   dataset_compare: PropTypes.bool,
-  dataset_1: PropTypes.object,
+  dataset_0: PropTypes.object.isRequired,
+  dataset_1: PropTypes.object.isRequired,
   names: PropTypes.array,
   line: PropTypes.array,
-  variable: PropTypes.string,
-  quantum: PropTypes.string,
-  dataset_0: PropTypes.object,
   onUpdate: PropTypes.func,
-  scale: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  scale_1: PropTypes.string,
   init: PropTypes.object,
   action: PropTypes.func,
   swapViews: PropTypes.func,
   showHelp: PropTypes.func,
-  datasetDepths: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withTranslation()(LineWindow);

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -170,6 +170,10 @@ export default class Map extends React.PureComponent {
       location: [0, 90],
     };
 
+    this.scaleViewer = new app.ScaleViewer({
+      image: "/api/v1.0/scale/giops_day/votemper/-5,30.png",
+    });
+
     this.loader = function (extent, resolution, projection) {
       if (this.props.state.vectortype) {
         let url = "";
@@ -671,6 +675,7 @@ export default class Map extends React.PureComponent {
         }),
       ])
     });
+    this.map.addControl(this.scaleViewer);
     this.map.on("moveend", this.refreshFeatures.bind(this));
     this.map.on("moveend", function () {
       const c = olproj.transform(this.mapView.getCenter(), this.props.state.projection, "EPSG:4326").map(function (c) { return c.toFixed(4); });
@@ -1318,8 +1323,8 @@ export default class Map extends React.PureComponent {
   }
 
   shouldUpdateScaleViewer(currentDataset, prevDataset,
-                          currentVariable, prevVariable,
-                           currentScale, prevScale)
+    currentVariable, prevVariable,
+    currentScale, prevScale)
   {
     return (currentDataset !== prevDataset)
           || (currentVariable !== prevVariable)
@@ -1330,11 +1335,17 @@ export default class Map extends React.PureComponent {
     if (this.scaleViewer != null) {
       this.map.removeControl(this.scaleViewer);
     }
+
+    let scale = currentScale;
+    if (Array.isArray(scale)) {
+      scale = scale.join(",");
+    }
+
     this.scaleViewer = new app.ScaleViewer({
       image: (
         `/api/v1.0/scale/${currentDataset}` +
         `/${currentVariable}` +
-        `/${currentScale}.png`
+        `/${scale}.png`
       )
     });
     this.map.addControl(this.scaleViewer);
@@ -1404,6 +1415,12 @@ export default class Map extends React.PureComponent {
     const datalayer = this.map.getLayers().getArray()[1];
     const old = datalayer.getSource();
     const props = old.getProperties();
+
+    let scale = this.props.scale;
+    if (Array.isArray(scale)) {
+      scale = scale.join(",");
+    }
+
     props.url = "/api/v1.0/tiles" +
       `/${this.props.options.interpType}` +
       `/${this.props.options.interpRadius}` +
@@ -1413,12 +1430,12 @@ export default class Map extends React.PureComponent {
       `/${this.props.state.variable}` +
       `/${this.props.state.time}` +
       `/${this.props.state.depth}` +
-      `/${this.props.scale}` +
+      `/${scale}` +
       "/{z}/{x}/{y}.png";
     props.projection = this.props.state.projection;
     props.attributions = [
       new olcontrol.Attribution({
-        html: this.props.state.dataset_attribution,
+        html: this.props.state.attribution,
       }),
     ];
 
@@ -1435,7 +1452,7 @@ export default class Map extends React.PureComponent {
                                      this.props.scale,
                                      prevProps.scale))
     {
-      this.updateScaleViewer(this.props.state.dataset, this.props.state.variable, this.props.state.scale);
+      this.updateScaleViewer(this.props.state.dataset, this.props.state.variable, this.props.scale);
     }
 
     if (this.shouldUpdateBathymetryLayer(this.props.state.projection,

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -6,7 +6,6 @@
 
 import React from "react";
 import ComboBox from "./ComboBox.jsx";
-import Range from "./Range.jsx";
 import SelectBox from "./SelectBox.jsx";
 import DatasetSelector from "./DatasetSelector.jsx";
 import {Panel, Button, Row, Col, Tabs, Tab} from "react-bootstrap";
@@ -33,7 +32,6 @@ class MapInputs extends React.Component {
   }
  
   render() {
-    _("Variable Range");
     _("Show Bathymetry Contours");
 
     //Creates Main Map Panel
@@ -44,49 +42,25 @@ class MapInputs extends React.Component {
         bsStyle='primary'
       >
         <Panel.Heading>
-          {this.props.state.dataset_compare ? _("Left Map (Anchor)") : _("Main Map")}
+          {this.props.dataset_compare ? _("Left Map (Anchor)") : _("Main Map")}
         </Panel.Heading>
         <Panel.Collapse>
           <Panel.Body>
             <DatasetSelector
+              key='map_inputs_dataset_0'
               id='dataset_0'
-              state={this.props.state}
               onUpdate={this.props.changeHandler}
-              onUpdateOptions={this.props.updateOptions}
-              depth={true}
-              availableDatasets={this.props.availableDatasets}
-              datasetVariables={this.props.datasetVariables}
-              datasetDepths={this.props.datasetDepths}
+              options={this.props.options}
+              projection={this.props.projection}
+              extent={this.props.extent}
             />
-            <Range
-              id='scale'
-              state={this.props.state.scale}
-              setDefaultScale={this.props.state.setDefaultScale}
-              def=''
-              onUpdate={this.props.changeHandler}
-              onSubmit={this.props.changeHandler}
-              title={_("Variable Range")}
-              autourl={"/api/v1.0/range/" +
-                      this.props.state.dataset + "/" + 
-                      this.props.state.variable + "/" +
-                      this.props.options.interpType + "/" +
-                      this.props.options.interpRadius + "/" +
-                      this.props.options.interpNeighbours + "/" +
-                      this.props.state.projection + "/" +
-                      this.props.state.extent.join(",") + "/" +
-                      this.props.state.depth + "/" +
-                      this.props.state.time +  ".json"
-              }
-              dataset_compare={this.props.state.dataset_compare}
-              default_scale={this.props.state.variable_scale}
-            ></Range>
           </Panel.Body>
         </Panel.Collapse>
       </Panel>
     ];
 
     // Creates Right Map Panel when comparing datasets
-    if (this.props.state.dataset_compare) {
+    if (this.props.dataset_compare) {
       inputs.push(
         <Panel
           key='right_map_panel'
@@ -97,47 +71,22 @@ class MapInputs extends React.Component {
           <Panel.Collapse>
             <Panel.Body>
               <DatasetSelector 
-                id='dataset_1'
-                state={this.props.state.dataset_1}
+                id='map_inputs_dataset_1'
                 onUpdate={this.props.changeHandler}
-                onUpdateOptions={this.props.updateOptions}
-                depth={true}
-                availableDatasets={this.props.availableDatasets}
-                datasetVariables={this.props.datasetVariables}
-                datasetDepths={this.props.datasetDepths}
+                options={this.props.options}
+                projection={this.props.projection}
+                extent={this.props.extent}
               />
-              <Range
-                key='scale_1'
-                id='scale_1'
-                state={this.props.state.scale_1}
-                setDefaultScale={this.props.state.setDefaultScale}
-                def=''
-                onUpdate={this.props.changeHandler}
-                title={_("Variable Range")}
-                autourl={"/api/v1.0/range/" +
-                        this.props.state.dataset_1.dataset + "/" +
-                        this.props.state.dataset_1.variable + "/" +
-                        this.props.options.interpType + "/" +
-                        this.props.options.interpRadius + "/" +
-                        this.props.options.interpNeighbours + "/" +
-                        this.props.state.projection + "/" +
-                        this.props.state.extent.join(",") + "/" +
-                        this.props.state.dataset_1.depth + "/" +
-                        this.props.state.dataset_1.time + ".json"
-                }
-                default_scale={this.props.state.dataset_1.variable_scale}
-              ></Range>
             </Panel.Body>
           </Panel.Collapse>
         </Panel>
       );
     }
 
-    const className = this.props.state.sidebarOpen ? "MapInputs open" : "MapInputs";
+    const className = this.props.sidebarOpen ? "MapInputs open" : "MapInputs";
 
     return (
       <div className={className}>
-
         
         <Tabs //Creates Tabs Container
           activeKey={this.state.currentTab}
@@ -158,7 +107,7 @@ class MapInputs extends React.Component {
                     <Col xs={9}>
                       <SelectBox
                         id='dataset_compare'
-                        state={this.props.state.dataset_compare}
+                        state={this.props.dataset_compare}
                         onUpdate={this.props.changeHandler}
                         title={_("Compare Datasets")}
                       />
@@ -178,12 +127,12 @@ class MapInputs extends React.Component {
                     id='syncRanges'
                     onUpdate={this.props.changeHandler}
                     title={_("Sync Variable Ranges")}
-                    style={{display: this.props.state.dataset_compare ? "block" : "none"}}
+                    style={{display: this.props.dataset_compare ? "block" : "none"}}
                   />
                   <Button
                     bsStyle="default"
                     block
-                    style={{display: this.props.state.dataset_compare ? "block" : "none"}}
+                    style={{display: this.props.dataset_compare ? "block" : "none"}}
                     onClick={this.props.swapViews}
                   >
                     {_("Swap Views")}
@@ -209,7 +158,7 @@ class MapInputs extends React.Component {
                 <Panel.Body>
                   <ComboBox   //Projection Drop Down - Hardcoded
                     id='projection'
-                    state={this.props.state.projection}
+                    state={this.props.projection}
                     onUpdate={this.props.changeHandler}
                     data={[
                       { id: "EPSG:3857", value: _("Global") },
@@ -220,7 +169,7 @@ class MapInputs extends React.Component {
                   />
                   <ComboBox   //Basemap Drop Down - Hardcoded
                     id='basemap'
-                    state={this.props.state.basemap}
+                    state={this.props.basemap}
                     onUpdate={this.props.changeHandler}
                     data={[
                       {
@@ -258,7 +207,8 @@ class MapInputs extends React.Component {
           </Tab>
         </Tabs>
         <div className='cookieBanner'>
-          This website uses Google Analytics. By continuing, you accept the usage of cookies. 
+          This website uses Google Analytics.
+          By continuing, you accept the usage of cookies. 
           <a target="_blank" rel="noopener noreferrer" href="https://www.wikihow.com/Disable-Cookies">How to Disable Cookies</a>
         </div>
       </div>
@@ -268,27 +218,17 @@ class MapInputs extends React.Component {
 
 //***********************************************************************
 MapInputs.propTypes = {
-  state: PropTypes.object,
   sidebarOpen: PropTypes.bool,
   basemap: PropTypes.string,
-  scale: PropTypes.string,
-  scale_1: PropTypes.string,
   bathymetry: PropTypes.bool,
   dataset_compare: PropTypes.bool,
-  dataset_1: PropTypes.object,
   projection: PropTypes.string,
-  depth: PropTypes.number,
-  time: PropTypes.number,
-  variable_scale: PropTypes.array,
   extent: PropTypes.array,
   changeHandler: PropTypes.func,
   swapViews: PropTypes.func,
   showHelp: PropTypes.func,
   options: PropTypes.object,
   updateOptions: PropTypes.func,
-  availableDatasets: PropTypes.arrayOf(PropTypes.object),
-  datasetVariables: PropTypes.arrayOf(PropTypes.object),
-  datasetDepths: PropTypes.arrayOf(PropTypes.object)
 };
 
 export default withTranslation()(MapInputs);

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -11,17 +11,15 @@ import {Nav, NavItem, Panel, Row, Col} from "react-bootstrap";
 import PlotImage from "./PlotImage.jsx";
 import SelectBox from "./SelectBox.jsx";
 import ComboBox from "./ComboBox.jsx";
-import TimePicker from "./TimePicker.jsx";
 import LocationInput from "./LocationInput.jsx";
-import Range from "./Range.jsx";
 import ImageSize from "./ImageSize.jsx";
 import PropTypes from "prop-types";
 import CustomPlotLabels from "./CustomPlotLabels.jsx";
+import DatasetSelector from "./DatasetSelector.jsx";
 
-import { default as SelectBoxAlias } from "./lib/SelectBox.jsx";
+import { GetVariablesPromise } from "../remote/OceanNavigator.js";
 
 import { withTranslation } from "react-i18next";
-const stringify = require("fast-stable-stringify");
 
 const TabEnum = {
   PROFILE: 1,
@@ -42,17 +40,22 @@ class PointWindow extends React.Component {
 
     this.state = {
       selected: TabEnum.PROFILE,
-      scale: props.scale + ",auto",
-      depth: props.depth,
       showmap: false,
       colormap: "default",
-      starttime: props.starttime,
-      variables: [],
+      datasetVariables: [],
       variable: [props.variable],
       observation_variable: [0],
       size: "10x7",
       dpi: 144,
       plotTitles: Array(7).fill(""),
+      dataset_0: {
+        dataset: props.dataset_0.dataset,
+        variable: [props.dataset_0.variable],
+        quantum: props.dataset_0.quantum,
+        time: props.dataset_0.time,
+        depth: props.dataset_0.depth,
+        starttime: props.dataset_0.starttime,
+      },
     };
 
     if (props.init !== null) {
@@ -76,65 +79,21 @@ class PointWindow extends React.Component {
       });
     }
 
-    this.populateVariables(this.props.dataset);
+    this.populateVariables(this.props.dataset_0.dataset);
   }
 
   componentWillUnmount() {
     this._mounted = false;
   }
 
-  componentWillReceiveProps(props) {
-    if (stringify(this.props) !== stringify(props) && this._mounted) {
-      const state = {};
-
-      if (!Array.isArray(this.state.depth)) {
-        state.depth = props.depth;
-      }
-      if (this.state.scale.indexOf("auto") !== -1) {
-        state.scale = props.scale + ",auto";
-      }
-      else {
-        state.scale = props.scale;
-      }
-
-      this.setState(state);
-
-      // Check if dataset was changed
-      if (this.props.dataset !== props.dataset) {
-        this.populateVariables(props.dataset);
-      }
-    }
-  }
-
   populateVariables(dataset) {
-    $.ajax({
-      url: "/api/v1.0/variables/?dataset=" + dataset,
-      dataType: "json",
-      cache: true,
-
-      success: function(data) {
-        if (this._mounted) {
-          const vars = data.map(function(d) {
-            return d.id;
-          });
-
-          if (vars.indexOf(this.props.variable.split(",")[0]) === -1) {
-            this.props.onUpdate("variable", vars[0]);
-          }
-
-          this.setState({
-            variables: data.map(function(d) {
-              return d.id;
-            }),
-          });
-        }
-      }.bind(this),
-
-      error: function(xhr, status, err) {
-        if (this._mounted) {
-          console.error(this.props.url, status, err.toString());
-        }
-      }.bind(this)
+    GetVariablesPromise(dataset).then(variableResult => {
+      this.setState({
+        datasetVariables: variableResult.data.map(v => { return v.id; })
+      });
+    },
+    error => {
+      console.error(error);
     });
   }
 
@@ -149,6 +108,16 @@ class PointWindow extends React.Component {
 
   onLocalUpdate(key, value) {
     if (this._mounted) {
+      if (key === "dataset_0") {
+        this.setState(prevState => ({
+          dataset_0: {
+            ...prevState.dataset_0,
+            ...value
+          }
+        }));
+        return;
+      }
+
       let newState = {};
 
       if (typeof(key) === "string") {
@@ -207,17 +176,19 @@ class PointWindow extends React.Component {
   }
 
   render() {
-
-    _("Dataset");
-    _("Time");
     _("Location");
-    _("Start Time");
-    _("End Time");
-    _("Depth");
-    _("Variable");
-    _("Variable Range");
     _("Colourmap");
     _("Saved Image Size");
+
+    const only3dVariables = this.state.selected == TabEnum.PROFILE || 
+                            this.state.selected == TabEnum.OBSERVATION;
+    const showDepthSelector = this.state.selected === TabEnum.MOORING;
+    const showDepthsAll = this.state.selected === TabEnum.MOORING;
+    const showTimeRange = this.state.selected === TabEnum.STICK ||
+                          this.state.selected === TabEnum.MOORING;
+    const showVariableSelector =  this.state.selected === TabEnum.PROFILE ||
+                                  this.state.selected === TabEnum.MOORING;
+    const showMultiVariableSelector = this.state.selected === TabEnum.PROFILE;
 
     // Rendered across all tabs
     const global = (<Panel
@@ -229,21 +200,31 @@ class PointWindow extends React.Component {
       <Panel.Heading>{_("Global Settings")}</Panel.Heading>
       <Panel.Collapse>
         <Panel.Body>
-          <ComboBox
-            key='dataset'
-            id='dataset'
-            state={this.props.dataset}
-            def=''
-            url='/api/v1.0/datasets/'
-            title={_("Dataset")}
-            onUpdate={this.props.onUpdate}
+          <DatasetSelector
+            key='point_window_dataset_0'
+            id='dataset_0'
+            onUpdate={this.onLocalUpdate}
+            showQuiverSelector={false}
+            showVariableRange={false}
+            showTimeRange={showTimeRange}
+            showDepthSelector={showDepthSelector}
+            options={this.props.options}
+            variables={only3dVariables ? "3d" : null}
+            showVariableSelector={showVariableSelector}
+            showDepthsAll={showDepthsAll}
+            multipleVariables={showMultiVariableSelector}
+            mountedDataset={this.props.dataset_0.dataset}
+            mountedVariable={this.props.dataset_0.variable}
           />
+
           <SelectBox
             key='showmap'
             id='showmap'
             state={this.state.showmap}
             onUpdate={this.onLocalUpdate}
-            title={_("Show Location")}>{_("showmap_help")}
+            title={_("Show Location")}
+          >
+            {_("showmap_help")}
           </SelectBox>
 
           <div style={{display: this.props.point.length == 1 ? "block" : "none",}}>
@@ -264,100 +245,16 @@ class PointWindow extends React.Component {
             title={_("Saved Image Size")}
           />
 
-          {/* Plot Title */}
           <CustomPlotLabels
             key='title'
             id='title'
             title={_("Plot Title")}
             updatePlotTitle={this.updatePlotTitle}
             plotTitle={this.state.plotTitles[this.state.selected - 1]}
-          ></CustomPlotLabels>
+          />
         </Panel.Body>
       </Panel.Collapse>
     </Panel>);
-
-    // Show a single time selector on all tabs except Stick and Virtual Mooring.
-    const showTime = this.state.selected !== TabEnum.STICK ||
-                      this.state.selected !== TabEnum.MOORING;
-    const time = showTime ? <TimePicker
-      key='time'
-      id='time'
-      state={this.props.time}
-      def=''
-      quantum={this.props.quantum}
-      url={"/api/v1.0/timestamps/?dataset=" + this.props.dataset + "&variable=" + this.props.variable}
-      title={_("Time")}
-      onUpdate={this.props.onUpdate}
-    /> : null;
-
-    // Show a start and end time selector for only Stick and Virtual Mooring tabs.
-    const showTimeRange = this.state.selected === TabEnum.STICK ||
-                          this.state.selected === TabEnum.MOORING;
-    const timeRange = showTimeRange ? <div>
-      <TimePicker
-        key='starttime'
-        id='starttime'
-        state={this.state.starttime}
-        def=''
-        quantum={this.props.quantum}
-        url={"/api/v1.0/timestamps/?dataset=" + this.props.dataset + "&variable=" + this.props.variable}
-        title={_("Start Time")}
-        onUpdate={this.onLocalUpdate}
-        max={this.props.time}
-      />
-      <TimePicker
-        key='time'
-        id='time'
-        state={this.props.time}
-        def=''
-        quantum={this.props.quantum}
-        url={"/api/v1.0/timestamps/?dataset=" + this.props.dataset + "&variable=" + this.props.variable}
-        title={_("End Time")}
-        onUpdate={this.props.onUpdate}
-        min={this.state.starttime}
-      /> </div> : null;
-
-    // Only show depth and scale selector for Mooring tab.
-    const showDepthVariableScale = this.state.selected === TabEnum.MOORING;
-    const depthVariableScale = showDepthVariableScale && 
-      this.props.datasetDepths ? <div>
-        <SelectBoxAlias 
-          id={"depth-selector-point-window"}
-          name={"depth"}
-          label={_("Depth")}
-          placeholder={_("Depth")}
-          options={this.props.datasetDepths}
-          onChange={this.onLocalUpdate}
-          selected={
-            this.props.datasetDepths.filter(d => {
-              let depth = parseInt(this.state.depth);
-              if (isNaN(depth)) { // when depth == "bottom" or "all"
-                depth = this.state.depth;
-              }
-
-              return d.id === depth;
-            })[0].id
-          }
-        />
-
-        <ComboBox
-          key='variable'
-          id='variable'
-          state={this.props.variable}
-          def=''
-          onUpdate={this.props.onUpdate}
-          url={"/api/v1.0/variables/?dataset="+this.props.dataset}
-          title={_("Variable")}><h1>{_("Variable")}</h1></ComboBox>
-
-        <Range
-          auto
-          key='scale'
-          id='scale'
-          state={this.state.scale}
-          def={""}
-          onUpdate={this.onLocalUpdate}
-          title={_("Variable Range")} />
-      </div> : null;
 
     // Show multidepth selector on for Stick tab
     const showMultiDepthAndVector = this.state.selected === TabEnum.STICK;
@@ -365,10 +262,10 @@ class PointWindow extends React.Component {
       <ComboBox
         key='variable'
         id='variable'
-        state={this.state.variable}
+        state={this.state.dataset_0.variable}
         def=''
         onUpdate={this.onLocalUpdate}
-        url={"/api/v1.0/variables/?vectors_only&dataset="+this.props.dataset}
+        url={"/api/v1.0/variables/?vectors_only&dataset="+this.state.dataset_0.dataset}
         title={_("Variable")}><h1>Variable</h1></ComboBox>
 
       <ComboBox
@@ -378,23 +275,9 @@ class PointWindow extends React.Component {
         state={this.state.depth}
         def={""}
         onUpdate={this.onLocalUpdate}
-        url={"/api/v1.0/depth/?variable=" + this.state.variable + "&dataset=" + this.props.dataset}
+        url={"/api/v1.0/depth/?variable=" + this.state.dataset_0.variable + "&dataset=" + this.props.dataset_0.dataset}
         title={_("Depth")}></ComboBox>
     </div> : null;
-
-
-    // Create Variable dropdown for Profile and Observation
-    const showProfileVariable = this.state.selected == TabEnum.PROFILE ||
-                                this.state.selected == TabEnum.OBSERVATION;
-    const profilevariable = showProfileVariable ? <ComboBox
-      key='variable'
-      id='variable'
-      multiple
-      state={this.state.variable}
-      def=''
-      onUpdate={this.onLocalUpdate}
-      url={"/api/v1.0/variables/?3d_only&dataset="+this.props.dataset}
-      title={_("Variable")}><h1>Variable</h1></ComboBox> : null;
 
     let observation_data = [];
     let observation_variable = <div></div>;
@@ -428,10 +311,22 @@ class PointWindow extends React.Component {
       }
     }
 
+    // Checks if the current dataset's variables contain Temperature
+    // and Salinity. This is used to enable/disable some tabs.
+    const temperatureRegex = /temp/;
+    // eslint-disable-next-line max-len
+    const hasTemperature = this.state.datasetVariables.some(v => v.match(temperatureRegex));
+
+    const salinityRegex = /salin/;
+    // eslint-disable-next-line max-len
+    const hasSalinity = this.state.datasetVariables.some(v => v.match(salinityRegex));
+
+    const hasTempSalinity = hasTemperature && hasSalinity;
+
     // Start constructing query for image
     const plot_query = {
-      dataset: this.props.dataset,
-      quantum: this.props.quantum,
+      dataset: this.state.dataset_0.dataset,
+      quantum: this.state.dataset_0.quantum,
       point: this.props.point,
       showmap: this.state.showmap,
       names: this.props.names,
@@ -445,42 +340,38 @@ class PointWindow extends React.Component {
     switch(this.state.selected) {
       case TabEnum.PROFILE:
         plot_query.type = "profile";
-        plot_query.time = this.props.time;
-        plot_query.variable = this.state.variable;
-        inputs = [global, time, profilevariable];
+        plot_query.time = this.state.dataset_0.time;
+        plot_query.variable = this.state.dataset_0.variable;
+        inputs = [global];
         break;
 
       case TabEnum.CTD:
         plot_query.type = "profile";
-        plot_query.time = this.props.time;
+        plot_query.time = this.state.dataset_0.time;
         plot_query.variable = "";
-        if (this.state.variables.indexOf("votemper") !== -1) {
+        if (hasTemperature) {
+          // TODO: find index of matching variable in regex
+          // since not all datasets call temp votemper
           plot_query.variable += "votemper,";
-        } else if (this.state.variables.indexOf("temp") !== -1) {
-          plot_query.variable += "temp,";
         }
-        if (this.state.variables.indexOf("vosaline") !== -1) {
+        if (hasSalinity) {
+          // TODO: find index of matching variable in regex
+          // for same reason as above
           plot_query.variable += "vosaline";
-        } else if (this.state.variables.indexOf("salinity") !== -1) {
-          plot_query.variable += "salinity";
         }
-        inputs = [global, time];
+        inputs = [global];
         break;
 
       case TabEnum.TS:
         plot_query.type = "ts";
-        plot_query.time = this.props.time;
-        if (this.props.dataset_compare) {
-          plot_query.compare_to = this.props.dataset_1;
-        }
-
-        inputs = [global, time];
+        plot_query.time = this.state.dataset_0.time;
+        inputs = [global];
         break;
 
       case TabEnum.SOUND:
         plot_query.type = "sound";
-        plot_query.time = this.props.time;
-        inputs = [global, time];
+        plot_query.time = this.state.dataset_0.time;
+        inputs = [global];
         break;
       case TabEnum.OBSERVATION:
         plot_query.type = "observation";
@@ -489,21 +380,21 @@ class PointWindow extends React.Component {
         });
 
         plot_query.observation_variable = this.state.observation_variable;
-        plot_query.variable = this.state.variable;
-        inputs = [global, observation_variable, profilevariable];
+        plot_query.variable = this.state.dataset_0.variable;
+        inputs = [global, observation_variable];
 
         break;
       case TabEnum.MOORING:
         plot_query.type = "timeseries";
-        plot_query.variable = this.props.variable;
-        plot_query.starttime = this.state.starttime;
-        plot_query.endtime = this.props.time;
-        plot_query.depth = this.state.depth;
+        plot_query.variable = this.state.dataset_0.variable;
+        plot_query.starttime = this.state.dataset_0.starttime;
+        plot_query.endtime = this.state.dataset_0.time;
+        plot_query.depth = this.state.dataset_0.depth;
         plot_query.colormap = this.state.colormap;
-        plot_query.scale = this.state.scale;
+        //plot_query.scale = "auto";
 
-        inputs = [global, timeRange, depthVariableScale];
-        if (this.state.depth == "all") {
+        inputs = [global];
+        if (this.state.dataset_0.depth == "all") {
           // Add Colormap selector
           inputs.push(
             <ComboBox
@@ -513,37 +404,31 @@ class PointWindow extends React.Component {
               def='default'
               onUpdate={this.onLocalUpdate}
               url='/api/v1.0/colormaps/'
-              title={_("Colourmap")}>{_("colourmap_help")}<img src="/colormaps.png" />
+              title={_("Colourmap")}
+            >
+              {_("colourmap_help")}
+              <img src="/colormaps.png" />
             </ComboBox>);
         }
 
         break;
       case TabEnum.STICK:
         plot_query.type = "stick";
-        plot_query.variable = this.state.variable;
-        plot_query.starttime = this.state.starttime;
-        plot_query.endtime = this.props.time;
-        plot_query.depth = this.state.depth;
+        plot_query.variable = this.state.dataset_0.variable;
+        plot_query.starttime = this.state.dataset_0.starttime;
+        plot_query.endtime = this.state.dataset_0.time;
+        plot_query.depth = this.state.dataset_0.depth;
 
-        inputs = [global, timeRange, multiDepthVector];
+        inputs = [global, multiDepthVector];
 
         break;
     }
 
-    // Checks if the current dataset's variables contain Temperature
-    // and Salinity. This is used to enable/disable some tabs.
-    const hasTempSalinity =
-    ( this.state.variables.indexOf("votemper") !== -1 ||
-      this.state.variables.indexOf("temp") !== -1) &&
-    ( this.state.variables.indexOf("vosaline") !== -1 ||
-      this.state.variables.indexOf("salinity") !== -1);
-
     const permlink_subquery = {
       selected: this.state.selected,
-      scale: this.state.scale,
-      depth: this.state.depth,
+      depth: this.state.dataset_0.depth,
       colormap: this.state.colormap,
-      starttime: this.state.starttime,
+      starttime: this.state.dataset_0.starttime,
     };
 
     return (
@@ -569,7 +454,9 @@ class PointWindow extends React.Component {
           <NavItem
             eventKey={TabEnum.OBSERVATION}
             disabled={this.props.point[0][2] === undefined}
-          >{_("Observation")}</NavItem>
+          >
+            {_("Observation")}
+          </NavItem>
           <NavItem
             eventKey={TabEnum.MOORING}>{_("Virtual Mooring")}</NavItem>
         </Nav>
@@ -594,22 +481,16 @@ class PointWindow extends React.Component {
 PointWindow.propTypes = {
   generatePermLink: PropTypes.func,
   point: PropTypes.array,
-  time: PropTypes.number,
-  variable: PropTypes.string,
   dpi: PropTypes.number,
   names: PropTypes.array,
-  quantum: PropTypes.string,
-  dataset: PropTypes.string,
   onUpdate: PropTypes.func,
-  scale: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  depth: PropTypes.number,
   init: PropTypes.object,
   action: PropTypes.func,
   dataset_compare: PropTypes.bool,
   swapViews: PropTypes.func,
   showHelp: PropTypes.func,
+  dataset_0: PropTypes.object,
   dataset_1: PropTypes.object,
-  datasetDepths: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withTranslation()(PointWindow);

--- a/oceannavigator/frontend/src/components/Range.jsx
+++ b/oceannavigator/frontend/src/components/Range.jsx
@@ -18,7 +18,7 @@ class Range extends React.Component {
 
     // Parse scale tuple
     let scale = this.props.state;
-    if (typeof (this.props.state.split) === "function") {
+    if (typeof this.props.state === "string" || this.props.state instanceof String) {
       scale = this.props.state.split(",");
     }
     const min = parseFloat(scale[0]);
@@ -47,16 +47,10 @@ class Range extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-
-    //Sets scale to default on variable change
-    if (this.props.setDefaultScale == true) {
-      this.handleDefaultButton();  //Changes Scale
-      this.props.onUpdate("setDefaultScale", false); //Resets set to default flag
-    }
     if (stringify(this.props) !== stringify(nextProps)) {
 
       let scale = nextProps.state;
-      if (typeof (scale.split) === "function") {
+      if (typeof scale === "string" || scale instanceof String) {
         scale = scale.split(",");
       }
       if (scale.length > 1) {
@@ -102,7 +96,7 @@ class Range extends React.Component {
     });
 
     var scale = this.props.state;
-    if (typeof (this.props.state.split) === "function") {
+    if (typeof this.props.state === "string" || this.props.state instanceof String) {
       scale = this.props.state.split(",");
     }
 
@@ -124,7 +118,7 @@ class Range extends React.Component {
       cache: false,
       success: function (data) {
         if (this._mounted) {
-          this.props.onUpdate(this.props.id, data.min + "," + data.max);
+          this.props.onUpdate(this.props.id, [data.min, data.max]);
         }
       }.bind(this),
       
@@ -144,7 +138,7 @@ class Range extends React.Component {
       </Checkbox>
     );
 
-    var autobuttons = <div></div>;
+    let autobuttons = <div></div>;
     if (this.props.autourl) {
       autobuttons = (
         <ButtonToolbar style={{ display: "inline-block", "float": "right" }}>
@@ -206,9 +200,8 @@ Range.propTypes = {
   auto: PropTypes.bool,
   title: PropTypes.string,
   onUpdate: PropTypes.func,
-  setDefaultScale: PropTypes.bool,
   default_scale: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  state: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  state: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
   autourl: PropTypes.string,
 };
 

--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -19,6 +19,8 @@ import "jquery-ui-month-picker/MonthPicker.js";
 import "jquery-ui/../i18n/datepicker-fr.js";
 import "jquery-ui/../i18n/datepicker-fr-CA.js";
 
+import { GetTimestampsPromise } from "../remote/OceanNavigator.js";
+
 import { withTranslation } from "react-i18next";
 
 class TimePicker extends React.Component {
@@ -57,16 +59,6 @@ class TimePicker extends React.Component {
 
   componentWillUnmount() {
     this._mounted = false;
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (
-      nextProps.url !== this.props.url ||
-      nextProps.min !== this.props.min ||
-      nextProps.max !== this.props.max
-    ) {
-      this.populate(nextProps);
-    }
   }
 
   getIndexFromTimestamp(timestamp) {
@@ -117,142 +109,134 @@ class TimePicker extends React.Component {
   }
 
   populate(props) {
-    if ("url" in props && "" !== props.url) {
-      $.ajax({
-        url: props.url,
-        dataType: "json",
-        cache: false,
+    // eslint-disable-next-line max-len
+    GetTimestampsPromise(props.dataset, props.variable).then(timestampResult => {
+      const data = timestampResult.data;
 
-        success: function (data) {
-          let map = {};
-          let revmap = {};
+      let map = {};
+      let revmap = {};
 
-          for (let i = 0; i < data.length; ++i) {
-            const d1 = new Date(data[i].value);
-            const d2 = new Date(d1.getTime() + d1.getTimezoneOffset() * 60000);
-            let d3 = d2;
-            if (this.props.quantum !== "hour") {
-              d3 = new Date(
-                Date.UTC(
-                  d1.getUTCFullYear(),
-                  d1.getUTCMonth(),
-                  d1.getUTCDate(),
-                  0,
-                  0,
-                  0,
-                  0
-                )
-              );
-            }
-            map[data[i].id] = d2;
-            revmap[d3.toUTCString()] = data[i].id;
-          }
-
-          const [min, max] = this.getMinMaxTimestamps(props, data);
-
-          this.setState(
-            {
-              data: data,
-              map: map,
-              revmap: revmap,
-              min: min,
-              max: max
-            },
-            function () {
-              switch (props.quantum) {
-                case "month":
-                  $(this.refs.picker).MonthPicker({
-                    Button: false,
-                    MonthFormat: "MM yy",
-                    OnAfterMenuClose: this.pickerChange,
-                    MinMonth: new Date(
-                      map[min].getTime() +
-                      map[min].getTimezoneOffset() * 60 * 1000
-                    ),
-                    MaxMonth: new Date(
-                      map[max].getTime() +
-                      map[max].getTimezoneOffset() * 60 * 1000
-                    ),
-                    i18n: {
-                      year: _("Year"),
-                      prevYear: _("Previous Year"),
-                      nextYear: _("Next Year"),
-                      next12Years: _("Jump Forward 12 Years"),
-                      prev12Years: _("Jump Back 12 Years"),
-                      nextLabel: _("Next"),
-                      prevLabel: _("Prev"),
-                      buttonText: _("Open Month Chooser"),
-                      jumpYears: _("Jump Years"),
-                      backTo: _("Back to"),
-                      months: [
-                        _("Jan."),
-                        _("Feb."),
-                        _("Mar."),
-                        _("Apr."),
-                        _("May"),
-                        _("June"),
-                        _("July"),
-                        _("Aug."),
-                        _("Sep."),
-                        _("Oct."),
-                        _("Nov."),
-                        _("Dec.")
-                      ]
-                    }
-                  });
-                  break;
-                case "hour":
-                  $(this.refs.picker).datepicker({
-                    Button: false,
-                    dateFormat: "dd MM yy",
-                    onClose: this.pickerChange,
-                    minDate: new Date(map[min]),
-                    maxDate: new Date(map[max])
-                  });
-                  $(this.refs.picker).datepicker(
-                    "option",
-                    "minDate",
-                    new Date(map[min])
-                  );
-                  $(this.refs.picker).datepicker(
-                    "option",
-                    "maxDate",
-                    new Date(map[max])
-                  );
-                  break;
-                case "day":
-                default:
-                  $(this.refs.picker).datepicker({
-                    Button: false,
-                    dateFormat: "dd MM yy",
-                    onClose: this.pickerChange,
-                    minDate: new Date(map[min]),
-                    maxDate: new Date(map[max])
-                  });
-
-                  $(this.refs.picker).datepicker(
-                    "option",
-                    "minDate",
-                    new Date(map[min])
-                  );
-                  $(this.refs.picker).datepicker(
-                    "option",
-                    "maxDate",
-                    new Date(map[max])
-                  );
-                  break;
-              }
-              this.pickerChange();
-            }.bind(this)
+      for (let i = 0; i < data.length; ++i) {
+        const d1 = new Date(data[i].value);
+        const d2 = new Date(d1.getTime() + d1.getTimezoneOffset() * 60000);
+        let d3 = d2;
+        if (this.props.quantum !== "hour") {
+          d3 = new Date(
+            Date.UTC(
+              d1.getUTCFullYear(),
+              d1.getUTCMonth(),
+              d1.getUTCDate(),
+              0,
+              0,
+              0,
+              0
+            )
           );
-        }.bind(this),
+        }
+        map[data[i].id] = d2;
+        revmap[d3.toUTCString()] = data[i].id;
+      }
 
-        error: function (xhr, status, err) {
-          console.warn(props.url, status, err.toString());
-        }.bind(this)
-      });
+      const [min, max] = this.getMinMaxTimestamps(props, data);
 
-    }
+      this.setState(
+        {
+          data: data,
+          map: map,
+          revmap: revmap,
+          min: min,
+          max: max
+        },
+        () => {
+          switch (props.quantum) {
+            case "month":
+              $(this.refs.picker).MonthPicker({
+                Button: false,
+                MonthFormat: "MM yy",
+                OnAfterMenuClose: this.pickerChange,
+                MinMonth: new Date(
+                  map[min].getTime() +
+                  map[min].getTimezoneOffset() * 60 * 1000
+                ),
+                MaxMonth: new Date(
+                  map[max].getTime() +
+                  map[max].getTimezoneOffset() * 60 * 1000
+                ),
+                i18n: {
+                  year: _("Year"),
+                  prevYear: _("Previous Year"),
+                  nextYear: _("Next Year"),
+                  next12Years: _("Jump Forward 12 Years"),
+                  prev12Years: _("Jump Back 12 Years"),
+                  nextLabel: _("Next"),
+                  prevLabel: _("Prev"),
+                  buttonText: _("Open Month Chooser"),
+                  jumpYears: _("Jump Years"),
+                  backTo: _("Back to"),
+                  months: [
+                    _("Jan."),
+                    _("Feb."),
+                    _("Mar."),
+                    _("Apr."),
+                    _("May"),
+                    _("June"),
+                    _("July"),
+                    _("Aug."),
+                    _("Sep."),
+                    _("Oct."),
+                    _("Nov."),
+                    _("Dec.")
+                  ]
+                }
+              });
+              break;
+            case "hour":
+              $(this.refs.picker).datepicker({
+                Button: false,
+                dateFormat: "dd MM yy",
+                onClose: this.pickerChange,
+                minDate: new Date(map[min]),
+                maxDate: new Date(map[max])
+              });
+              $(this.refs.picker).datepicker(
+                "option",
+                "minDate",
+                new Date(map[min])
+              );
+              $(this.refs.picker).datepicker(
+                "option",
+                "maxDate",
+                new Date(map[max])
+              );
+              break;
+            case "day":
+            default:
+              $(this.refs.picker).datepicker({
+                Button: false,
+                dateFormat: "dd MM yy",
+                onClose: this.pickerChange,
+                minDate: new Date(map[min]),
+                maxDate: new Date(map[max])
+              });
+
+              $(this.refs.picker).datepicker(
+                "option",
+                "minDate",
+                new Date(map[min])
+              );
+              $(this.refs.picker).datepicker(
+                "option",
+                "maxDate",
+                new Date(map[max])
+              );
+              break;
+          }
+          this.pickerChange();
+        }
+      );
+    }, error => {
+      console.error(error);
+    });
   }
 
   pickerChange() {
@@ -279,10 +263,15 @@ class TimePicker extends React.Component {
       });
 
       if (times.length > 0) {
+        let index = this.getIndexFromTimestamp(this.props.state);
+        if (index === -1) {
+          index = this.state.data.length - 1;
+        }
+
         if (this.state.value === undefined) {
           this.props.onUpdate(this.props.id, times[0].id);
         } else if (
-          this.state.data[this.getIndexFromTimestamp(this.props.state)].value.indexOf(isodatestr) !== 0
+          this.state.data[index].value.indexOf(isodatestr) !== 0
         ) {
           this.props.onUpdate(this.props.id, times[0].id);
         }
@@ -431,7 +420,7 @@ class TimePicker extends React.Component {
     }
 
     return (
-      <div key={this.props.url} className="TimePicker input">
+      <div key={this.props.id + this.props.key} className="TimePicker input">
         <h1>{this.props.title}</h1>
 
         <div>
@@ -454,13 +443,14 @@ class TimePicker extends React.Component {
 //***********************************************************************
 TimePicker.propTypes = {
   title: PropTypes.string,
-  url: PropTypes.string,
-  quantum: PropTypes.string,
+  quantum: PropTypes.string.isRequired,
   state: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  onUpdate: PropTypes.func,
-  id: PropTypes.string,
+  onUpdate: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
   min: PropTypes.number,
-  max: PropTypes.number
+  max: PropTypes.number,
+  dataset: PropTypes.string.isRequired,
+  variable: PropTypes.string.isRequired,
 };
 
 export default withTranslation()(TimePicker);

--- a/oceannavigator/frontend/src/components/lib/SelectBox.jsx
+++ b/oceannavigator/frontend/src/components/lib/SelectBox.jsx
@@ -26,7 +26,6 @@ export default class SelectBox extends React.Component {
 
     const disabled = !Array.isArray(this.props.options) ||
                      !this.props.options.length;
-
     return (
       <FormGroup controlid={`formgroup-${this.props.id}-selectbox`}>
         <ControlLabel>{this.props.label}</ControlLabel>
@@ -34,9 +33,17 @@ export default class SelectBox extends React.Component {
           componentClass="select"
           name={this.props.name}
           placeholder={disabled ? _("Loading...") : this.props.placeholder}
-          onChange={(e) => this.props.onChange(e.target.name, e.target.value)}
+          onChange={(e) => {
+            if (this.props.multiple) {
+              this.props.onChange(e.target.name, e.target.selectedOptions);
+            }
+            else {
+              this.props.onChange(e.target.name, e.target.value);
+            }
+          }}
           disabled={disabled}
           value={this.props.selected}
+          multiple={this.props.multiple}
         >
           {options}
         </FormControl>
@@ -53,6 +60,14 @@ SelectBox.propTypes = {
   placeholder: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
-  selected: PropTypes.oneOfType([PropTypes.string,
-  PropTypes.number,]).isRequired,
+  selected: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.string)
+  ]).isRequired,
+  multiple: PropTypes.bool,
+};
+
+SelectBox.defaultProps = {
+  multiple: false,
 };

--- a/oceannavigator/frontend/src/remote/OceanNavigator.js
+++ b/oceannavigator/frontend/src/remote/OceanNavigator.js
@@ -2,21 +2,23 @@
 // that use IE which doesn't support that.
 
 const axios = require("axios");
+import { cacheAdapterEnhancer } from "axios-extensions";
 
-function _createPromise() {
-  return axios.create();
-}
+const instance = axios.create({
+  headers: { "Cache-Control": "no-cache" },
+  adapter: cacheAdapterEnhancer(axios.defaults.adapter)
+});
 
 
 export function GetDatasetsPromise() {
-  return _createPromise().get(
-    "/api/v1.0/datasets"
+  return instance.get(
+    "/api/v1.0/datasets/"
   );
 }
 
 export function GetVariablesPromise(dataset) {
-  return _createPromise().get(
-    "/api/v1.0/variables",
+  return instance.get(
+    "/api/v1.0/variables/",
     {
       params: {
         dataset: dataset
@@ -26,8 +28,8 @@ export function GetVariablesPromise(dataset) {
 }
 
 export function GetTimestampsPromise(dataset, variable) {
-  return _createPromise().get(
-    "/api/v1.0/timestamps",
+  return instance.get(
+    "/api/v1.0/timestamps/",
     {
       params: {
         dataset: dataset,
@@ -38,8 +40,8 @@ export function GetTimestampsPromise(dataset, variable) {
 }
 
 export function GetDepthsPromise(dataset, variable) {
-  return _createPromise().get(
-    "/api/v1.0/depth",
+  return instance.get(
+    "/api/v1.0/depth/",
     {
       params: {
         dataset: dataset,
@@ -51,19 +53,19 @@ export function GetDepthsPromise(dataset, variable) {
 }
 
 export function GetPresetPointsPromise() {
-  return _createPromise().get(
-    "/api/v1.0/points"
+  return instance.get(
+    "/api/v1.0/points/"
   );
 }
 
 export function GetPresetLinesPromise() {
-  return _createPromise().get(
-    "/api/v1.0/lines"
+  return instance.get(
+    "/api/v1.0/lines/"
   );
 }
 
 export function GetPresetAreasPromise() {
-  return _createPromise().get(
-    "/api/v1.0/areas"
+  return instance.get(
+    "/api/v1.0/areas/"
   );
 }

--- a/oceannavigator/frontend/webpack.config.js
+++ b/oceannavigator/frontend/webpack.config.js
@@ -73,6 +73,9 @@ const config = {
       title: "Ocean Navigator",
       xhtml: true,
       template: "src/index.ejs",
+    }),
+    new webpack.DefinePlugin({
+      "process.env.LOGGER_LEVEL": JSON.stringify("info")
     })
   ]
 };

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -126,6 +126,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
+"@types/lru-cache@^4.1.1":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.3.tgz#ec5eb6dd818b7a06336cfb7368723164b195f818"
+  integrity sha512-QjCOmf5kYwekcsfEKhcEHMK8/SvgnneuSDXFERBuC/DPca2KJIO/gpChTsVb35BoWLBpEAJWz1GFVEArSdtKtw==
+
 "@types/node@*":
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.1.tgz#9fad171a5b701613ee8a6f4ece3c88b1034b1b03"
@@ -615,6 +620,16 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios-extensions@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/axios-extensions/-/axios-extensions-3.1.3.tgz#cd745bb7dc899743f85a2b5a291c7f36d9f41e12"
+  integrity sha512-/OB9OcJLNOIx9pdW4m4/hFRvNo12wlX5BaprIzqpMaLR02I88Mr98/wW4QN9rhx0/yg9rM7i6Af/RpV4MyxXjA==
+  dependencies:
+    "@types/lru-cache" "^4.1.1"
+    lru-cache "^5.1.1"
+    tslib "^1.9.0"
+    util "^0.11.1"
 
 axios@^0.21.2:
   version "0.21.2"
@@ -5383,6 +5398,11 @@ ts-loader@^8.2.0:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
+tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
@@ -5534,7 +5554,7 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-util@^0.11.0:
+util@^0.11.0, util@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==


### PR DESCRIPTION
## Background

This finishes the effort to reduce the number duplicate API calls made to the back end in the context of preparing for the go button. There is still considerable work left to completely eliminate this problem, but there is indeed a noticeable performance improvement with the caching implementation and improved general reliability.

* Updated the UX of the loading pop-up window to be more descriptive (see below for screenshots). In the future, we could also display errors relating to the dataset change operation.
* Implemented the `axios-extensions` package to provide caching middle ware for some of our requests.
* Removed some implementations of the deprecated React function `componentWillReceiveProps` to no effect to functionality. There are still some areas where we use it, and they will need to be removed before React can be updated.
* Created a "defaults" file for where various components can reference the same default values (`oceannavigator/frontend/src/components/Defaults.js`) without copy-pasting stuff.
* Cleaned up the `PropTypes` in relevant files to improve the self-documentation ability of the code, and provide better early warnings to required props. Still lots of work to be done here in the future.
* Fixed a bug in `oceannavigator/frontend/src/remote/OceanNavigator.js` where `axios` was always redirecting via 301 due to a missing `/` in the URL, which resulted in the cache not working correctly. Now it works just fine.
* Added a new field to the `variables` API end point that indicates whether a variable is 2D or not. Used by the front end to filter available variables for various plots.
* Refactored dataset fetching (the old `change_dataset` function) from the `OceanNavigator` component into the `DatasetSelector` component to simplify the state update process amongst all of our components to make way for the go button. This is the bulk of the logic change. Most of the other changes in here are to make this refactoring work (lmao). Also, we now enforce a strict ordering by which we fetch dataset information. This will enable the `PlotImage` component to be improved in the future so that it doesn't spam plot requests with garbage data. If an error is encountered at any point of the loading stage, the process will abort and not change the dataset (9 times out of 10 anyway lol). This is to help reduce the chances of the UI getting in a bad state and then sending requests with garbage API arguments.
  1. Get `/datasets`
  2. Get `/variables` for selected dataset.
  3. Get `/depths` for selected dataset
  4. (Still in the stupid `Timepicker` component)...get `/timestamps` for selected dataset. We still need to refactor the `Timepicker` component and move all of it's timestamp loading logic (after simplifying it) into the `DatasetSelector` component.

## Why did you take this approach?

* Used newer React and JS language features to make the code more idiomatic and less messy:
  * Replaced some `function` definitions and `.bind(this)` calls with arrow functions, which provide more compact syntax, and automatically bind the parent object.
  * Used call-backs with `setState` to ensure correct ordering of state change operations and avoid race conditions.
  * Heavy use of the spread operator `...`.

## Anything in particular that should be highlighted?

* I basically ripped out and re-wrote the core data loading logic in the front end. There are definitely hidden bugs in here that will take time to be weeded out. I tested the profiles, transect, hovmoller, and area plots with a few datasets to ensure nothing was blatantly busted however.
* The meat-and-potatoes of this change is in the `DatasetSelector` component (`oceannavigator/frontend/src/components/DatasetSelector.jsx`).
* Inspecting the changes commit-by-commit would be an okay way of breaking this pr into smaller chunks. I tried to keep the commits self-contained but this is the Navigator so....(start at 0b05595b7e8fe08276c29fe57b8bba10fd108dee if you want to do this).

## Screenshot(s)

Note the difference in speed at which the datasets are changed, and the difference between the number of requests sent just for the dataset variable. Not sure why the videos are sped up but whatever.

Current experience on production:

https://user-images.githubusercontent.com/5572045/143961221-ed1a5709-97bc-483f-be49-bac22f01cefc.mp4

![image](https://user-images.githubusercontent.com/5572045/143961579-95476994-5fba-421e-a906-97b28bb18904.png)


After this change:

https://user-images.githubusercontent.com/5572045/143961456-8fcd7314-4aee-4ac6-96b7-f82ff107955e.mp4

![image](https://user-images.githubusercontent.com/5572045/143961684-7bcb286e-d9bb-4aee-87c6-2f183846b6ab.png)



## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
