### PR TITLE
Cannot generate bathymetry tiles for polar projections #999

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -1407,7 +1407,7 @@ export default class Map extends React.PureComponent {
       default:
         source = new olsource.XYZ({
           url: (
-            `/api/v1.0/tiles/bath/${currentBathy}` +
+            `/api/v1.0/tiles/bath/${currentProj}` +
             "/{z}/{x}/{y}.png"
           ),
           projection: currentProj,


### PR DESCRIPTION
## Background
Fixes issue #999 


## Why did you take this approach?
The query was using bathymetry type instead of that selected projection type. Changing `currentBathy` to `currentProj` fixing the problem.
```
updateBathymetryLayer(currentProj, currentBathy) {
    let source = null;
    switch (currentBathy) {
      case "etopo1":
      default:
        source = new olsource.XYZ({
          url: (
            `/api/v1.0/tiles/bath/${currentProj}` +
            "/{z}/{x}/{y}.png"
          ),
          projection: currentProj,
        })
        break;
    }
```

## Anything in particular that should be highlighted?


## Screenshot(s)
![Capture1](https://user-images.githubusercontent.com/80789651/161089300-52602e3e-5569-4453-9963-78c244b37eeb.PNG)
![Capture2](https://user-images.githubusercontent.com/80789651/161089310-fc59e71e-6f9b-4c47-b548-4dbd05d0f0e5.PNG)
![Capture3](https://user-images.githubusercontent.com/80789651/161089315-5fa236f5-9057-4290-8e33-569e04dc42aa.PNG)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
