### PR TITLE
Fix PSSC Subsetting

### DIFF
--- a/data/calculated.py
+++ b/data/calculated.py
@@ -34,7 +34,8 @@ class CalculatedData(NetCDFData):
             return self._calculated[variable_key]["dims"]
         except KeyError:
             raise KeyError(
-                f"{variable_key} does not have a dims attribute defined in datasetconfig.json. "
+                f"{variable_key} does not have a dims attribute \
+                    defined in datasetconfig.json. "
                 f"This is required for all calculated variables."
             )
 


### PR DESCRIPTION
## Background
Subsetting PSSC has been broken since it was brought into the Navigator last year. Some of our previous work with the subset endpoint and calculated variables seems to have fixed the dimension issue that initially kept it form working but there is still a problem with the variable's interpolation attribute which is a dictionary and cannot be encoded in NC format. Casting the attributes to strings fixes the problem.

## Why did you take this approach?
I previously fixed a similar issue with the `dims` attribute that prevented the Navigator from writing to NC3 but I didn't realize that there were other attributes causing issues. Now we'll just cast/re-cast all attributes to strings in case any of the others cause issues.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
