### PR TITLE
API: Enable /data to also return 2D variables

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -358,18 +358,23 @@ def get_data_v1_0():
         lat_slice = slice(0, lat_var.size, 4)
         lon_slice = slice(0, lon_var.size, 4)
 
-        time_index = ds.nc_data.timestamp_to_time_index(result['time'])
+        time_index = ds.nc_data.timestamp_to_time_index(result['time'])     
         
-        data = ds \
-                .nc_data \
-                .get_dataset_variable(result['variable'])[time_index, result['depth'], lat_slice, lon_slice]
-        
+        data = ds.nc_data.get_dataset_variable(result['variable'])
+
+        if len(data.shape) == 3:
+            data_slice = (time_index, lat_slice, lon_slice)
+        else:
+            data_slice = (time_index, result['depth'], lat_slice, lon_slice)
+
+        data = data[data_slice]
+
         bearings = None
         if 'mag' in result['variable']:
             with open_dataset(config, variable='bearing', timestamp=result['time']) as ds_bearing:
                 bearings = ds_bearing \
                                 .nc_data \
-                                .get_dataset_variable('bearing')[time_index, result['depth'], lat_slice, lon_slice]
+                                .get_dataset_variable('bearing')[data_slice]
                                 
         d = data_array_to_geojson(
                 data.squeeze(drop=True),


### PR DESCRIPTION
## Background

Fixes a bug where a 2D dataset variable is incorrectly sliced...it has no depth

## Why did you take this approach?

Seems like the most logical approach.

## Anything in particular that should be highlighted?

* This will allow us to expand our offerings of velocity arrows to more datasets. PRs for those will be put up after this is merged.

## Screenshot(s)

Tested on 2D CCG RIOPS which was previously crashing
![image](https://user-images.githubusercontent.com/5572045/152072000-69ddba99-e4af-4a2e-b55b-b86f9f5b2afa.png)

3D still works:
![image](https://user-images.githubusercontent.com/5572045/152072374-6bdbd9c3-7705-49be-b71b-f2c210aed74e.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
