### PR TITLE
Basemap bug fixes

### DIFF
--- a/plotting/map.py
+++ b/plotting/map.py
@@ -658,7 +658,7 @@ class MapPlotter(Plotter):
             cs = self.basemap.contour(
                 self.longitude, self.latitude, self.bathymetry, latlon=True,
                 linewidths=0.5,
-                norm=LogNorm(vmin=1, vmax=6000),
+                #norm=LogNorm(vmin=1, vmax=6000),
                 cmap='Greys',
                 levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])
             plt.clabel(cs, fontsize='x-large', fmt='%1.0fm')
@@ -817,7 +817,7 @@ class MapPlotter(Plotter):
 
         # Map Info
         self.basemap.drawmapboundary(fill_color=(0.3, 0.3, 0.3), zorder=-1)
-        if self.basemap.coastsegs[0]:  # ensure map contains coastline before trying to draw
+        if len(self.basemap.coastsegs) > 0:  # ensure map contains coastline before trying to draw
             self.basemap.drawcoastlines(linewidth=0.5)
         self.basemap.fillcontinents(color='grey', lake_color='dimgrey')
 

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -10,7 +10,6 @@ import pyresample.utils
 from flask_babel import gettext
 from geopy.distance import GeodesicDistance
 from matplotlib.path import Path
-from matplotlib.colors import LogNorm
 from matplotlib.patches import PathPatch, Polygon
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.basemap import maskoceans
@@ -660,7 +659,7 @@ class MapPlotter(Plotter):
                 linewidths=0.5,
                 #norm=LogNorm(vmin=1, vmax=6000),
                 cmap='Greys',
-                levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])
+                levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])                
             plt.clabel(cs, fontsize='x-large', fmt='%1.0fm')
 
         if self.area and self.show_area:
@@ -817,7 +816,7 @@ class MapPlotter(Plotter):
 
         # Map Info
         self.basemap.drawmapboundary(fill_color=(0.3, 0.3, 0.3), zorder=-1)
-        if len(self.basemap.coastsegs) > 0:  # ensure map contains coastline before trying to draw
+        if self.basemap.coastsegs:  # ensure map contains coastline before trying to draw
             self.basemap.drawcoastlines(linewidth=0.5)
         self.basemap.fillcontinents(color='grey', lake_color='dimgrey')
 

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -10,6 +10,7 @@ import pyresample.utils
 from flask_babel import gettext
 from geopy.distance import GeodesicDistance
 from matplotlib.path import Path
+from matplotlib.colors import FuncNorm
 from matplotlib.patches import PathPatch, Polygon
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.basemap import maskoceans
@@ -657,9 +658,9 @@ class MapPlotter(Plotter):
             cs = self.basemap.contour(
                 self.longitude, self.latitude, self.bathymetry, latlon=True,
                 linewidths=0.5,
-                #norm=LogNorm(vmin=1, vmax=6000),
+                norm=FuncNorm((lambda x: np.log10(x), lambda x: 10**x), vmin=1, vmax=6000),
                 cmap='Greys',
-                levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])                
+                levels=[100, 200, 500, 1000, 2000, 3000, 4000, 5000, 6000])
             plt.clabel(cs, fontsize='x-large', fmt='%1.0fm')
 
         if self.area and self.show_area:


### PR DESCRIPTION
## Background
Found two basemap related issues when testing the area plot functionality of the updated toolchain on the staging site. The first is related to basemap's `drawcoastlines` method which fails when the selected area contains zero coast lines. To avoid calling this method unnecessarily we can check for area for polygons in the `basemap.coastsegs` attribute. 

The second issue is related the the normalization used when drawing area bathymetry with little variation. It seems that the object produced by `matplotlib.colors.LogNorm` has changed a little and is no longer compatible with basemap in this situation. The fix here was to recreate the same normalization object using matplotlib's `FuncNorm` function. This produces the same result without the error. 

## Why did you take this approach?
These are the most minimal changes I could apply that restored functionality to the area plot window. I imagine we will find more of these issues as we update other packages so the long term solution is to drop basemap for something like cartopy. 

## Checks
- [x] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

