### PR TITLE
VM Plotting Issue With Multi Point Selection

### DIFF
--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -394,9 +394,14 @@ class TimeseriesPlotter(PointPlotter):
                 subplot += 1
 
             plt.subplot(gs[:, subplot])
-            plt.plot_date(
-                datenum, np.squeeze(self.data), fmt="-", figure=fig, xdate=True
-            )
+            for idx, _ in enumerate(self.points):
+                plt.plot_date(
+                    datenum,
+                    np.squeeze(self.data[idx, :, :]),
+                    fmt="-",
+                    figure=fig,
+                    xdate=True,
+                )
             plt.ylabel(
                 f"{self.variable_name.title()} ({utils.mathtext(self.variable_unit)})",
                 fontsize=14,


### PR DESCRIPTION
## Background
The issue with VM time series plotting option with selecting/importing multiple points is fixed by looping through all the selected points. 

## Why did you take this approach?
The VM time series plotting with selecting/importing single points is working fine as expected below;
![1](https://user-images.githubusercontent.com/80789651/168844121-4cd08075-c085-4f13-9264-17d2e9d091a6.PNG)

But For multi points selection or importing multi points the UI is getting error message from backend plotting. The details message with screen shots are below:
![2](https://user-images.githubusercontent.com/80789651/168847873-d89d8afc-5015-438f-8a45-dfc85bb6ad2c.PNG)
![3](https://user-images.githubusercontent.com/80789651/168847906-a64c904a-4656-48fa-b539-ce37f34d8227.PNG)
![4](https://user-images.githubusercontent.com/80789651/168847928-f1f067f5-d62e-437e-b04f-ae66e53068ce.PNG)

## Anything in particular that should be highlighted?
The wrong dimension in X and Y plotting with multi points selection originated in the timeseries.py file plotting function. 

## Screenshot(s)

![55](https://user-images.githubusercontent.com/80789651/168851454-d0469aa6-11c2-4537-ba0e-2d9215d30668.PNG)
![99](https://user-images.githubusercontent.com/80789651/168851502-55363ba9-fa61-4741-861f-c95ced905263.PNG)

## Checks
- [ ] I ran unit tests.
- [y ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
