### PR TITLE
Subset Panel Time Stamp Update Issue Resolved 

### DIFF
--- a/kml
+++ b/kml
@@ -1,1 +1,1 @@
-/data/kml
+E:/data/kml

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -89,7 +89,7 @@ class AreaWindow extends React.Component {
 
   componentDidMount() {
     this._mounted = true;
-}
+  }
 
   componentWillUnmount() {
     this._mounted = false;
@@ -156,7 +156,6 @@ class AreaWindow extends React.Component {
     _("Show Selected Area(s)");
     _("Saved Image Size");
 
-    
     const mapSettings = (<Panel 
       defaultExpanded
       bsStyle='primary'

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -20,9 +20,11 @@ import CustomPlotLabels from "./CustomPlotLabels.jsx";
 import DatasetSelector from "./DatasetSelector.jsx";
 import Icon from "./lib/Icon.jsx";
 import TimePicker from "./TimePicker.jsx";
+import SubsetPanel from "./SubsetPanel.jsx";
 import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
+import {GetVariablesPromise} from "../remote/OceanNavigator.js";
 const stringify = require("fast-stable-stringify");
 
 class AreaWindow extends React.Component {
@@ -84,6 +86,7 @@ class AreaWindow extends React.Component {
       output_format: "NETCDF4", // Subset output format
       convertToUserGrid: false,
       zip: false, // Should subset file(s) be zipped
+      subset_variable: [],
     };
 
     if (props.init !== null) {
@@ -96,16 +99,23 @@ class AreaWindow extends React.Component {
     this.onTabChange = this.onTabChange.bind(this);
     this.updatePlotTitle = this.updatePlotTitle.bind(this);
     this.saveScript = this.saveScript.bind(this);
+    this.getSubsetVariable = this.getSubsetVariable.bind(this);
   }
 
   componentDidMount() {
     this._mounted = true;
-  }
+    this.getSubsetVariable();
+}
 
   componentWillUnmount() {
     this._mounted = false;
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.dataset_0.dataset !== prevProps.dataset_0.dataset) {
+      this.getSubsetVariable();
+    }
+  }
   //Updates Plot with User Specified Title
   updatePlotTitle(title) {
     if (title !== this.state.plotTitle) {
@@ -121,10 +131,10 @@ class AreaWindow extends React.Component {
             ...prevState.dataset_0,
             ...value
           }
-        }));
+        }));      
         return;
       }
-
+      
       if (key === "dataset_1") {
         this.setState(prevState => ({
           dataset_1: {
@@ -180,23 +190,35 @@ class AreaWindow extends React.Component {
     const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
     window.location.href = "/api/v1.0/subset/?" +
        "&output_format=" + this.state.output_format +
-       "&dataset_name=" + this.state.dataset_0.dataset +
+       "&dataset_name=" + this.props.dataset_0.dataset +
        "&variables=" + this.state.output_variables.join() +
         queryString +
        "&time=" + [this.state.output_starttime, output_endtime].join() +
        "&user_grid=" + (this.state.convertToUserGrid ? 1 : 0) +
        "&should_zip=" + (this.state.zip ? 1 : 0);
+
+       console.log(`output_format=`,  this.state.output_format)
+       console.log(`dataset_name=`,  this.props.dataset_0.dataset)
+       console.log(`&variables=`,  this.state.output_variables.join())
+       console.log(`&Starttime=`,  this.props.dataset_0.starttime)
+       console.log(`&Endtime=`,  output_endtime)
+       console.log(`&queryString=`,  queryString)
   }
 
   saveScript(key) {
     let query = {
       "output_format": this.state.output_format,
-      "dataset_name": this.state.dataset_0.dataset,
+      "dataset_name": this.props.dataset_0.dataset,
       "variables": this.state.output_variables.join(),
       "time": [this.state.output_starttime, this.state.output_endtime].join(),
       "user_grid": (this.state.convertToUserGrid ? 1:0),
       "should_zip": (this.state.zip ? 1:0)
     };
+    console.log(`output_format=`,  this.state.output_format)
+    console.log(`dataset_name=`,  this.props.dataset_0.dataset)
+    console.log(`&variables=`,  this.state.output_variables.join())
+    console.log(`query=`,  query)
+    console.log(`key=`,  key)
     // check if predefined area
     if (typeof this.props.area[0] === 'string' || this.props.area[0] instanceof String) { 
       query['area'] = this.props.area[0];
@@ -219,6 +241,22 @@ class AreaWindow extends React.Component {
     });
   }
 
+  getSubsetVariable() {
+    GetVariablesPromise(this.props.dataset_0.dataset).then(variableResult => {
+      const subsetVariables = variableResult.data.filter((variable) => {
+        return !variable.id.includes("psubsurfacechannel");
+      });
+      this.setState({
+        subset_variable: subsetVariables       
+      });
+    });
+    
+    this.setState({
+      output_starttime: this.props.dataset_0.starttime,
+      output_endtime: this.props.dataset_0.time
+    });
+  }
+
   render() {
     _("Dataset");
     _("Time");
@@ -233,7 +271,10 @@ class AreaWindow extends React.Component {
     _("Show Selected Area(s)");
     _("Saved Image Size");
 
-    const mapSettings = (<Panel
+    console.log(`Area_Window_output_starttime`, this.state.output_starttime)
+    console.log(`Area_Window_output_endtime`, this.state.output_endtime)
+    
+    const mapSettings = (<Panel 
       defaultExpanded
       bsStyle='primary'
       key='map_settings'
@@ -366,124 +407,132 @@ class AreaWindow extends React.Component {
       </Panel.Collapse>
     </Panel>);
 
-    const subsetPanel = (<Panel
-      key='subset'
-      defaultExpanded
-      bsStyle='primary'
-    >
-      <Panel.Heading>{_("Subset")}</Panel.Heading>
-      <Panel.Collapse>
-        <Panel.Body>
-          <form>
-            <ComboBox
-              id='variable'
-              key='variable'
-              multiple={true}
-              state={this.state.output_variables}
-              def={"defaults.dataset"}
-              onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}
-              url={"/api/v1.0/variables/?dataset=" + this.state.dataset_0.dataset
-              }
-              title={_("Variables")}
-            />
+    const subsetPanel = <SubsetPanel 
+                          id = "SubsetPanel"
+                          key = "SubsetPanel"
+                          dataset= {this.props.dataset_0}
+                        />
+    // (<Panel
+    //   key='subset'
+    //   defaultExpanded
+    //   bsStyle='primary'
+    // >
+    //   <Panel.Heading>{_("Subset")}</Panel.Heading>
+    //   <Panel.Collapse>
+    //     <Panel.Body>
+    //       <form>         
+    //         <ComboBox
+    //           id='variable'
+    //           key='variable'
+    //           multiple={true}
+    //           state={this.state.output_variables}
+    //           def={"defaults.dataset"}
+    //           onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}
+    //           // url={"/api/v1.0/variables/?dataset=" + this.state.dataset_0.dataset
+    //           // }             
+    //           data = {this.state.subset_variable}            
+    //           title={_("Variables")}
+    //         />
 
-            <SelectBox
-              id='time_range'
-              key='time_range'
-              state={this.state.output_timerange}
-              onUpdate={(_, value) => {this.setState({output_timerange: value,});}}
-              title={_("Select Time Range")}
-            />
+    //         <SelectBox
+    //           id='time_range'
+    //           key='time_range'
+    //           state={this.state.output_timerange}
+    //           onUpdate={(_, value) => {this.setState({output_timerange: value,});}}
+    //           title={_("Select Time Range")}
+    //         />
 
-            <TimePicker
-              id='starttime'
-              key='starttime'
-              state={this.state.output_starttime}
-              def=''
-              quantum={this.state.dataset_0.quantum}
-              dataset={this.state.dataset_0.dataset}
-              variable={this.state.dataset_0.variable}
-              title={this.state.output_timerange ? _("Start Time (UTC)") : _("Time (UTC)")}
-              onUpdate={ (_, value) => { this.setState({output_starttime: value}); }}
-              max={this.state.dataset_0.time + 1}
-            />
+    //         <TimePicker
+    //           id='starttime'
+    //           key='starttime' 
+    //           state={this.props.dataset_0.time}
+    //           def=''
+    //           quantum={this.props.dataset_0.quantum}
+    //           dataset={this.props.dataset_0.dataset}
+    //           variable={this.props.dataset_0.variable}
+    //           title={this.state.output_timerange ? _("Start Time (UTC)") : _("Time (UTC)")}
+    //           onUpdate={ (_, value) => { this.setState({output_starttime: value}); }}
+    //           max={this.state.output_endtime}
 
-            <div style={{display: this.state.output_timerange ? "block" : "none",}}>
-              <TimePicker
-                id='time'
-                key='time'
-                state={this.state.output_endtime}
-                def=''
-                quantum={this.state.dataset_0.quantum}
-                dataset={this.state.dataset_0.dataset}
-                variable={this.state.dataset_0.variable}
-                title={this.state.output_timerange ? _("End Time (UTC)") : _("Time (UTC)")}
-                onUpdate={ (_, value) => { this.setState({output_endtime: value}); }}
-                min={this.state.dataset_0.time}
-              />
-            </div>
+    //         />
 
-            <FormGroup controlId="output_format">
-              <ControlLabel>{_("Output Format")}</ControlLabel>
-              <FormControl componentClass="select" onChange={e => { this.setState({output_format: e.target.value}); }}>
-                <option value="NETCDF4">{_("NetCDF-4")}</option>
-                <option value="NETCDF3_CLASSIC">{_("NetCDF-3 Classic")}</option>
-                <option value="NETCDF3_64BIT">{_("NetCDF-3 64-bit")}</option>
-                <option value="NETCDF3_NC" disabled={
-                  this.state.dataset_0.dataset.indexOf("giops") === -1 &&
-                  this.state.dataset_0.dataset.indexOf("riops") === -1 // Disable if not a giops or riops dataset
-                }>
-                  {_("NetCDF-3 NC")}
-                </option>
-                <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
-              </FormControl>
-            </FormGroup>
+    //         <div style={{display: this.state.output_timerange ? "block" : "none",}}>
+    //           <TimePicker
+    //             id='time'
+    //             key='time'
+    //             state={this.props.dataset_0.time}
+    //             def=''
+    //             quantum={this.props.dataset_0.quantum}
+    //             dataset={this.props.dataset_0.dataset}
+    //             variable={this.props.dataset_0.variable}         
+    //             title={this.state.output_timerange ? _("End Time (UTC)") : _("Time (UTC)")}
+    //             onUpdate={ (_, value) => { this.setState({output_endtime: value}); }}
+    //             min={this.state.output_starttime}
+                
+    //           />
+    //         </div>
 
-            {/*
-            <SelectBox
-              id='convertToUserGrid'
-              key='convertToUserGrid'
-              state={this.state.convertToUserGrid}
-              onUpdate={this.onLocalUpdate}
-              title={_("Convert to User Grid")}
-            />
-            */}        
-            <SelectBox 
-              id='zip'
-              key='zip'
-              state={this.state.zip} 
-              onUpdate={ (_, checked) => { this.setState({zip: checked}); } }
-              title={_("Compress as *.zip")}
-            />
+    //         <FormGroup controlId="output_format">
+    //           <ControlLabel>{_("Output Format")}</ControlLabel>
+    //           <FormControl componentClass="select" onChange={e => { this.setState({output_format: e.target.value}); }}>
+    //             <option value="NETCDF4">{_("NetCDF-4")}</option>
+    //             <option value="NETCDF3_CLASSIC">{_("NetCDF-3 Classic")}</option>
+    //             <option value="NETCDF3_64BIT">{_("NetCDF-3 64-bit")}</option>
+    //             <option value="NETCDF3_NC" disabled={
+    //               this.props.dataset_0.dataset.indexOf("giops") === -1 &&
+    //               this.props.dataset_0.dataset.indexOf("riops") === -1 // Disable if not a giops or riops dataset
+    //             }>
+    //               {_("NetCDF-3 NC")}
+    //             </option>
+    //             <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
+    //           </FormControl>
+    //         </FormGroup>
 
-            <Button 
-              bsStyle="default" 
-              key='save'
-              id='save'
-              onClick={this.subsetArea}
-              disabled={this.state.output_variables == ""}
-            ><Icon icon="save" /> {_("Save")}</Button>
+    //         {/*
+    //         <SelectBox
+    //           id='convertToUserGrid'
+    //           key='convertToUserGrid'
+    //           state={this.state.convertToUserGrid}
+    //           onUpdate={this.onLocalUpdate}
+    //           title={_("Convert to User Grid")}
+    //         />
+    //         */}        
+    //         <SelectBox 
+    //           id='zip'
+    //           key='zip'
+    //           state={this.state.zip} 
+    //           onUpdate={ (_, checked) => { this.setState({zip: checked}); } }
+    //           title={_("Compress as *.zip")}
+    //         />
+
+    //         <Button 
+    //           bsStyle="default" 
+    //           key='save'
+    //           id='save'
+    //           onClick={this.subsetArea}
+    //           disabled={this.state.output_variables == ""}
+    //         ><Icon icon="save" /> {_("Save")}</Button>
             
-            <DropdownButton
-              id="script"
-              title={<span><Icon icon="file-code-o" /> {_("API Scripts")}</span>}
-              bsStyle={"default"}
-              disabled={this.state.output_variables == ""}
-              onSelect={this.saveScript}
-              dropup
-            >
-              <MenuItem
-                eventKey="python"
-              ><Icon icon="code" /> {_("Python 3")}</MenuItem>
-              <MenuItem
-                eventKey="r"
-              ><Icon icon="code" /> {_("R")}</MenuItem>
-            </DropdownButton>
-          </form>
-        </Panel.Body>
-      </Panel.Collapse>
-    </Panel>
-    );
+    //         <DropdownButton
+    //           id="script"
+    //           title={<span><Icon icon="file-code-o" /> {_("API Scripts")}</span>}
+    //           bsStyle={"default"}
+    //           disabled={this.state.output_variables == ""}
+    //           onSelect={this.saveScript}
+    //           dropup
+    //         >
+    //           <MenuItem
+    //             eventKey="python"
+    //           ><Icon icon="code" /> {_("Python 3")}</MenuItem>
+    //           <MenuItem
+    //             eventKey="r"
+    //           ><Icon icon="code" /> {_("R")}</MenuItem>
+    //         </DropdownButton>
+    //       </form>
+    //     </Panel.Body>
+    //   </Panel.Collapse>
+    // </Panel>
+    // );
 
     const dataset = (<Panel
       key='left_map'

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -22,7 +22,7 @@ class SubsetPanel extends React.Component {
       convertToUserGrid: false,
       zip: false, // Should subset file(s) be zipped
       subset_variables: [],
-    }
+    };
   // Function bindings
   this.subsetArea = this.subsetArea.bind(this);
   this.saveScript = this.saveScript.bind(this);
@@ -63,7 +63,7 @@ calculateAreaBoundingBox(area) {
 }
 
 subsetArea() {
-  var queryString = []
+  var queryString = [];
   // check if predefined area
   if (typeof this.props.area[0] === 'string' || this.props.area[0] instanceof String) { 
     queryString = "&area=" + this.props.area[0];
@@ -74,7 +74,7 @@ subsetArea() {
     queryString = "&min_range=" + min_range +
                   "&max_range=" + max_range;
   }
-  const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
+  const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime;
   window.location.href = "/api/v1.0/subset/?" +
      "&output_format=" + this.state.output_format +
      "&dataset_name=" + this.props.dataset.dataset +

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -112,20 +112,15 @@ saveScript(key) {
 
 getSubsetVariables() {
   GetVariablesPromise(this.props.dataset.dataset).then(variableResult => {
-    const subsetVariables = variableResult.data.filter((variable) => {
-      return !variable.id.includes("psubsurfacechannel");
-    });
     this.setState({
-      subset_variables: subsetVariables       
+      subset_variables: variableResult.data, 
     });
   });
-  
   this.setState({
     output_starttime: this.props.dataset.starttime,
-    output_endtime: this.props.dataset.time
+    output_endtime: this.props.dataset.time    
   });
 }
-
 render() {
   const subsetPanel = (
     <Panel
@@ -143,11 +138,10 @@ render() {
                 multiple={true}
                 state={this.state.output_variables}
                 def={"defaults.dataset"}
-                onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}            
+                onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}
                 data={this.state.subset_variables}            
                 title={("Variables")}
               />
-
               <SelectBox
                 id='time_range'
                 key='time_range'
@@ -155,7 +149,6 @@ render() {
                 onUpdate={(_, value) => {this.setState({output_timerange: value,});}}
                 title={_("Select Time Range")}
               />
-
               <TimePicker
                 id='starttime'
                 key='starttime'
@@ -168,7 +161,6 @@ render() {
                 onUpdate={ (key, value) => { this.setState({output_starttime: value}); }}
                 max={this.props.dataset.time + 1}
               />
-
               <div style={{display: this.state.output_timerange ? "block" : "none",}}>
                 <TimePicker
                   id='time'
@@ -183,7 +175,6 @@ render() {
                   min={this.props.dataset.time}               
                 />
               </div>
-
               <FormGroup controlId="output_format">
                 <ControlLabel>{_("Output Format")}</ControlLabel>
                 <FormControl componentClass="select" onChange={e => { this.setState({output_format: e.target.value}); }}>
@@ -199,7 +190,6 @@ render() {
                   <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
                 </FormControl>
               </FormGroup>
-
               <SelectBox 
                 id='zip'
                 key='zip'
@@ -207,15 +197,13 @@ render() {
                 onUpdate={ (_, checked) => { this.setState({zip: checked}); } }
                 title={_("Compress as *.zip")}
               />
-
               <Button 
                 bsStyle="default" 
                 key='save'
                 id='save'
                 onClick={this.subsetArea}
                 disabled={this.state.output_variables == ""}
-              ><Icon icon="save" /> {_("Save")}</Button> 
-            
+              ><Icon icon="save" /> {_("Save")}</Button>             
               <DropdownButton
                 id="script"
                 title={<span><Icon icon="file-code-o" /> {_("API Scripts")}</span>}
@@ -227,11 +215,10 @@ render() {
                 <MenuItem
                   eventKey="python"
                 ><Icon icon="code" /> {_("Python 3")}</MenuItem>
-                {/* <MenuItem
+                 <MenuItem
                   eventKey="r"
-                ><Icon icon="code" /> {_("R")}</MenuItem> */}
+                ><Icon icon="code" /> {_("R")}</MenuItem> 
               </DropdownButton> 
-
             </form>
           </Panel.Body>
         </Panel.Collapse>
@@ -242,9 +229,8 @@ render() {
     <div>     
       {subsetPanel} 
     </div>
-  );
-}
-    
+    );
+  }   
 }
 
 //***********************************************************************

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -15,23 +15,23 @@ class SubsetPanel extends React.Component {
     this._mounted = false;
     this.state = {
       output_timerange: false,
-      output_variables: "",
+      output_variables: [],
       output_starttime: props.dataset.starttime,
       output_endtime: props.dataset.time,
       output_format: "NETCDF4", // Subset output format
       convertToUserGrid: false,
       zip: false, // Should subset file(s) be zipped
-      subset_variable: [],
+      subset_variables: [],
     }
   // Function bindings
   this.subsetArea = this.subsetArea.bind(this);
   this.saveScript = this.saveScript.bind(this);
-  this.getSubsetVariable = this.getSubsetVariable.bind(this);
+  this.getSubsetVariables = this.getSubsetVariables.bind(this);
   }
 
 componentDidMount() {
   this._mounted = true;
-  this.getSubsetVariable();
+  this.getSubsetVariables();
 }
   
 componentWillUnmount() {
@@ -40,7 +40,7 @@ componentWillUnmount() {
   
 componentDidUpdate(prevProps) {
   if (this.props.dataset.dataset !== prevProps.dataset.dataset) {
-    this.getSubsetVariable();
+    this.getSubsetVariables();
   }
 }
 
@@ -110,13 +110,13 @@ saveScript(key) {
                         "&scriptType=SUBSET";
 }
 
-getSubsetVariable() {
+getSubsetVariables() {
   GetVariablesPromise(this.props.dataset.dataset).then(variableResult => {
     const subsetVariables = variableResult.data.filter((variable) => {
       return !variable.id.includes("psubsurfacechannel");
     });
     this.setState({
-      subset_variable: subsetVariables       
+      subset_variables: subsetVariables       
     });
   });
   
@@ -144,7 +144,7 @@ render() {
                 state={this.state.output_variables}
                 def={"defaults.dataset"}
                 onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}            
-                data = {this.state.subset_variable}            
+                data={this.state.subset_variables}            
                 title={("Variables")}
               />
 
@@ -157,8 +157,8 @@ render() {
               />
 
               <TimePicker
-                id='subsetstarttime'
-                key='subsetstarttime' 
+                id='starttime'
+                key='starttime'
                 state={this.state.output_starttime}
                 def=''
                 quantum={this.props.dataset.quantum}
@@ -171,8 +171,8 @@ render() {
 
               <div style={{display: this.state.output_timerange ? "block" : "none",}}>
                 <TimePicker
-                  id='subsettime'
-                  key='subsettime'
+                  id='time'
+                  key='time'
                   state={this.state.output_endtime}
                   def=''
                   quantum={this.props.dataset.quantum}

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import {Nav, NavItem, Panel, Row,  Col, Button, 
+    FormControl, FormGroup, ControlLabel, DropdownButton, MenuItem} from "react-bootstrap";
+import ComboBox from "./ComboBox.jsx";
+import Range from "./Range.jsx";
+import SelectBox from "./SelectBox.jsx";
+import TimePicker from "./TimePicker.jsx";
+import PropTypes from "prop-types";
+import { withTranslation } from "react-i18next";
+import {GetVariablesPromise} from "../remote/OceanNavigator.js";
+const stringify = require("fast-stable-stringify");
+
+
+export default class SubsetPanel extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+
+      }
+    }
+
+    render(){
+        const subsetPanel = (<Panel
+            key='subset'
+            defaultExpanded
+            bsStyle='primary'
+          >
+            <Panel.Heading>{("Subset")}</Panel.Heading>
+            <Panel.Collapse>
+              <Panel.Body>
+                <form>   
+                <h1> Test </h1>      
+       
+                </form>
+              </Panel.Body>
+            </Panel.Collapse>
+          </Panel>
+          );
+          return (
+            <div>     
+            {subsetPanel} 
+            </div>
+          );
+    }
+    
+}

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -1,46 +1,256 @@
 import React from "react";
-import {Nav, NavItem, Panel, Row,  Col, Button, 
-    FormControl, FormGroup, ControlLabel, DropdownButton, MenuItem} from "react-bootstrap";
+import {Panel, Button, FormControl, FormGroup, ControlLabel, DropdownButton, MenuItem} from "react-bootstrap";
 import ComboBox from "./ComboBox.jsx";
-import Range from "./Range.jsx";
 import SelectBox from "./SelectBox.jsx";
 import TimePicker from "./TimePicker.jsx";
 import PropTypes from "prop-types";
+import Icon from "./lib/Icon.jsx";
 import { withTranslation } from "react-i18next";
 import {GetVariablesPromise} from "../remote/OceanNavigator.js";
 const stringify = require("fast-stable-stringify");
 
-
-export default class SubsetPanel extends React.Component {
-    constructor(props) {
-      super(props);
-      this.state = {
-
-      }
+class SubsetPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this._mounted = false;
+    this.state = {
+      output_timerange: false,
+      output_variables: "",
+      output_starttime: props.dataset.starttime,
+      output_endtime: props.dataset.time,
+      output_format: "NETCDF4", // Subset output format
+      convertToUserGrid: false,
+      zip: false, // Should subset file(s) be zipped
+      subset_variable: [],
     }
+  // Function bindings
+  this.subsetArea = this.subsetArea.bind(this);
+  this.saveScript = this.saveScript.bind(this);
+  this.getSubsetVariable = this.getSubsetVariable.bind(this);
+  }
 
-    render(){
-        const subsetPanel = (<Panel
-            key='subset'
-            defaultExpanded
-            bsStyle='primary'
-          >
-            <Panel.Heading>{("Subset")}</Panel.Heading>
-            <Panel.Collapse>
-              <Panel.Body>
-                <form>   
-                <h1> Test </h1>      
-       
-                </form>
-              </Panel.Body>
-            </Panel.Collapse>
-          </Panel>
-          );
-          return (
-            <div>     
-            {subsetPanel} 
-            </div>
-          );
-    }
+componentDidMount() {
+  this._mounted = true;
+  this.getSubsetVariable();
+}
+  
+componentWillUnmount() {
+  this._mounted = false;
+}
+  
+componentDidUpdate(prevProps) {
+  if (this.props.dataset.dataset !== prevProps.dataset.dataset) {
+    this.getSubsetVariable();
+  }
+}
+
+// Find max extents of drawn area
+calculateAreaBoundingBox(area) {
+  let lat_min = area.polygons[0][0][0];
+  let lat_max = area.polygons[0][0][1];
+  let long_min = area.polygons[0][0][0];
+  let long_max = area.polygons[0][0][1];
+
+  for (let i = 0; i < area.polygons[0].length; ++i) {
+    lat_min = Math.min(lat_min, area.polygons[0][i][0]);
+    long_min = Math.min(long_min, area.polygons[0][i][1]);
+
+    lat_max = Math.max(lat_max, area.polygons[0][i][0]);
+    long_max = Math.max(long_max, area.polygons[0][i][1]);
+  }
+
+  return [lat_min, lat_max, long_min, long_max];
+}
+
+subsetArea() {
+  var queryString = []
+  // check if predefined area
+  if (typeof this.props.area[0] === 'string' || this.props.area[0] instanceof String) { 
+    queryString = "&area=" + this.props.area[0];
+  } else {
+    const AABB = this.calculateAreaBoundingBox(this.props.area[0]);
+    const min_range = [AABB[0], AABB[2]].join();
+    const max_range = [AABB[1], AABB[3]].join(); 
+    queryString = "&min_range=" + min_range +
+                  "&max_range=" + max_range;
+  }
+  const output_endtime = this.state.output_timerange ? this.state.output_endtime : this.state.output_starttime
+  window.location.href = "/api/v1.0/subset/?" +
+     "&output_format=" + this.state.output_format +
+     "&dataset_name=" + this.props.dataset.dataset +
+     "&variables=" + this.state.output_variables.join() +
+      queryString +
+     "&time=" + [this.state.output_starttime, output_endtime].join() +
+     "&user_grid=" + (this.state.convertToUserGrid ? 1 : 0) +
+     "&should_zip=" + (this.state.zip ? 1 : 0);
+}
+
+saveScript(key) {
+  let query = {
+    "output_format": this.state.output_format,
+    "dataset_name": this.props.dataset.dataset,
+    "variables": this.state.output_variables.join(),
+    "time": [this.state.output_starttime, this.state.output_endtime].join(),
+    "user_grid": (this.state.convertToUserGrid ? 1:0),
+    "should_zip": (this.state.zip ? 1:0)
+  };
+  // check if predefined area
+  if (typeof this.props.area[0] === 'string' || this.props.area[0] instanceof String) { 
+    query['area'] = this.props.area[0];
+  } else {
+    const AABB = this.calculateAreaBoundingBox(this.props.area[0]);
+    query['min_range'] = [AABB[0], AABB[2]].join();
+    query['max_range'] = [AABB[1], AABB[3]].join() ;
+  }
+
+  window.location.href = window.location.origin + 
+                        "/api/v1.0/generatescript/?query=" + 
+                        stringify(query) + 
+                        "&lang=" + key + 
+                        "&scriptType=SUBSET";
+}
+
+getSubsetVariable() {
+  GetVariablesPromise(this.props.dataset.dataset).then(variableResult => {
+    const subsetVariables = variableResult.data.filter((variable) => {
+      return !variable.id.includes("psubsurfacechannel");
+    });
+    this.setState({
+      subset_variable: subsetVariables       
+    });
+  });
+  
+  this.setState({
+    output_starttime: this.props.dataset.starttime,
+    output_endtime: this.props.dataset.time
+  });
+}
+
+render() {
+  const subsetPanel = (
+    <Panel
+      key='subset'
+      defaultExpanded
+      bsStyle='primary'
+    >
+      <Panel.Heading>{_("Subset")}</Panel.Heading>
+        <Panel.Collapse>
+          <Panel.Body>
+            <form>   
+              <ComboBox
+                id='variable'
+                key='variable'
+                multiple={true}
+                state={this.state.output_variables}
+                def={"defaults.dataset"}
+                onUpdate={(keys, values) => { this.setState({output_variables: values[0],}); }}            
+                data = {this.state.subset_variable}            
+                title={("Variables")}
+              />
+
+              <SelectBox
+                id='time_range'
+                key='time_range'
+                state={this.state.output_timerange}
+                onUpdate={(_, value) => {this.setState({output_timerange: value,});}}
+                title={_("Select Time Range")}
+              />
+
+              <TimePicker
+                id='subsetstarttime'
+                key='subsetstarttime' 
+                state={this.state.output_starttime}
+                def=''
+                quantum={this.props.dataset.quantum}
+                dataset={this.props.dataset.dataset}
+                variable={this.props.dataset.variable}
+                title={this.state.output_timerange ? _("Start Time (UTC)") : _("Time (UTC)")}
+                onUpdate={ (key, value) => { this.setState({output_starttime: value}); }}
+                max={this.props.dataset.time + 1}
+              />
+
+              <div style={{display: this.state.output_timerange ? "block" : "none",}}>
+                <TimePicker
+                  id='subsettime'
+                  key='subsettime'
+                  state={this.state.output_endtime}
+                  def=''
+                  quantum={this.props.dataset.quantum}
+                  dataset={this.props.dataset.dataset}
+                  variable={this.props.dataset.variable}         
+                  title={this.state.output_timerange ? _("End Time (UTC)") : _("Time (UTC)")}
+                  onUpdate={ (key, value) => { this.setState({output_endtime: value}); }}
+                  min={this.props.dataset.time}               
+                />
+              </div>
+
+              <FormGroup controlId="output_format">
+                <ControlLabel>{_("Output Format")}</ControlLabel>
+                <FormControl componentClass="select" onChange={e => { this.setState({output_format: e.target.value}); }}>
+                  <option value="NETCDF4">{_("NetCDF-4")}</option>
+                  <option value="NETCDF3_CLASSIC">{_("NetCDF-3 Classic")}</option>
+                  <option value="NETCDF3_64BIT">{_("NetCDF-3 64-bit")}</option>
+                  <option value="NETCDF3_NC" disabled={
+                    this.props.dataset.dataset.indexOf("giops") === -1 &&
+                    this.props.dataset.dataset.indexOf("riops") === -1 // Disable if not a giops or riops dataset
+                  }>
+                    {("NetCDF-3 NC")}
+                  </option>
+                  <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
+                </FormControl>
+              </FormGroup>
+
+              <SelectBox 
+                id='zip'
+                key='zip'
+                state={this.state.zip} 
+                onUpdate={ (_, checked) => { this.setState({zip: checked}); } }
+                title={_("Compress as *.zip")}
+              />
+
+              <Button 
+                bsStyle="default" 
+                key='save'
+                id='save'
+                onClick={this.subsetArea}
+                disabled={this.state.output_variables == ""}
+              ><Icon icon="save" /> {_("Save")}</Button> 
+            
+              <DropdownButton
+                id="script"
+                title={<span><Icon icon="file-code-o" /> {_("API Scripts")}</span>}
+                bsStyle={"default"}
+                disabled={this.state.output_variables == ""}
+                onSelect={this.saveScript}
+                dropup
+              >
+                <MenuItem
+                  eventKey="python"
+                ><Icon icon="code" /> {_("Python 3")}</MenuItem>
+                {/* <MenuItem
+                  eventKey="r"
+                ><Icon icon="code" /> {_("R")}</MenuItem> */}
+              </DropdownButton> 
+
+            </form>
+          </Panel.Body>
+        </Panel.Collapse>
+    </Panel>
+    );
+
+  return (
+    <div>     
+      {subsetPanel} 
+    </div>
+  );
+}
     
 }
+
+//***********************************************************************
+SubsetPanel.propTypes = {
+  dataset: PropTypes.object.isRequired,
+  area: PropTypes.array.isRequired,
+};
+
+export default withTranslation()(SubsetPanel);

--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -61,6 +61,12 @@ class TimePicker extends React.Component {
     this._mounted = false;
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.dataset !== prevProps.dataset) {
+      this.populate(this.props)
+    }
+  }
+
   getIndexFromTimestamp(timestamp) {
     const keys = Object.keys(this.state.map);
     return keys.indexOf(timestamp.toString());
@@ -110,10 +116,8 @@ class TimePicker extends React.Component {
 
   populate(props) {
     // eslint-disable-next-line max-len
-    console.log(`timepicker dataset_variable`,props.dataset, props.variable)
     GetTimestampsPromise(props.dataset, props.variable).then(timestampResult => {
       const data = timestampResult.data;
-      console.log(`timepicker data`, data)
 
       let map = {};
       let revmap = {};

--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -110,8 +110,10 @@ class TimePicker extends React.Component {
 
   populate(props) {
     // eslint-disable-next-line max-len
+    console.log(`timepicker dataset_variable`,props.dataset, props.variable)
     GetTimestampsPromise(props.dataset, props.variable).then(timestampResult => {
       const data = timestampResult.data;
+      console.log(`timepicker data`, data)
 
       let map = {};
       let revmap = {};

--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -63,7 +63,7 @@ class TimePicker extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.dataset !== prevProps.dataset) {
-      this.populate(this.props)
+      this.populate(this.props);
     }
   }
 


### PR DESCRIPTION
## Background
This PR is the continuation of the issue https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/971 - Subset panel does not update when dataset is changed within the area window. The previous PR # 971 only resolved the issue with subset variable update with the dataset changed. The present PR resolved the issue with timestamp update with the dataset changed.

 ## Why did you take this approach?
The Time Stamp variable "Start Time (UTC)"  and "End Time (UTC)" in the subset panel not updating with the change of dataset and update of subset variables. The date and time was showing NAN and time selector calendar was remain unchanged (default Giops_Day time range). Please see below some of the screen shots of this issue:
![Capture2](https://user-images.githubusercontent.com/80789651/176547775-eb37fcad-a547-4bd8-be38-cdddd451b323.PNG)
![Capture3](https://user-images.githubusercontent.com/80789651/176547780-e06acb81-a7f1-49f9-8f55-e201a2be361b.PNG)
![Capture4](https://user-images.githubusercontent.com/80789651/176547782-cc1dc7ba-bf19-4aac-8042-cfe34e0b59cf.PNG)

## Anything in particular that should be highlighted?
- Create a separate component of SubsetPanel.jsx and import it in the AreaWindow.jsx component
- The TimePicker.jsx component needed a componentDidUpdate method to query the timestamps for new datasets. 

## Screenshot(s)

![Capture1](https://user-images.githubusercontent.com/80789651/176543924-393a177a-53f3-4a9b-856a-1bf61962dc13.PNG)

## Checks
- [y ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
