### PR TITLE
restore quiver arrows

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -373,8 +373,8 @@ def get_data_v1_0():
                                 .get_dataset_variable('bearing')[time_index, result['depth'], lat_slice, lon_slice]
                                 
         d = data_array_to_geojson(
-                data,
-                bearings, # this is a hack
+                data.squeeze(drop=True),
+                bearings.squeeze(drop=True), # this is a hack
                 lat_var[lat_slice],
                 lon_var[lon_slice]
             )


### PR DESCRIPTION
## Background
Prior to  #925 the `calculated.__getitem__()`  function retuned calculated objects with minimal coordinate and dimension data - generally just lat and lon. Since these changes, this method now returns data with all available coordinates and dimensions, including depth and time which allowed us to fix the subsetting issues described in the PR. The `data_array_to_geojson` function expects arguments in the old format so these additional coordinates need to be dropped.  

## Why did you take this approach?
Using xarray's `squeeze()` method we can drop the time and depth dimensions from the DataArray object before passing it to `data_array_to_geojson`.  Because these dimensions have unit length calling squeeze with `drop=True` just broadcasts the DataArray to a 2D shape with lat and lon coordinates while dropping the other coordinates.  

## Anything in particular that should be highlighted?
I tested this fix with the GIOPS dataset since it's currently the only dataset where users can display quiver arrows. 

## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
