### PR TITLE
Fix `id` of right map dataset selector

### DIFF
--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -72,7 +72,7 @@ class MapInputs extends React.Component {
             <Panel.Body>
               <DatasetSelector
                 key='map_inputs_dataset_1'
-                id='map_inputs_dataset_1'
+                id='dataset_1'
                 onUpdate={this.props.changeHandler}
                 options={this.props.options}
                 projection={this.props.projection}

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -167,7 +167,7 @@ class OceanNavigator extends React.Component {
     }
 
     if (key === "dataset_1") {
-      this.state(value);
+      this.setState(value);
       return;
     }
 


### PR DESCRIPTION
Related to #950 

This may resolve the issue of the compare mode not updating, given in `OceanNavigator.jsx` we expect the id to be either `dataset_0` or `dataset_1`.

Can't test this locally since my container is way out of date with the package updates.

## Background


## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
