### PR TITLE
Restore NC3 Subsetting for Calculated Variables

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -371,8 +371,8 @@ class NetCDFData(Data):
                                               y_coord: y_slice,
                                               x_coord: x_slice
                                           })})
-                # Remove 'dims' attr (prevents exporting to NC3 formats)            
-                subset[variable].attrs.pop('dims')  
+                # Convert 'dims' attr to string (allows exporting to NC3 formats)            
+                subset[variable].attrs['dims'] = "(" + ",".join(subset[variable].attrs['dims']) + ")"
 
         output_format = query.get('output_format')
         filename = dataset_name + "_" + "%dN%dW-%dN%dW" % (p0.latitude, p0.longitude, p1.latitude, p1.longitude) \

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -371,6 +371,8 @@ class NetCDFData(Data):
                                               y_coord: y_slice,
                                               x_coord: x_slice
                                           })})
+                # Remove 'dims' attr (prevents exporting to NC3 formats)            
+                subset[variable].attrs.pop('dims')  
 
         output_format = query.get('output_format')
         filename = dataset_name + "_" + "%dN%dW-%dN%dW" % (p0.latitude, p0.longitude, p1.latitude, p1.longitude) \


### PR DESCRIPTION
## Background
We were notified that users are unable to subset area data using NetCDF-3 formats for calculated variables. When creating a subset from one of these variables the Navigator attempts to add the attributes from the datasetconfig.json as variable attributes in the resulting NetCDF file. This includes the 'dims' attribute is a list of strings describing the dimensions used for the variable calculation. It seems that xarray will try to encode variables like this one using the _NC_STRING_ format which is only compatible with NetCDF-4 files, causing the error. More detail can be found in Issue #919.

Closes #919 

## Why did you take this approach?
My initial approach was to cast the 'dims; variable to another datatype to see if xarray would encode it using a compatible format however nothing seemed to work. In the end I felt that it was best to drop this attribute entirely since the dimensions should be listed in the resulting NC file anyway. All calculated variables given in the datasetconfig.json file need to have a 'dims' attribute so we shouldn't need to add logic to check for this attribute before dropping it. 

## Anything in particular that should be highlighted?
I found that some of the calculated variables are returned without named dimensions resulting in variables with dimensions `dim_0, dim_1, etc.` so having a 'dims' attribute could help here. Since this seems to be the root of issue #897 I decided to address that in the fix I'm working on there.  

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
