### PR TITLE
Make stride of geojson conversion configurable through datasetconfig

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -114,7 +114,7 @@ class DatasetConfig:
         """
 
         stride = self._get_attribute("vector_arrow_stride")
-        if not stride:
+        if stride:
             return stride
 
         return 4

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -105,6 +105,21 @@ class DatasetConfig:
         return self._get_attribute("bathymetry_file_url")
 
     @property
+    def vector_arrow_stride(self) -> int:
+        """
+        Returns the stride used to slice the dataset for generating geojson
+        for the vector arrows (i.e. every n-th value).
+
+        Defaults to 4.
+        """
+
+        stride = self._get_attribute("vector_arrow_stride")
+        if stride != "":
+            return stride
+
+        return 4
+    
+    @property
     def model_class(self) -> str:
         return self._get_attribute("model_class")
 

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -114,7 +114,7 @@ class DatasetConfig:
         """
 
         stride = self._get_attribute("vector_arrow_stride")
-        if stride != "":
+        if not stride:
             return stride
 
         return 4

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -355,8 +355,10 @@ def get_data_v1_0():
 
         lat_var, lon_var = ds.nc_data.latlon_variables
 
-        lat_slice = slice(0, lat_var.size, 4)
-        lon_slice = slice(0, lon_var.size, 4)
+        stride = config.vector_arrow_stride
+
+        lat_slice = slice(0, lat_var.size, stride)
+        lon_slice = slice(0, lon_var.size, stride)
 
         time_index = ds.nc_data.timestamp_to_time_index(result['time'])     
         


### PR DESCRIPTION
## Background

Adds a new attribute `vector_arrow_stride` available in the datasetconfig file to control the density of arrows being shown in the UI.

* If not specified in the config file, it defaults to 4.

To specify it for CIOPS East for example:

```json
...
  "help": "...",
  "variables": {},
  "vector_arrow_stride": 8
}
```

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)
no change in behaviour
![image](https://user-images.githubusercontent.com/5572045/153493987-9d14af79-72ae-4e71-8671-0eb2e14b276f.png)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
