### PR TITLE
Fix subsetting for multiple variables and over time ranges

### DIFF
--- a/data/calculated.py
+++ b/data/calculated.py
@@ -180,4 +180,15 @@ class CalculatedArray():
         for d in self.dims:
             key.append(keys[d])
 
-        return self[tuple(key)]
+        selection = self[tuple(key)]
+        # check to see that dimensions are named, if not recreate DataArray w/ correct dims and coords
+        if selection.dims != tuple(keys.keys()):   
+            shape = [k.stop - k.start for k in keys.values()]
+            selection = xr.DataArray(
+                            data = np.reshape(selection.data, shape), 
+                            dims = keys.keys(),
+                            coords = {str(k) : self._parent.coords[k][v] for k,v in keys.items()},
+                            attrs = self.attrs
+                        )
+
+        return selection

--- a/data/calculated.py
+++ b/data/calculated.py
@@ -132,7 +132,7 @@ class CalculatedArray():
         else: 
             dims = self._dims
 
-        key = [k for k in key if type(k) is slice] #remove any non-slice elements 
+        key = [filter(lambda k: type(k) is slice, key)]
         return xr.DataArray(
                     data = np.reshape(data_array.data, [k.stop - k.start for k in key]), 
                     dims = dims,

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -334,7 +334,7 @@ def soniclayerdepth(depth, latitude, temperature, salinity) -> np.ndarray:
         depth, latitude, temperature, salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
-    if (len(sound_speed.shape) > 3): 
+    if (len(sound_speed.shape) > 3): # if true dims are (time, depth, y, x)
         sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     return __soniclayerdepth_from_sound_speed(sound_speed, depth)
@@ -358,7 +358,7 @@ def deepsoundchannel(depth, latitude, temperature, salinity) -> np.ndarray:
         depth, latitude, temperature, salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
-    if (len(sound_speed.shape) > 3): 
+    if (len(sound_speed.shape) > 3): # if true dims are (time, depth, y, x) 
         sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     min_indices = __find_depth_index_of_min_value(sound_speed)
@@ -392,7 +392,7 @@ def deepsoundchannelbottom(depth, latitude, temperature, salinity) -> np.ndarray
 
     # Use masked array to quickly enable/disable data (see below)
     sound_speed = np.ma.array(sspeed(depth, latitude, temperature, salinity), fill_value=np.nan)
-    if (len(sound_speed.shape) > 3): 
+    if (len(sound_speed.shape) > 3): # if true dims are (time, depth, y, x) 
         sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     min_indices = __find_depth_index_of_min_value(sound_speed)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -223,7 +223,9 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
     press = __calc_pressure(depth, latitude)
 
     if salinity.shape != press.shape:
-        # pad array shape to match otherwise seawater freaks out
+        # Need to pad press so it can broadcast against temperature and salinity.
+        # eg. if using GIOPS and salinity has shape (3, 50, 3, 12) then press has
+        # shape (50, 3). This logic pads press to give shape (1, 50, 3, 1).
         for ax, val in enumerate(salinity.shape):  
             if ax > press.ndim - 1 or press.shape[ax] != val:
                 press = np.expand_dims(press, axis=ax)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -299,9 +299,6 @@ def __get_soniclayerdepth_mask(soundspeed: np.ndarray, min_depth_indices: np.nda
 
 def __soniclayerdepth_from_sound_speed(soundspeed: np.ndarray, depth: np.ndarray) -> np.ndarray:
 
-    if (len(soundspeed.shape) > 3): 
-        soundspeed = np.swapaxes(soundspeed,0,1) # swap time and depth dims to ensure depth is 0th
-
     min_indices = __find_depth_index_of_min_value(soundspeed)
 
     mask = __get_soniclayerdepth_mask(soundspeed, min_indices)
@@ -337,6 +334,8 @@ def soniclayerdepth(depth, latitude, temperature, salinity) -> np.ndarray:
         depth, latitude, temperature, salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
+    if (len(sound_speed.shape) > 3): 
+        sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     return __soniclayerdepth_from_sound_speed(sound_speed, depth)
 

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -297,6 +297,9 @@ def __get_soniclayerdepth_mask(soundspeed: np.ndarray, min_depth_indices: np.nda
 
 def __soniclayerdepth_from_sound_speed(soundspeed: np.ndarray, depth: np.ndarray) -> np.ndarray:
 
+    if (len(soundspeed.shape) > 3): 
+        soundspeed = np.swapaxes(soundspeed,0,1) # swap time and depth dims to ensure depth is 0th
+
     min_indices = __find_depth_index_of_min_value(soundspeed)
 
     mask = __get_soniclayerdepth_mask(soundspeed, min_indices)
@@ -354,6 +357,8 @@ def deepsoundchannel(depth, latitude, temperature, salinity) -> np.ndarray:
         depth, latitude, temperature, salinity)
 
     sound_speed = sspeed(depth, latitude, temperature, salinity)
+    if (len(sound_speed.shape) > 3): 
+        sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     min_indices = __find_depth_index_of_min_value(sound_speed)
 
@@ -386,7 +391,8 @@ def deepsoundchannelbottom(depth, latitude, temperature, salinity) -> np.ndarray
 
     # Use masked array to quickly enable/disable data (see below)
     sound_speed = np.ma.array(sspeed(depth, latitude, temperature, salinity), fill_value=np.nan)
-
+    if (len(sound_speed.shape) > 3): 
+        sound_speed = np.swapaxes(sound_speed,0,1) # swap time and depth dims to ensure depth is 0th
 
     min_indices = __find_depth_index_of_min_value(sound_speed)
     
@@ -437,7 +443,7 @@ def depthexcess(depth, latitude, temperature, salinity, bathy) -> np.ndarray:
     dscb = deepsoundchannelbottom(depth, latitude, temperature, salinity)
 
     # Actually do the math.
-    return dscb - bathy
+    return dscb - bathy.data
 
 def calculate_del_C(depth:np.ndarray,soundspeed:np.ndarray,minima:np.ndarray,maxima:np.ndarray,freq_cutoff:float) -> np.ndarray:
     """

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -224,7 +224,9 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
 
     if salinity.shape != press.shape:
         # pad array shape to match otherwise seawater freaks out
-        press = press[..., np.newaxis]
+        for i in range(len(salinity.shape)):  
+            if i > len(press.shape) - 1 or salinity.shape[i] != press.shape[i]:
+                press = np.expand_dims(press, axis=i)
 
     speed = seawater.svel(salinity, temperature, press)
     return np.squeeze(speed)

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -224,9 +224,9 @@ def sspeed(depth: Union[np.ndarray, xr.Variable],
 
     if salinity.shape != press.shape:
         # pad array shape to match otherwise seawater freaks out
-        for i in range(len(salinity.shape)):  
-            if i > len(press.shape) - 1 or salinity.shape[i] != press.shape[i]:
-                press = np.expand_dims(press, axis=i)
+        for ax, val in enumerate(salinity.shape):  
+            if ax > press.ndim - 1 or press.shape[ax] != val:
+                press = np.expand_dims(press, axis=ax)
 
     speed = seawater.svel(salinity, temperature, press)
     return np.squeeze(speed)

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -356,7 +356,7 @@ class NetCDFData(Data):
         # Filter out unwanted variables
         output_vars = query.get('variables').split(',')
         # Keep the coordinate variables
-        output_vars.extend([depth_var, time_var, lat_var, lon_var])
+        output_vars.extend(filter(None, [depth_var, time_var, lat_var, lon_var]))
         for variable in subset.data_vars:
             if variable not in output_vars:
                 subset = subset.drop(variable)

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -227,13 +227,13 @@ class AreaWindow extends React.Component {
       queryString = "&min_range=" + min_range +
                       "&max_range=" + max_range;
     }
-
+    const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
     window.location.href = "/api/v1.0/subset/?" +
        "&output_format=" + this.state.output_format +
        "&dataset_name=" + this.state.dataset_0.dataset +
        "&variables=" + this.state.output_variables.join() +
         queryString +
-       "&time=" + [this.state.output_starttime, this.state.output_endtime].join() +
+       "&time=" + [this.state.output_starttime, output_endtime].join() +
        "&user_grid=" + (this.state.convertToUserGrid ? 1 : 0) +
        "&should_zip=" + (this.state.zip ? 1 : 0);
   }


### PR DESCRIPTION
## Background
Continuing the work started in PR #920 which allowed users to export subsets in all NetCDF formats but didn't fix issues that prevented users from creating subsets with multiple variables or over a time range. 

A major component of this issue was the `calculated.isel()` function which returned xarray DataArray objects without properly defined dimensions. These objects were given xarray's default dimension names (`[dim_0, dim_1,...]`) which caused conflicts when variables of varying sizes were added to the subset xarray object. Generally this occurs when sub-setting 2D and 3D calculated variables. In this situation `dim_0` would often correspond to the latitude of the 2D variable but the depth of the 3D one. These dimensions generally have different sizes and so cannot be merged.  

Another issue which affected sub-setting with a time range was that a number of the calculated variable functions assumed that the first dimension of the data array was always depth. However, when a time range is selected the first dimension will be time. This prevented sub-setting of any variables derived from sound speed (critical depth, depth excess, sound channel axis, etc). 

I also noticed that the Navigator will try to return a time range subset for single time stamps if any timestamp other than recent is selected. This is because the `output_endtime` variable is set to the most recent time by default, and only updated when a time range is selected. 

## Why did you take this approach?
Rather than simply rename the dimensions of the DataArray returned by `calculated.isel()` I decided to create a new object. This might require a little more code but ensures that's the data is the expected shape with correctly named dimensions, and we can also include the proper coordinates that go with the dimensions. This fix allows us to subset multiple variables and fixes issue #897.

To correct the second issue some of the calculated functions now swap the first two dimensions of the data arrays so that depth is in the 0th position. This is required since the subroutines used for these calculations assume that depths is 0th which is not the case when the variable spans multiple time stamps. It would of been nice to programmatically determine which dimension was depth and pass that to these functions however since this varies quite a lot by request there wasn't a dependable way to do this. 

Lastly, to ensure that users only get subsets for the timestamp requested we can just check to see if the 'Time Range' check box is selected. If not we can just set 'output_starttime' and 'output_endtime' to the same value for the query. 

## Anything in particular that should be highlighted?
I've tested this work for the datasets and variables listed in the 'Subset Testing' sheet I started a while back (found [here](https://docs.google.com/spreadsheets/d/1yNJT0nHrWS4-R7TxMf2XSgvIDqMpKQjHYvYWnB17854/edit?usp=sharingl)). This seems to clear up most of the issues we've been experiencing with the Subsetting function lately but not all. This functionality still doesn't work for some variables such as PSSC and some datasets including CIOPS but these issues are outside of the scope of this PR. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

