### PR TITLE
Update Cartopy resource directory

### DIFF
--- a/plotting/basemap.py
+++ b/plotting/basemap.py
@@ -27,15 +27,15 @@ def _get_land_geoms(resolution: str, extent: list) -> shpreader.BasicReader:
 
     if resolution == "f":
         land_shp = shpreader.BasicReader(
-            current_app.config["SHAPE_FILE_DIR"] + "/ne_10m_diff.shp"
+            current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/ne_10m_diff.shp"
         )
     elif resolution == "i":
         land_shp = shpreader.BasicReader(
-            current_app.config["SHAPE_FILE_DIR"] + "/ne_50m_diff.shp"
+            current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/ne_50m_diff.shp"
         )
     else:
         land_shp = shpreader.BasicReader(
-            current_app.config["SHAPE_FILE_DIR"] + "/ne_110m_diff.shp"
+            current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/ne_110m_diff.shp"
         )
 
     # crop land geometries to plot extent

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -164,7 +164,7 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
         zorder=1,
     )
 
-    img = plt.imread(current_app.config["SHAPE_FILE_DIR"] + "/bluemarble.png")
+    img = plt.imread(current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/bluemarble.png")
     img_extent = (-180, 180, -90, 90)
     m.imshow(
         img, origin="upper", extent=img_extent, transform=ccrs.PlateCarree(), zorder=1


### PR DESCRIPTION
## Background
To keep our datastore organized we'll keep the shapefiles needed for Cartopy in a subdirectory of `SHAPE_FILE_DIR` called _cartopy_resources_ per Dwayne's suggestion. This PR just updates the paths when importing the land geometry shapefiles

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
