### PR TITLE
Change areawindow datasetselector onupdate method

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -499,7 +499,7 @@ class AreaWindow extends React.Component {
           <DatasetSelector 
             key='area_window_dataset_0'
             id='dataset_0'
-            onUpdate={this.onLocalUpdate}
+            onUpdate={this.props.onUpdate}
             showQuiverSelector={false}
             showVariableRange={false}
             options={this.props.options}
@@ -539,7 +539,7 @@ class AreaWindow extends React.Component {
               <DatasetSelector
                 key='area_window_dataset_1'
                 id='dataset_1'
-                onUpdate={this.onLocalUpdate}
+                onUpdate={this.props.onUpdate}
                 showQuiverSelector={false}
                 showVariableRange={false}
                 options={this.props.options}


### PR DESCRIPTION
## Background
Per issue #951 the dataset selector wasn't updating the compare dataset area plot after it was initially created. It looks like this problem was due to the DatasetSelector's onupdate method which was set to the AreaWindow's onLocalUpdate method. This method does not update the values of dataset_0 and dataset_1 of the parent components when the dataset/variables are changed. Using `this.props.onUpdate` instead passed these values to the parent classes and updates the plots correctly. 

## Why did you take this approach?
This change follows the approach used in other components such as LineWindow. 

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
