### PR TITLE
Remove erroneous call to `addControl` in Map component

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -231,7 +231,7 @@ export default class Map extends React.PureComponent {
         });
       }
     };
-    this.map.addControl(this.scaleViewer);
+    
     this.obsDrawSource = new olsource.Vector({
       features: [],
     });


### PR DESCRIPTION
## Background

Artifact from a messed up rebase that causes a white screen

The scale viewer is still being manually added on line 679 which is the intended behaviour.

Restores previous functionality. Thanks Justin for pointing this out!

## Why did you take this approach?

Only way.

## Anything in particular that should be highlighted?


## Screenshot(s)
![image](https://user-images.githubusercontent.com/5572045/147363421-792d56cf-56ab-4716-8996-a50fe3f12646.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
