### PR TITLE
Bugfix: Remove unused function binding in `AreaWindow`

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -92,8 +92,6 @@ class AreaWindow extends React.Component {
 
     // Function bindings
     this.onLocalUpdate = this.onLocalUpdate.bind(this);
-    this.pushLocalStateToGlobalState = 
-      this.pushLocalStateToGlobalState.bind(this);
     this.subsetArea = this.subsetArea.bind(this);
     this.onTabChange = this.onTabChange.bind(this);
     this.updatePlotTitle = this.updatePlotTitle.bind(this);


### PR DESCRIPTION
## Background

Follow up to #926 

The fixes the last of the three issues Justin notified me about that were related to the big front end refactor that was merged a couple of weeks ago.

## Why did you take this approach?
Unused code so I deleted it

## Anything in particular that should be highlighted?
Nope

## Screenshot(s)

Previous behaviour restored
![image](https://user-images.githubusercontent.com/5572045/147882621-2e74da40-1273-4d5e-9660-01e452bf95ea.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
