### PR TITLE
Only run lint_python action when python files are edited

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -3,9 +3,13 @@ name: Lint Python
 on:
   push:
     branches: [ master, ]
+    paths:
+      - '**.py'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths:
+      - '**.py'
 
 jobs:
   build:


### PR DESCRIPTION
## Background

Reduces useless CI runs when python files aren't changed. same change is coming up with the tests.

## Why did you take this approach?


## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
