### PR TITLE
Add Navigator option to Run and Debug button in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "ONav",
+            "type": "python",
+            "request": "launch",
+            "program": "runserver.py",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        },
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
## Background
Added `ONav` and `Python: Current File` options to VS Code's _Run and Debug_ button. The first allows VS Code users to launch the Navigator with debugging via the `runserver.py` script. The other runs the currently selected python file - useful when running/testing scripts.

## Screenshot(s)

![debug_button](https://user-images.githubusercontent.com/79917349/164289464-59329efa-e97a-4a4f-b1cd-ef241c37be12.png)

## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
