### PR TITLE
Revive dataset help button

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -271,6 +271,15 @@ class DatasetSelector extends React.Component {
     let datasetSelector = null;
     // eslint-disable-next-line max-len
     if (this.state.availableDatasets && this.state.availableDatasets.length > 0 && !this.state.loading) {
+      const helpContent = this.state.availableDatasets.map(d => {
+        return (
+          <p key={`help-${d.id}`}>
+            <em>{d.value}</em>
+            <span dangerouslySetInnerHTML={{ __html: d.help}} />
+          </p>
+        );
+      });
+
       datasetSelector = <SelectBox
         id={`dataset-selector-dataset-selector-${this.props.id}`}
         name="dataset"
@@ -281,6 +290,7 @@ class DatasetSelector extends React.Component {
         })}
         onChange={this.onUpdate}
         selected={this.state.dataset}
+        helpContent={helpContent}
       />;
     }
 

--- a/oceannavigator/frontend/src/components/lib/SelectBox.jsx
+++ b/oceannavigator/frontend/src/components/lib/SelectBox.jsx
@@ -1,12 +1,33 @@
 import React from "react";
-import { FormGroup, ControlLabel, FormControl } from "react-bootstrap";
+import { FormGroup, ControlLabel, FormControl, Modal, Button } from "react-bootstrap";
 import PropTypes from "prop-types";
+
+import Icon from "./Icon";
+
+import { withTranslation } from "react-i18next";
 
 const fastEqual = require("fast-deep-equal/es6/react");
 
-export default class SelectBox extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return !fastEqual(this.props, nextProps);
+export class SelectBox extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showHelp: false,
+    };
+
+    this.toggleShowHelp = this.toggleShowHelp.bind(this);
+  }
+
+  toggleShowHelp() {
+    this.setState(prevState => ({
+      showHelp: !prevState.showHelp,
+    }));
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !fastEqual(this.props, nextProps) ||
+      !fastEqual(this.state, nextState);
   }
 
   render() {
@@ -28,27 +49,59 @@ export default class SelectBox extends React.Component {
                      !this.props.options.length;
 
     return (
-      <FormGroup controlid={`formgroup-${this.props.id}-selectbox`}>
-        <ControlLabel>{this.props.label}</ControlLabel>
-        <FormControl
-          componentClass="select"
-          name={this.props.name}
-          placeholder={disabled ? _("Loading...") : this.props.placeholder}
-          onChange={(e) => {
-            if (this.props.multiple) {
-              this.props.onChange(e.target.name, e.target.selectedOptions);
-            }
-            else {
-              this.props.onChange(e.target.name, e.target.value);
-            }
-          }}
-          disabled={disabled}
-          value={this.props.selected}
-          multiple={this.props.multiple}
+      <>
+        <FormGroup controlid={`formgroup-${this.props.id}-selectbox`}>
+          <ControlLabel>{this.props.label}</ControlLabel>
+          
+          <Button
+            onClick={this.toggleShowHelp}
+            bsStyle="default"
+            bsSize="xsmall"
+            style={{"display": this.props.helpContent ? "block" : "none", "float": "right"}}
+          >
+            ?
+          </Button>
+
+          <FormControl
+            componentClass="select"
+            name={this.props.name}
+            placeholder={disabled ? _("Loading...") : this.props.placeholder}
+            onChange={(e) => {
+              if (this.props.multiple) {
+                this.props.onChange(e.target.name, e.target.selectedOptions);
+              }
+              else {
+                this.props.onChange(e.target.name, e.target.value);
+              }
+            }}
+            disabled={disabled}
+            value={this.props.selected}
+            multiple={this.props.multiple}
+          >
+            {options}
+          </FormControl>
+        </FormGroup>
+
+        <Modal
+          show={this.state.showHelp}
+          onHide={this.toggleShowHelp}
+          bsSize="large"
+          dialogClassName="helpdialog"
+          backdrop={true}
         >
-          {options}
-        </FormControl>
-      </FormGroup>
+          <Modal.Header closeButton closeLabel={_("Close")}>
+            <Modal.Title>{_("Help")}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            {this.props.helpContent}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.toggleShowHelp}>
+              <Icon icon="close"/> {_("Close")}
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </>
     );
   }
 }
@@ -67,8 +120,12 @@ SelectBox.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
   ]).isRequired,
   multiple: PropTypes.bool,
+  helpContent: PropTypes.arrayOf(PropTypes.object),
 };
 
 SelectBox.defaultProps = {
   multiple: false,
+  helpContent: null,
 };
+
+export default withTranslation()(SelectBox);


### PR DESCRIPTION
## Background

Follow up to #926 where I removed the dataset help button but forgot to add it back

## Why did you take this approach?
Added this help button as an optional feature of the new dropdown component, so this button could appear elsewhere for extra help.

## Anything in particular that should be highlighted?


## Screenshot(s)
![image](https://user-images.githubusercontent.com/5572045/148853652-7ce101b4-e1cb-4fad-8039-c4777f5d96b0.png)

![image](https://user-images.githubusercontent.com/5572045/148853667-9d1e47a5-30c7-4ae2-8c35-89b284bafe72.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
