### PR TITLE
Add `/api/dump-heap-memory` endpoint

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -8,6 +8,7 @@ import pickle
 import shutil
 import sqlite3
 import sys
+import tempfile
 from io import BytesIO
 
 import geojson
@@ -119,8 +120,7 @@ def test_sentry():
 @bp_v1_0.route("/api/dump-heap-memory", methods=["GET"])
 def dump_heap_memory():
 
-    filename = f"/tmp/onav_memory_dump_{datetime.datetime.now()}.pickle"
-    with open(filename, "wb") as dump:
+    with tempfile.NamedTemporaryFile() as dump:
         xs = []
         for obj in gc.get_objects():
             i = id(obj)
@@ -134,7 +134,12 @@ def dump_heap_memory():
                 xs.append({"id": i, "class": cls, "size": size, "referents": referents})
         pickle.dump(xs, dump)
 
-    return send_file(filename, as_attachment=True, mimetype="application/octet-stream")
+        return send_file(
+            dump.name,
+            download_name=f"onav_memory_dump_{datetime.datetime.now()}.pickle",
+            as_attachment=True,
+            mimetype="application/octet-stream",
+        )
 
 
 @bp_v1_0.route("/api/v1.0/generatescript/")


### PR DESCRIPTION
## Background

The production LXD containers are using over 96GB of RAM. Each gunicorn process is hogging about 4GB. That's not good so we need to see what objects are taking up memory.

* Introduces a new `/api/dump-heap-memory` endpoint which will generate a file in `/tmp/` containing a dump of all Python objects in memory with the `__class__` attribute.

GET requests will return a pickle file with the heap memory for the python process dumped inside. Can be viewed via 

```python
with open(memory.pickle, 'rb') as dump:
    obj = pickle.load(dump)
```

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
