### PR TITLE
Reduce map preload levels from 7 to 1

### DIFF
--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -258,7 +258,7 @@ export default class Map extends React.PureComponent {
     // Data layer
     this.layer_data = new ollayer.Tile(
       {
-        preload: 7,
+        preload: 1,
         source: new olsource.XYZ({
           attributions: [
             new olcontrol.Attribution({
@@ -277,7 +277,7 @@ export default class Map extends React.PureComponent {
         }),
         opacity: this.props.options.mapBathymetryOpacity,
         visible: this.props.options.bathymetry,
-        preload: 7,
+        preload: 1,
     });
 
     // MBTiles Land shapes (high res)
@@ -1022,7 +1022,7 @@ export default class Map extends React.PureComponent {
         const shadedRelief = this.props.options.topoShadedRelief ? "true" : "false";
 
         return new ollayer.Tile({
-          preload: 7,
+          preload: 1,
           source: new olsource.XYZ({
             url: `/api/v1.0/tiles/topo/${shadedRelief}/${projection}/{z}/{x}/{y}.png`,
             projection: projection,
@@ -1035,7 +1035,7 @@ export default class Map extends React.PureComponent {
         });
       case "ocean":
         return new ollayer.Tile({
-          preload: 7,
+          preload: 1,
           source: new olsource.XYZ({
             url: "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}",
             projection: "EPSG:3857",
@@ -1048,7 +1048,7 @@ export default class Map extends React.PureComponent {
         });
       case "world":
         return new ollayer.Tile({
-          preload: 7,
+          preload: 1,
           source: new olsource.XYZ({
             url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
             projection: "EPSG:3857",


### PR DESCRIPTION
## Background

This will reduce the number of requests being sent to the python server and help reduce unnecessary load. By setting to 1 it will pre-load tiles for the current zoom level.

https://openlayers.org/en/latest/apidoc/module-ol_layer_Tile-TileLayer.html

We don't need to be pre-loading 7 zoom levels of tiles at a time.

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
