### PR TITLE
Revert "Bump jquery-ui from 1.12.1 to 1.13.0 in /oceannavigator/frontend"

### DIFF
--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -29,7 +29,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "glob-parent": "^5.1.2",
     "jquery": "~3.5.0",
-    "jquery-ui": "^1.13.0",
+    "jquery-ui": "^1.12.1",
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",
     "ol": "^6.6.1",
     "papaparse": "^5.2.0",

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -2897,17 +2897,10 @@ jquery-ui-month-picker@kidsysco/jquery-ui-month-picker:
   version "3.0.4"
   resolved "https://codeload.github.com/kidsysco/jquery-ui-month-picker/tar.gz/6bf5fcb6a38b07206162383468283e68d3e10e97"
 
-jquery-ui@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
-
-"jquery@>=1.8.0 <4.0.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+jquery-ui@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
 jquery@~3.5.0:
   version "3.5.1"


### PR DESCRIPTION
Reverts DFO-Ocean-Navigator/Ocean-Data-Map-Project#918

breaks the timepicker