### PR TITLE
Subset panel does not update when dataset is changed within the area window Issue #971

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -180,7 +180,7 @@ class AreaWindow extends React.Component {
     const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
     window.location.href = "/api/v1.0/subset/?" +
        "&output_format=" + this.state.output_format +
-       "&dataset_name=" + this.state.dataset_0.dataset +
+       "&dataset_name=" + this.props.dataset_0.dataset +
        "&variables=" + this.state.output_variables.join() +
         queryString +
        "&time=" + [this.state.output_starttime, output_endtime].join() +
@@ -191,7 +191,7 @@ class AreaWindow extends React.Component {
   saveScript(key) {
     let query = {
       "output_format": this.state.output_format,
-      "dataset_name": this.state.dataset_0.dataset,
+      "dataset_name": this.props.dataset_0.dataset,
       "variables": this.state.output_variables.join(),
       "time": [this.state.output_starttime, this.state.output_endtime].join(),
       "user_grid": (this.state.convertToUserGrid ? 1:0),
@@ -382,7 +382,7 @@ class AreaWindow extends React.Component {
               state={this.state.output_variables}
               def={"defaults.dataset"}
               onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}
-              url={"/api/v1.0/variables/?dataset=" + this.state.dataset_0.dataset
+              url={"/api/v1.0/variables/?dataset=" + this.props.dataset_0.dataset
               }
               title={_("Variables")}
             />


### PR DESCRIPTION
## Background
This PR resolved the issue  #971 - Subset panel does not update when dataset is changed within the area window.

## Why did you take this approach?
The variable options in the subset panel are not updated when the dataset is changed from within the AreaWindow component. In the screenshots shown in issue # 971,  the user changed datasets from RIOPS 3D Forecast to GIOPS 10 Day 3D forecast and pressed the GO button but the subset panel remains unchanged. The most notable issue is that these datasets are hourly and daily forecasts we should see the time pickers update to accommodate the time resolution of the second dataset. Clicking the 'save' button on the subset panel will download a netcdf file containing data from the first dataset.


## Anything in particular that should be highlighted?
- Resolved the subset variable update issue 
- Resolved the netcdf file download issue 

## Screenshot(s)

![Capture](https://user-images.githubusercontent.com/80789651/175221811-563b47b0-7149-4aa6-97b2-10521f5276ae.PNG)

## Checks
- [y ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
