### PR TITLE
Add Git Version endpoint to API and Response Header

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -50,6 +50,25 @@ def configure_log_formatter() -> None:
     )
 
 
+def subprocess_check_output(*args) -> str:
+    try:
+        return (
+            subprocess.check_output([*args], stderr=subprocess.STDOUT)
+            .decode("ascii")
+            .strip()
+        )
+    except UnicodeDecodeError:
+        print(
+            "Unable to decode subprocess response - try updating your current branch."
+        )
+        return ""
+    except subprocess.CalledProcessError as e:
+        print(
+            f"Exception on process - args={args} rc=#{e.returncode} output=#{e.output}"
+        )
+        return ""
+
+
 def create_app(testing: bool = False, dataset_config_path: str = ""):
     configure_log_formatter()
 
@@ -64,14 +83,8 @@ def create_app(testing: bool = False, dataset_config_path: str = ""):
     app.config.from_pyfile("oceannavigator.cfg", silent=False)
     app.config.from_envvar("OCEANNAVIGATOR_SETTINGS", silent=True)
     app.testing = testing
-    app.git_hash = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
-    )
-    app.git_tag = (
-        subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
-        .decode("ascii")
-        .strip()
-    )
+    app.git_hash = subprocess_check_output("git", "rev-parse", "HEAD")
+    app.git_tag = subprocess_check_output("git", "describe", "--tags", "--abbrev=0")
 
     if app.config.get("WSGI_PROFILING"):
         if not os.path.isdir("./profiler_results"):

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 import tempfile
 from sys import argv
 
@@ -62,6 +63,9 @@ def create_app(testing: bool = False, dataset_config_path: str = ""):
     app.add_url_rule("/", "root", lambda: app.send_static_file("index.html"))
     app.config.from_pyfile("oceannavigator.cfg", silent=False)
     app.config.from_envvar("OCEANNAVIGATOR_SETTINGS", silent=True)
+    app.git_version = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+    )
     app.testing = testing
 
     if app.config.get("WSGI_PROFILING"):

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -63,10 +63,15 @@ def create_app(testing: bool = False, dataset_config_path: str = ""):
     app.add_url_rule("/", "root", lambda: app.send_static_file("index.html"))
     app.config.from_pyfile("oceannavigator.cfg", silent=False)
     app.config.from_envvar("OCEANNAVIGATOR_SETTINGS", silent=True)
-    app.git_version = (
+    app.testing = testing
+    app.git_hash = (
         subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
     )
-    app.testing = testing
+    app.git_tag = (
+        subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
+        .decode("ascii")
+        .strip()
+    )
 
     if app.config.get("WSGI_PROFILING"):
         if not os.path.isdir("./profiler_results"):

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -141,12 +141,17 @@ def dump_heap_memory():
             mimetype="application/octet-stream",
         )
 
-@bp_v1_0.route('/api/v1.0/gitversion')
-def git_version():
+@bp_v1_0.route('/api/v1.0/gitinfo')
+def git_info():
     """
     Returns the current Git hash of the application.
     """
-    return jsonify(current_app.git_version)
+    git_info = {
+        "git_hash" : current_app.git_hash,
+        "git_tag" : current_app.git_tag,
+    }
+    
+    return jsonify(git_info)
 
 @bp_v1_0.route("/api/v1.0/generatescript/")
 def generateScript():
@@ -1439,7 +1444,8 @@ def after_request(response):
     header = response.headers
     # Relying on iptables to keep this safe
     header["Access-Control-Allow-Origin"] = "*"
-    header["X-ONav-Git-Version"] = current_app.git_version
+    header["X-ONav-Git-Hash"] = current_app.git_hash
+    header["X-ONav-Git-Tag"] = current_app.git_tag
     header["X-XSS-Protection"] = "1; mode=block"
     header["X-Frame-Options"] = "SAMEORIGIN"
 

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -1439,7 +1439,7 @@ def after_request(response):
     header = response.headers
     # Relying on iptables to keep this safe
     header["Access-Control-Allow-Origin"] = "*"
-    header["Git-Version"] = current_app.git_version
+    header["X-ONav-Git-Version"] = current_app.git_version
     header["X-XSS-Protection"] = "1; mode=block"
     header["X-Frame-Options"] = "SAMEORIGIN"
     

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -1442,7 +1442,7 @@ def after_request(response):
     header["X-ONav-Git-Version"] = current_app.git_version
     header["X-XSS-Protection"] = "1; mode=block"
     header["X-Frame-Options"] = "SAMEORIGIN"
-    
+
     return response
 
 

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -7,7 +7,6 @@ import os
 import pickle
 import shutil
 import sqlite3
-import subprocess
 import sys
 import tempfile
 from io import BytesIO
@@ -147,8 +146,7 @@ def git_version():
     """
     Returns the current Git hash of the application.
     """
-    git_version = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
-    return jsonify(git_version)
+    return jsonify(current_app.git_version)
 
 @bp_v1_0.route("/api/v1.0/generatescript/")
 def generateScript():
@@ -1441,9 +1439,10 @@ def after_request(response):
     header = response.headers
     # Relying on iptables to keep this safe
     header["Access-Control-Allow-Origin"] = "*"
+    header["Git-Version"] = current_app.git_version
     header["X-XSS-Protection"] = "1; mode=block"
     header["X-Frame-Options"] = "SAMEORIGIN"
-
+    
     return response
 
 

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 from io import BytesIO
@@ -141,6 +142,13 @@ def dump_heap_memory():
             mimetype="application/octet-stream",
         )
 
+@bp_v1_0.route('/api/v1.0/gitversion')
+def git_version():
+    """
+    Returns the current Git hash of the application.
+    """
+    git_version = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    return jsonify(git_version)
 
 @bp_v1_0.route("/api/v1.0/generatescript/")
 def generateScript():


### PR DESCRIPTION
## Background
Adds an API endpoint that returns the Git version of the Navigator's code via `/api/v1.0/gitversion`. This can be useful for testing/profiling the Navigator and comparing performance of different releases. The git version is also added to the Response Headers so that we can grab it from individual API requests.

## Why did you take this approach?
GitPython provides a more direct approach but may leak resources. I came across other approaches which account for system environment but since the Navigator is only deployed in nix systems this approach seemed most straight forward.

## Screenshots
![git_version](https://user-images.githubusercontent.com/79917349/164302036-5ab095cf-b811-4cc5-a7b2-39b89edbe191.png)

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
