### PR TITLE
Add Werkzeug profiling middleware

### DIFF
--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -11,6 +11,7 @@ from flask_babel import Babel
 from flask_compress import Compress
 from sentry_sdk.integrations.flask import FlaskIntegration
 from utils.ascii_terminal_colors import ASCIITerminalColors
+from werkzeug.contrib.profiler import ProfilerMiddleware
 
 # Although DatasetConfig is not used in this module, this import is absolutely necessary
 # because it is how the rest of the app gets access to DatasetConfig
@@ -39,6 +40,11 @@ def create_app(testing: bool = False):
     app.config.from_pyfile('oceannavigator.cfg', silent=False)
     app.config.from_envvar('OCEANNAVIGATOR_SETTINGS', silent=True)
     app.testing = testing
+
+    if app.config.get('WSGI_PROFILING'):
+        if not os.path.isdir('./profiler_results'):
+            os.mkdir('./profiler_results')
+        app.wsgi_app = ProfilerMiddleware(app.wsgi_app, stream=None, restrictions=[10], profile_dir='./profiler_results')        
 
     if testing:
         # Override cache dirs when testing


### PR DESCRIPTION
## Background
Added the option to enable the Werkzeug profiling middleware on the Navigator using a new `WSGI_PROFILING` option in the 'oceannavigator.cfg' file. Enabling this option will profile each API request the Navigator receives and write it to a new directory names 'profiler_results' in the Navigator's root directory. These files are cProfile output which can be really helpful in benchmarking and finding bottlenecks in the code, They can be analyzed in python or with a viewer such as SnakeViz or Tuna (shown below). 

Profile output:
![prof_files](https://user-images.githubusercontent.com/79917349/145433400-8937d5e3-893e-455a-a415-fcd06deb5be7.png)
A profile icicle plot viewed in Tuna:
![tuna_ex](https://user-images.githubusercontent.com/79917349/145433415-678f0d4f-db8f-48b7-9915-4e3f725afbf8.png)

## Why did you take this approach?
This functionality is already provided via Flask so this work just gives us a easy way to enable it when required. Profiling can add a fair amount of overhead to the application so having the option to enable it is essential. 

## Checks
- [] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

