### PR TITLE
Fix great lakes area plots

### DIFF
--- a/plotting/map.py
+++ b/plotting/map.py
@@ -817,7 +817,7 @@ class MapPlotter(Plotter):
 
         # Map Info
         self.basemap.drawmapboundary(fill_color=(0.3, 0.3, 0.3), zorder=-1)
-        if self.basemap.coastsegs:  # ensure map contains coastline before trying to draw
+        if self.basemap.coastsegs and self.basemap.coastsegs[0]:  # ensure map contains coastline before trying to draw
             self.basemap.drawcoastlines(linewidth=0.5)
         self.basemap.fillcontinents(color='grey', lake_color='dimgrey')
 


### PR DESCRIPTION
## Background
Another basemap related error only seems to affect the WCPs-GLS Great Lakes dataset. `self.basemap.coastsegs` returns an array of empty arrays for some reason so the check to see if coastlines need to be plotted passes which causes a ValueError. Added a second check into the first element of coastsegs to handle this case.


## Why did you take this approach?
This works for in cases where there area is in open water and `coastsegs = [ ]` and areas enclosed by coaslines where `coastsegs = [[ ]. [ ], ...]`

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

