### PR TITLE
Limit default time selector range

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -100,9 +100,9 @@ class DatasetSelector extends React.Component {
         this.setState({ loadingPercent: 75 });
 
         const timeData = timeResult.data;
-
+        
         const newTime = timeData[timeData.length - 1].id;
-        const newStarttime = timeData[0].id;
+        const newStarttime = timeData.length > 20 ? timeData[timeData.length - 20].id : timeData[0].id;
 
         // eslint-disable-next-line max-len
         GetDepthsPromise(newDataset, newVariable).then(depthResult => {


### PR DESCRIPTION
## Background

As discussed in issue #946 ,the time range selector used for virtual mooring and hovmoller plots defaults to the first and last available timestamps. Since bringing more historical data into the Navigator this results in front end querying timeseries plots with thousands of timestamps for some datasets when a user first opens either the virtual mooring or hovmoller plot windows. These datasets include RIOPS, CMEMS, and SalishSeaCast. 

To fix this, we check the number of available timestamps for a given dataset and set the default timepicker values to the most recent 20 if more are available. This allows the Navigator to quickly produce a plot for the users when they open these tabs. They can then request longer timeseries' if needed. This fixes #946.

## Why did you take this approach?
This allows the Navigator to quickly produce a plot. The user can then select a longer time range if needed.


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
