### PR TITLE
[Bugfix] Ensure int is returned in `NetCDFData#timestamp_to_time_index`

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -182,9 +182,9 @@ class NetCDFData(Data):
 
         time_var = np.sort(self.time_variable.astype(int))
 
-        result = np.nonzero(np.isin(time_var, timestamp))[0]
+        result = np.nonzero(np.isin(time_var, timestamp))[0].tolist()
 
-        return result if result.shape[0] > 1 else result[0]
+        return result if len(result) > 1 else result[0]
 
     def timestamp_to_iso_8601(self, timestamp: Union[int, List]):
         """Converts a given timestamp (e.g. 2031436800) or list of timestamps

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -434,11 +434,11 @@ def get_data_v1_0():
             ) as ds_bearing:
                 bearings = ds_bearing.nc_data.get_dataset_variable("bearing")[
                     data_slice
-                ]
+                ].squeeze(drop=True)
 
         d = data_array_to_geojson(
             data.squeeze(drop=True),
-            bearings.squeeze(drop=True),  # this is a hack
+            bearings,  # this is a hack
             lat_var[lat_slice],
             lon_var[lon_slice],
         )

--- a/tests/routes/test_api_v_1_0_get_data.py
+++ b/tests/routes/test_api_v_1_0_get_data.py
@@ -15,8 +15,7 @@ class TestAPIv1GetData(unittest.TestCase):
     def __get_response_data(self, resp):
         return json.loads(resp.get_data(as_text=True))
 
-    @unittest.skip("Failing")
-    def test_data_endpoint(self) -> None:
+    def test_data_endpoint_no_bearing(self) -> None:
         res = self.app.get(
             "/api/v1.0/data/",
             query_string={
@@ -32,7 +31,25 @@ class TestAPIv1GetData(unittest.TestCase):
 
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.content_type, "application/json")
-        self.assertEqual(len(data["features"]), 75)
+        self.assertEqual(len(data["features"]), 265)
+
+    def test_data_endpoint_with_bearing(self) -> None:
+        res = self.app.get(
+            "/api/v1.0/data/",
+            query_string={
+                "dataset": "giops_real",
+                "variable": "magwatervel",
+                "time": 2212444800,
+                "depth": 0,
+                "geometry_type": "area",
+            },
+        )
+
+        data = self.__get_response_data(res)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, "application/json")
+        self.assertEqual(len(data["features"]), 265)
 
     def test_data_endpoint_returns_error_400_when_args_are_missing(self) -> None:
         res = self.app.get("/api/v1.0/data/", query_string={})

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -42,7 +42,8 @@
             "vosaline": { "name": "Salinity", "unit": "PSU", "scale": [30, 40] },
             "vozocrtx": { "name": "Water Y Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
             "vomecrty": { "name": "Water X Velocity", "unit": "m/s", "scale": [-3, 3], "zero_centered": "true" },
-            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" }
+            "magwatervel": { "name": "Water Velocity", "unit": "m/s", "scale": [0, 3], "equation": "magnitude(vozocrtx, vomecrty)",  "dims": ["time", "depth", "latitude", "longitude"], "east_vector_component": "vozocrtx", "north_vector_component": "vomecrty" },
+            "bearing": { "hide": "true", "name": "Water Velocity Bearing (deg clockwise +tive from N)", "unit": "degrees", "scale": [0, 360], "equation": "bearing(vomecrty, vozocrtx)" ,"dims": ["time", "depth", "latitude", "longitude"] }
         }
     },
 


### PR DESCRIPTION
## Background

Ran into the following crash that #988 revealed

```
======================================================================
ERROR: test_data_endpoint_with_bearing (tests.routes.test_api_v_1_0_get_data.TestAPIv1GetData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nabil/Ocean-Data-Map-Project/tests/routes/test_api_v_1_0_get_data.py", line 37, in test_data_endpoint_with_bearing
    res = self.app.get(
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/werkzeug/test.py", line 1127, in get
    return self.open(*args, **kw)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/testing.py", line 216, in open
    return super().open(  # type: ignore
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/werkzeug/test.py", line 1072, in open
    response = self.run_wsgi_app(request.environ, buffered=buffered)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/werkzeug/test.py", line 943, in run_wsgi_app
    rv = run_wsgi_app(self.application, environ, buffered=buffered)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/werkzeug/test.py", line 1229, in run_wsgi_app
    app_rv = app(environ, start_response)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 90, in sentry_patched_wsgi_app
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 140, in __call__
    reraise(*_capture_exception(hub))
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/sentry_sdk/_compat.py", line 54, in reraise
    raise value
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 133, in __call__
    rv = self.app(
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 90, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/nabil/Ocean-Data-Map-Project/routes/api_v1_0.py", line 428, in get_data_v1_0
    data = data[data_slice]
  File "/home/nabil/Ocean-Data-Map-Project/data/calculated.py", line 139, in __getitem__
    return xr.DataArray(data_array, coords=coords, attrs=self.attrs)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/xarray/core/dataarray.py", line 406, in __init__
    coords, dims = _infer_coords_and_dims(data.shape, coords, dims)
  File "/home/nabil/miniconda3/envs/navigator/lib/python3.8/site-packages/xarray/core/dataarray.py", line 161, in _infer_coords_and_dims
    raise ValueError(
ValueError: coordinate 'time' is a DataArray dimension, but it has shape () rather than expected shape 1 matching the dimension size

```

Turns out `NetCDFData#timestamp_to_time_index` was returning `np.int64`'s which caused the check in https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/blob/f0b41cf90419627ac716e1c12039e147ef49db35/data/calculated.py#L157 to break. This behaviour is a bug and should have been returning Python-native `int`'s.

* Also adds two tests to cover this fix to ensure it remains fixed.

## Why did you take this approach?

Simplest way without breaking other things.

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
