### PR TITLE
Handle missing Cartopy resources

### DIFF
--- a/plotting/basemap.py
+++ b/plotting/basemap.py
@@ -33,6 +33,7 @@ def _get_land_geoms(resolution: str, extent: list) -> shpreader.BasicReader:
             current_app.config["SHAPE_FILE_DIR"] + shp_file
         )
     except shpreader.shapefile.ShapefileException:
+        print(f"Could not open {shp_file}, using Cartopy feature interface.")
         land_shp = cfeature.NaturalEarthFeature("physical", "land", resolution)
 
     # crop land geometries to plot extent

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -2,11 +2,10 @@ import datetime
 import re
 
 import cartopy.crs as ccrs
-import numpy as np
+import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
-
+import numpy as np
 from flask import current_app
-from utils.errors import ClientError
 
 
 def get_filename(plot_type, dataset_name, extension):
@@ -164,11 +163,20 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
         zorder=1,
     )
 
-    img = plt.imread(current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/bluemarble.png")
-    img_extent = (-180, 180, -90, 90)
-    m.imshow(
-        img, origin="upper", extent=img_extent, transform=ccrs.PlateCarree(), zorder=1
-    )
+    try:
+        img = plt.imread(
+            current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/bluemarble.png"
+        )
+        m.imshow(
+            img,
+            origin="upper",
+            extent=(-180, 180, -90, 90),
+            transform=ccrs.PlateCarree(),
+            zorder=1,
+        )
+    except FileNotFoundError:
+        m.add_feature(cfeature.LAND)
+        m.add_feature(cfeature.OCEAN)
 
 
 def point_plot(points, grid_loc):

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -162,10 +162,11 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
         ylabel_style={"size": 10},
         zorder=1,
     )
-
+    
+    img_path = "/cartopy_resources/bluemarble.png"
     try:
         img = plt.imread(
-            current_app.config["SHAPE_FILE_DIR"] + "/cartopy_resources/bluemarble.png"
+            current_app.config["SHAPE_FILE_DIR"] + img_path
         )
         m.imshow(
             img,
@@ -175,6 +176,7 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
             zorder=1,
         )
     except FileNotFoundError:
+        print(f"Could not open {img_path}, using Cartopy feature interface.")
         m.add_feature(cfeature.LAND)
         m.add_feature(cfeature.OCEAN)
 


### PR DESCRIPTION
## Background
Error handling is needed for deployments where the necessary Cartopy images and shapefiles may no be available, i.e. for our  automated CI testing. If these files cannot be located, the Navigator will fall back to using Cartopy's built-in resources.

## Why did you take this approach?
If these resources are unavilable it only makes sense to use those provided by Cartopy. This should allow GitHub actions to complete CI testing.  

## Screenshot(s)
If the bluemarble image (top) is missing plot image with Cartopy's included features (bottom)
![trans1](https://user-images.githubusercontent.com/79917349/167912446-f8fb155e-cbee-419c-98e9-7700edd94354.png)
![trans2](https://user-images.githubusercontent.com/79917349/167912454-b97f1961-5a0b-4cdc-98e8-8a4f51debdd8.png)

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
