### PR TITLE
Fix R API scripts

### DIFF
--- a/plotting/templates/rCSVtemplate.txt
+++ b/plotting/templates/rCSVtemplate.txt
@@ -13,4 +13,4 @@ print(url)
 
 
 print("Downloading file and exiting...")
-download.file(url, fname, method="auto", mode = "wb")
+download.file(url, fname, method="auto", mode="wb")

--- a/plotting/templates/rCSVtemplate.txt
+++ b/plotting/templates/rCSVtemplate.txt
@@ -8,9 +8,9 @@ queryObj <- fromJSON(query)
 fname <- paste("ONAV_CSV_", queryObj["dataset"],"_", queryObj["variable"],".csv", sep="")
 gsub("[\r\n]", "", query)
 base_url <- "http://navigator.oceansdata.ca/api/v1.0/plot/?"
-url <- paste(base_url,"&query=",URLencode(query),"&dpi=",toString(dpi), sep="")
+url <- paste(base_url,"&query=",URLencode(query),"&save&format=csv&size=10x7&dpi=",toString(dpi), sep="")
 print(url)
 
 
 print("Downloading file and exiting...")
-download.file(url, fname, method="libcurl")
+download.file(url, fname, method="auto", mode = "wb")

--- a/plotting/templates/rPLOTtemplate.txt
+++ b/plotting/templates/rPLOTtemplate.txt
@@ -14,4 +14,4 @@ print(url)
 
 
 print("Downloading file and exiting...")
-download.file(url, fname, method="libcurl")
+download.file(url, fname, method="auto", mode = 'wb')

--- a/plotting/templates/rPLOTtemplate.txt
+++ b/plotting/templates/rPLOTtemplate.txt
@@ -14,4 +14,4 @@ print(url)
 
 
 print("Downloading file and exiting...")
-download.file(url, fname, method="auto", mode = 'wb')
+download.file(url, fname, method="auto", mode="wb")


### PR DESCRIPTION
## Background
We found that the R scripts were downloading garbage data. It appears that the files were corrupted on downlead plus the csv script was actually downloading a plot image and just saving it with a '.png' extension. Setting `method="auto"` and  `mode="wb"` in the download.file function appears to resolve the file corruption issue. Tested both scripts on Ubuntu 20.04 and Windows 10.

## Why did you take this approach?
Using the auto method gives R some flexibility to select the download method based on the user's OS. Otherwise we'd have to specify a method that might not be available on the user's system.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
