### PR TITLE
Remove `hashable_lru` decorator from `open_dataset`

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -2,10 +2,8 @@ from data.calculated import CalculatedData
 from data.fvcom import Fvcom
 from data.mercator import Mercator
 from data.nemo import Nemo
-from utils.decorators import hashable_lru
 
 
-@hashable_lru
 def open_dataset(dataset, **kwargs):
     """Open a dataset.
 


### PR DESCRIPTION
## Background
See #1003 for graphs

Removes one source of unbounded memory growth. This decorator isn't even being used correctly since the function arguments are being hashed based on memory location and so we never see a cache hit.

## Why did you take this approach?
Fastest way to stem the bleeding until we have time to properly implement a memcached-backed `open_dataset` in the future.


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
