### PR TITLE
Fix some python deprecations

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -180,7 +180,7 @@ class NetCDFData(Data):
             [int or ndarray] -- Time index(es).
         """
 
-        time_var = np.sort(self.time_variable.astype(np.int))
+        time_var = np.sort(self.time_variable.astype(int))
 
         result = np.nonzero(np.isin(time_var, timestamp))[0]
 
@@ -386,7 +386,7 @@ class NetCDFData(Data):
         output_vars.extend(filter(None, [depth_var, time_var, lat_var, lon_var]))
         for variable in subset.data_vars:
             if variable not in output_vars:
-                subset = subset.drop(variable)
+                subset = subset.drop_vars([variable])
 
         for variable in output_vars:
             # if variable is a computed variable, overwrite it

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -138,7 +138,7 @@ def generateScript():
         resp = send_file(
             b,
             as_attachment=True,
-            attachment_filename=f"API_script_{script_type}.py",
+            download_name=f"API_script_{script_type}.py",
             mimetype="application/x-python",
         )
 
@@ -147,7 +147,7 @@ def generateScript():
         resp = send_file(
             b,
             as_attachment=True,
-            attachment_filename=f"API_script_{script_type}.r",
+            download_name=f"API_script_{script_type}.r",
             mimetype="text/plain",
         )
 


### PR DESCRIPTION


## Background

Related to #886 

Fixing some deprecation warnings emitted when running tests: https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/runs/5523667443?check_suite_focus=true#step:8:1

np.int, xarray.drop, flask attachment_name

## Why did you take this approach?

Followed suggestions from test logs.

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
