### PR TITLE
Updates to a couple of service scripts

### DIFF
--- a/bin/launch-web-service.sh
+++ b/bin/launch-web-service.sh
@@ -17,4 +17,4 @@ echo " "
 echo "Use the following IP in your URL ${HOST_IP}:$((PORT))"
 echo " "
 echo "This will log information from the application to the screen and the logfile."
-exec bash runserver.sh $PORT &> >(tee -a ${HOME}/launch-on-web-service.log)
+exec bash runserver.sh $PORT 

--- a/bin/runserver.sh
+++ b/bin/runserver.sh
@@ -3,7 +3,7 @@
 # Usage: ./runserver.sh <port> <optional_dataset_config_file.json>
 # <optional_dataset_config_file.json>:  Specify a non-default dataset config file to load the Navigator with.
 #                                       Argument not required.
-WORKER_THREADS=2
+WORKER_THREADS=1
 
 [[ "$1" == "" ]] && PORT=5000 || PORT=$1
 
@@ -25,4 +25,4 @@ else
 
 fi
 
-gunicorn -w $((NUMBER_WORKERS)) --threads $((WORKER_THREADS)) --worker-class=gthread -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2
+gunicorn --error-log ${HOME}/gunicorn.log -w 4 --threads $((WORKER_THREADS)) --worker-class=gthread -t 300 --graceful-timeout 300 --preload -b 0.0.0.0:$((PORT)) --reload "oceannavigator:create_app()" $2 --daemon


### PR DESCRIPTION
Removed the logging information from the launch-web-service.sh script as
runserver.sh now contains a Gunicorn --log-file definition. As well, the
number of Gunicorn worker threads has been reduced from 2 to 1.
