### PR TITLE
Remove API button from map toolbar

### DIFF
--- a/oceannavigator/frontend/src/components/MapToolbar.jsx
+++ b/oceannavigator/frontend/src/components/MapToolbar.jsx
@@ -731,7 +731,7 @@ class MapToolbar extends React.Component {
               className="languageButton"
             />
 
-            <OverlayTrigger
+            {/* <OverlayTrigger
               placement="bottom"
               overlay={<Tooltip id="tooltip">{_("API Documentation")}</Tooltip>}
             >
@@ -742,7 +742,7 @@ class MapToolbar extends React.Component {
               >
                 API
               </NavItem>
-            </OverlayTrigger>
+            </OverlayTrigger> */}
             <OverlayTrigger
               placement="bottom"
               overlay={<Tooltip id="tooltip">{_("Help")}</Tooltip>}


### PR DESCRIPTION
## Background
The link to the API documentation is currently broken so the button should be removed until the documentation becomes available.

## Why did you take this approach?
I just commented out the relevant code so that we can easily restore it once docs become available. 

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
