### PR TITLE
Addition GDWPS dataset wave data

### DIFF
--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -78,6 +78,8 @@ def data_array_to_geojson(
         props = {**attribs, "data": elem.item()}
 
         if bearings is not None:
+            if np.isnan(bearings[multi_idx].item()):
+                continue
             props["bearing"] = bearings[multi_idx].item()
 
         features.append(Feature(geometry=p, properties=props))

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -438,3 +438,18 @@ class VectorVariableConfig(VariableConfig):
             north_vector_component = None
 
         return north_vector_component
+
+     @property
+    def bearing_component(self) -> str:
+        """
+        Returns the bearing_component for the variable
+        if defined in dataset config file
+        Returns:
+            str -- bearing_component name
+        """
+        try:
+            bearing_component = self.__get_attribute("bearing_component")
+        except KeyError:
+            bearing_component = None
+
+        return bearing_component

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -439,7 +439,7 @@ class VectorVariableConfig(VariableConfig):
 
         return north_vector_component
 
-     @property
+    @property
     def bearing_component(self) -> str:
         """
         Returns the bearing_component for the variable

--- a/oceannavigator/frontend/data-help/gdwps-10day.html
+++ b/oceannavigator/frontend/data-help/gdwps-10day.html
@@ -1,0 +1,43 @@
+<html>
+	<p><a href="https://dd.weather.gc.ca/model_gdwps/netcdf/">Global Deterministic Wave Prediction System (GDWPS)</a><br/><br/>
+How the GDWPS 05 day atmospheric elements forecasts are derived;<br/><br/>
+<table>
+	<tr><td> GDWPS pseudo-analysis is executed four times a day for 6 hours
+			 centred at 00, 06, 12, and 18 UTC </td></tr>
+</table><br/><br/>
+The Global Deterministic Wave Prediction System (GDWPS) carries out physics calculations to arrive at deterministic predictions of atmospheric elements from the current day out to 10 days into the future. 
+Atmospheric elements include temperature, precipitation, cloud cover, wind speed and direction, humidity and others.
+This product contains raw numerical results of these calculations. 
+Geographical coverage is global. Data is available at horizontal resolutions of 25 km and 66 km. Data is available for 28 vertical levels.
+The winds and ice are available hourly from the IAU (incremental analysis update) cycle of the GDWPS G2 run. 
+The GDWPS pseudo-analysis is executed four times a day for 6 hourscentred at 00, 06, 12, and 18 UTC. 
+Each pseudo-analysis retrieves initial conditions by reading a restart file, 
+which was written at the end of the previous pseudo-analysis, and so it is a smooth continuation of the previous run. 
+The forecast is executed twice per day. 
+The initial conditions of the 00 UTC forecast come from the previous day's 18 UTC pseudo-analysis, 
+and the initial conditions of the 12 UTC forecast come from the 06 UTC pseudo-analysis. 
+In order to bridge the 3-hour gap from the end of the pseudo-analysis to 
+the availability of the GDWPS G1 run, the G1 IAU data is used.<br/><br/>
+<table>
+<tr><td>Variables and derived products from GDWPS: </td>
+    <td>Significant height of wind waves (m)<br/>
+	Direction of wind waves (degree<br/>
+	10 metre U wind component (m/s)<br/>
+	10 metre V wind component (m/s)<br/>
+	Mean zero-crossing wave period (s)<br/>
+	Peak wave period (s)<br/>
+	Sea ice area fraction (%)<br/>
+	Wind Velocity (m/s)<br/>
+	derived wind wave velocity (m/s)</td></tr>
+</table><br/><br/>
+Geographical Coverage: global ocean<br/><br/>
+Spatial Resolution: Direction: 36 bins (10° each) Frequency: 36 bins from 0.035 Hz to 0.984 Hz in increments of 1.10.
+Horizontal resolution: 1/4 degree
+Independent variables: x, y, time, spectral frequency, spectral direction
+<br/><br/>
+Geographical Coverage: global ocean
+Domain: Computational 3 overlapping grids (p01: 59N - 86N,  p02: 65S - 65N,  p03: 80S - 61.5S) <br/><br/>
+Formulation: Linear balance equation for the spectral wave action density<br/><br/>
+Time steps: Overall time step 450 s<br/><br/>
+Data Source: <a href="https://eccc-msc.github.io/open-data/msc-datamart/readme_en/">Environment and Climate Change Canada</a></p>
+</html>

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -370,8 +370,8 @@ class DatasetSelector extends React.Component {
     let quiverSelector = null;
     if (this.props.showQuiverSelector && !this.state.loading) {
       let quiverVariables = [];
-      const ListvalidQuivModelClass = ["Mercator"]    // List of Valid Model_Class for Quiver Plot. Need to update this List when Model_Class : "Nemo" and "Fvcom" working
-      if ((ListvalidQuivModelClass.includes(this.state.model_class)) && (this.state.datasetVariables)) {
+      const modelClassesWithQuiver = ["Mercator"]    // List of Valid Model_Class for Quiver Plot. Need to update this List when Model_Class : "Nemo" and "Fvcom" working
+      if (this.state.datasetVariables && modelClassesWithQuiver.includes(this.state.model_class)) {
         quiverVariables = this.state.datasetVariables.filter((variable) => {
           return variable.id.includes("mag") && variable.id.includes("vel");
         });

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -75,7 +75,7 @@ class DatasetSelector extends React.Component {
     });
 
     const quantum = currentDataset.quantum;
-
+    const model_class= currentDataset.model_class;
     GetVariablesPromise(newDataset).then(variableResult => {
       this.setState({ loadingPercent: 33 });
 
@@ -124,7 +124,7 @@ class DatasetSelector extends React.Component {
             dataset: newDataset,
 
             quantum: quantum,
-
+            model_class: model_class,
             datasetVariables: variableResult.data,
             variable: newVariable,
             variable_scale: newVariableScale,
@@ -370,7 +370,8 @@ class DatasetSelector extends React.Component {
     let quiverSelector = null;
     if (this.props.showQuiverSelector && !this.state.loading) {
       let quiverVariables = [];
-      if (this.state.datasetVariables) {
+      const ListvalidQuivModelClass = ["Mercator"]    // List of Valid Model_Class for Quiver Plot. Need to update this List when Model_Class : "Nemo" and "Fvcom" working
+      if ((ListvalidQuivModelClass.includes(this.state.model_class)) && (this.state.datasetVariables)) {
         quiverVariables = this.state.datasetVariables.filter((variable) => {
           return variable.id.includes("mag") && variable.id.includes("vel");
         });

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -36,6 +36,8 @@ const PARENT_ATTRIBUTES_TO_UPDATE = Object.freeze([
   "quiverVariable",
 ]);
 
+const MODEL_CLASSES_WITH_QUIVER = Object.freeze(["Mercator"]);
+
 class DatasetSelector extends React.Component {
   constructor(props) {
     super(props);
@@ -370,8 +372,7 @@ class DatasetSelector extends React.Component {
     let quiverSelector = null;
     if (this.props.showQuiverSelector && !this.state.loading) {
       let quiverVariables = [];
-      const modelClassesWithQuiver = ["Mercator"]    // List of Valid Model_Class for Quiver Plot. Need to update this List when Model_Class : "Nemo" and "Fvcom" working
-      if (this.state.datasetVariables && modelClassesWithQuiver.includes(this.state.model_class)) {
+      if (this.state.datasetVariables && MODEL_CLASSES_WITH_QUIVER.includes(this.state.model_class)) {
         quiverVariables = this.state.datasetVariables.filter((variable) => {
           return variable.id.includes("mag") && variable.id.includes("vel");
         });

--- a/oceannavigator/frontend/src/components/Defaults.js
+++ b/oceannavigator/frontend/src/components/Defaults.js
@@ -1,6 +1,7 @@
 
 const DATASET_DEFAULTS = Object.freeze({
   dataset: "giops_day",
+  model_class: "Mercator",
   attribution: "",
   quantum: "day",
   depth: 0,

--- a/oceannavigator/frontend/src/components/Defaults.js
+++ b/oceannavigator/frontend/src/components/Defaults.js
@@ -1,7 +1,6 @@
 
 const DATASET_DEFAULTS = Object.freeze({
   dataset: "giops_day",
-  model_class: "Mercator",
   attribution: "",
   quantum: "day",
   depth: 0,

--- a/oceannavigator/frontend/src/components/Defaults.js
+++ b/oceannavigator/frontend/src/components/Defaults.js
@@ -23,4 +23,3 @@ const DEFAULT_OPTIONS = Object.freeze({
 });
   
 export { DATASET_DEFAULTS, DEFAULT_OPTIONS };
-  

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -559,7 +559,7 @@ export default class Map extends React.PureComponent {
           if (velocity < knotsToMetersPerSecond(0.5)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
-                scale: 0.3,
+                scale: 0.25,
                 src: I1,
                 opacity: 1,
                 anchor: anchor,
@@ -570,7 +570,7 @@ export default class Map extends React.PureComponent {
           else if (velocity < knotsToMetersPerSecond(1.0)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
-                scale: 0.35,
+                scale: 0.30,
                 src: I2,
                 opacity: 1,
                 anchor: anchor,
@@ -600,7 +600,7 @@ export default class Map extends React.PureComponent {
               })
             })
           }
-          else if (velocity < knotsToMetersPerSecond(5.0)) {
+          else if (velocity < knotsToMetersPerSecond(6.0)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
                 scale: 0.5,
@@ -611,10 +611,10 @@ export default class Map extends React.PureComponent {
               })
             })
           }
-          else if (velocity < knotsToMetersPerSecond(7.0)) {
+          else if (velocity < knotsToMetersPerSecond(12.0)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
-                scale: 0.7,
+                scale: 0.6,
                 src: I6,
                 opacity: 1,
                 anchor: anchor,
@@ -622,10 +622,10 @@ export default class Map extends React.PureComponent {
               })
             })
           }
-          else if (velocity < knotsToMetersPerSecond(10.0)) {
+          else if (velocity < knotsToMetersPerSecond(18.0)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
-                scale: 0.75,
+                scale: 0.7,
                 src: I7,
                 opacity: 1,
                 anchor: anchor,
@@ -633,10 +633,10 @@ export default class Map extends React.PureComponent {
               })
             })
           }
-          else if (velocity < knotsToMetersPerSecond(13.0)) {
+          else if (velocity < knotsToMetersPerSecond(36.0)) {
             return new olstyle.Style({
               image: new olstyle.Icon({
-                scale: 0.9,
+                scale: 0.8,
                 src: I8,
                 opacity: 1,
                 anchor: anchor,

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -293,6 +293,15 @@ colormaps = {
     "temperature": mcolors.ListedColormap(
         np.loadtxt(os.path.join(data_dir, "temperature.txt"))
     ),
+    "10 metre U wind component": cmocean.cm.balance,
+    "10 metre v wind component": cmocean.cm.balance,
+    "Significant height of wind waves": cmocean.cm.tempo,
+    "Direction of wind waves": cmocean.cm.balance,
+    "Mean zero-crossing wave period": cmocean.cm.phase,
+    "Peak wave period": cmocean.cm.phase,
+    "Sea ice area fraction": cmocean.cm.matter,
+    "Significant height of combined wind waves and swell": cmocean.cm.tempo,
+    "Wind Velocity": cmocean.cm.amp,
 }
 colormaps["wind"] = colormaps["velocity"]
 

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -221,6 +221,7 @@ def datasets_query_v1_0():
                     "quantum": config.quantum,
                     "help": config.help,
                     "attribution": config.attribution,
+                    "model_class": config.model_class,
                 }
             )
     data = sorted(data, key=lambda k: k["value"])
@@ -469,10 +470,14 @@ def get_data_v1_0():
 
         bearings = None
         if "mag" in result["variable"]:
+            bearings_var = DatasetConfig(
+                result["dataset"]).variable[result["variable"]].bearing_component
+            if not bearings_var:
+                bearings_var = "bearing"            
             with open_dataset(
-                config, variable="bearing", timestamp=result["time"]
+                config, variable=bearings_var, timestamp=result["time"]
             ) as ds_bearing:
-                bearings = ds_bearing.nc_data.get_dataset_variable("bearing")[
+                bearings = ds_bearing.nc_data.get_dataset_variable(bearings_var)[
                     data_slice
                 ].squeeze(drop=True)
 

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -470,10 +470,7 @@ def get_data_v1_0():
 
         bearings = None
         if "mag" in result["variable"]:
-            bearings_var = DatasetConfig(
-                result["dataset"]).variable[result["variable"]].bearing_component
-            if not bearings_var:
-                bearings_var = "bearing"            
+            bearings_var = config.variable[result["variable"]].bearing_component or "bearing"   
             with open_dataset(
                 config, variable=bearings_var, timestamp=result["time"]
             ) as ds_bearing:


### PR DESCRIPTION
## Background
Addition of new GDWPS wave dataset in the Ocean Navigator UI . The details description of the dataset is below: 
The Global Deterministic Prediction System (GDPS) performs physical calculations to produce deterministic forecasts of atmospheric elements from the present day to 10 days in the future. Elements of the atmosphere include temperature, precipitation, cloud cover, wind speed and direction, and humidity. This product contains the raw numerical results of these calculations. The geographical coverage is global. The horizontal spatial resolution of the data is 15 km. Data is available for 33 vertical levels. The forecasts are carried out twice a day.

## Why did you take this approach?
The client requested to add the Global Deterministic Prediction System (GDPS) wave dataset to our Ocean Navigator UI.

## Anything in particular that should be highlighted?
- Enable and Disable Quiver Variable selector for Mercator and NEMO/Fvcom Model. 
- Added and set "vector_arrow_stride": 10  in the `datasetconfig.json` file for high dense dataset (e.g. CMEMS)
- GDWPS Dataset is in [GRIB2](https://eccc-msc.github.io/open-data/msc-data/nwp_gdwps/readme_gdwps-datamart_en/) format. A script is built to convert it in the netCDF format. 

## Screenshot(s)

![Capture_1](https://user-images.githubusercontent.com/80789651/173254796-1437cbe4-6a6b-4f4b-92da-829a866eac1d.PNG)

## Checks
- [Y ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
