### PR TITLE
Fix calculated variable unit tests

### DIFF
--- a/data/calculated_parser/parser.py
+++ b/data/calculated_parser/parser.py
@@ -41,7 +41,7 @@ class Parser:
         Returns a numpy array of data.
         """
         self.data = data
-        self.result = np.nan  # populated by p_statement_expr()
+        self.result = np.array(np.nan)  # populated by p_statement_expr()
         self.key = key
         self.dims = dims
         self.expression = expression
@@ -94,6 +94,8 @@ class Parser:
     # docstrings, because it's used for the parsing specification.
     def p_statement_expr(self, t):
         'statement : expression'
+        if not isinstance(t[1],np.ndarray):
+            t[1] = np.array(t[1])
         self.result = t[1]
 
     def p_expression_variable(self, t):


### PR DESCRIPTION
## Background

The changes made to the `CalculatedArray` class in PRs #924 and #925 last fall broke many of the unit tests in  _test_calculated_data.py_. The main cause of these broken tests was that the code used to assign coordinates to the `CalculatedArray` objects was not intended to handle scalar indices. Scalar indices cause issues when grabbing the coordinates for the `CalculatedArray object because slicing coordinates with them returns an xarray coordinate object with zero length which cannot be assigned to a non-empty DataArray. To resolve this I added the `_format_key()` helper function which ensures that all of the indices passed to `__getitem__()` are iterable. This allows us to assign coordinates to these dimensions without issue. 

Other tests failed because DataArray wasn't returning a numpy array in some cases. To make sure that the parser always returns a numpy array we now initially set `self.result = np.array(np.nan)` then check that the parsed function result is an array before reassigning. 

## Why did you take this approach?
I initially started by modifying the tests to work with the new code but once I realized that most of these issues were related to the scalar indices I thought it would make more sense to make the few changes needed to make the `CalculatedArray.__getitem__()` more robust and fix the unit test issues.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.

