### PR TITLE
Bugfix: Fix reference to non-existant prop in DatasetSelector

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -377,12 +377,12 @@ class DatasetSelector extends React.Component {
     if (this.props.showVariableSelector && this.state.datasetVariables && this.state.datasetVariables.length > 0 && !this.state.loading) {
       let options = [];
       if (this.props.variables === "3d") {
-        options = this.props.datasetVariables.filter(v => {
+        options = this.state.datasetVariables.filter(v => {
           return v.two_dimensional === false;
         });
       }
       else {
-        options = this.props.datasetVariables;
+        options = this.state.datasetVariables;
       }
 
        // Work-around for when someone selected a plot that requires


### PR DESCRIPTION
## Background

Second of the three bugs Justin flagged for me to take a look at.

Left-over typo from the refactor.

Caused a white screen crash on page load

## Why did you take this approach?
The `datasetVariables` reference in the `props` is the old way of getting the dataset variables; before the `DatasetComponent` selector itself handled the fetching of that list. 

Did a quick search for `this.props.datasetVariables` in the `DatasetSelector` file and there are no more instances.

## Anything in particular that should be highlighted?
Nope

## Screenshot(s)
![image](https://user-images.githubusercontent.com/5572045/147766486-a1f7ac29-a12e-40a4-a3bb-5d4073766653.png)

3D variables are still filtered through in the point window where appropriate
![image](https://user-images.githubusercontent.com/5572045/147766855-7c148417-cfe1-4fea-afce-adfe0c927692.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
