### PR TITLE
Fix `cache_timeout` -> `max_age` deprecation warning

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -333,7 +333,7 @@ def scale_v1_0(dataset: str, variable: str, scale: str):
         }
     )
 
-    return send_file(bytesIOBuff, mimetype="image/png", cache_timeout=MAX_CACHE)
+    return send_file(bytesIOBuff, mimetype="image/png", max_age=MAX_CACHE)
 
 
 @bp_v1_0.route(


### PR DESCRIPTION


## Background

Related to #886 

`cache_timeout` is deprecated.

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
