### PR TITLE
Use cached quiver variable data

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -347,8 +347,7 @@ def get_data_v1_0():
     
     if os.path.isfile(cached_file_name):
         print(f"Using cached {cached_file_name}")
-        with open(cached_file_name, 'r') as f:
-            send_file(f, 'application/json')
+        return send_file(cached_file_name, 'application/json')
 
     config = DatasetConfig(result['dataset'])
     


### PR DESCRIPTION
## Background
Since updating our python tool chain we've been getting the following error when trying to add water velocity quivers to the main map:
```
Traceback (most recent call last):
  ...
  File "/home/ubuntu/Ocean-Data-Map-Project/routes/api_v1_0.py", line 351, in get_data_v1_0
    send_file(f, 'application/json')
...
ValueError: Files must be opened in binary mode or use BytesIO.
```

After a bit of reading the Flask/Werkzeug docs it seems that this error was always an issue for us but prior to Flask 2.0 `send_file` would send an empty file instead of raising the `ValueError` . The reason this wasn't an issue for us before is that we never actually returned the send_file object. Instead we proceeded through the function and re-calculated the quiver arrows, essentially rendering our cached geojson data useless anyway. To resolve this we can just return send_file with the filepath of the cached data.

## Why did you take this approach?
My initial approach was to open the file as a binary object using the `'rb'` option but this actually doesn't work because the file is closed before the Flask/WSGI server can process and send the data. It turns out that Flask/WSGI handles all of the open/close operations independently so the `with open()` logic isn't necessary at all. We just need to the file path and mime type to the send_file function. I was a little wary after reading this but after a bit of testing this appears to work without any IO contention issues. 

## Anything in particular that should be highlighted?
Displaying the quiver arrows is much faster since we're returning the cached data now. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
