### PR TITLE
Quiver variable restriction on model class

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -36,6 +36,8 @@ const PARENT_ATTRIBUTES_TO_UPDATE = Object.freeze([
   "quiverVariable",
 ]);
 
+const MODEL_CLASSES_WITH_QUIVER = Object.freeze(["Mercator"]);
+
 class DatasetSelector extends React.Component {
   constructor(props) {
     super(props);
@@ -75,6 +77,7 @@ class DatasetSelector extends React.Component {
     });
 
     const quantum = currentDataset.quantum;
+    const model_class= currentDataset.model_class;
 
     GetVariablesPromise(newDataset).then(variableResult => {
       this.setState({ loadingPercent: 33 });
@@ -122,7 +125,7 @@ class DatasetSelector extends React.Component {
             loadingPercent: 0,
 
             dataset: newDataset,
-
+            model_class: model_class,
             quantum: quantum,
 
             datasetVariables: variableResult.data,
@@ -370,7 +373,7 @@ class DatasetSelector extends React.Component {
     let quiverSelector = null;
     if (this.props.showQuiverSelector && !this.state.loading) {
       let quiverVariables = [];
-      if (this.state.datasetVariables) {
+      if (this.state.datasetVariables && MODEL_CLASSES_WITH_QUIVER.includes(this.state.model_class)) {
         quiverVariables = this.state.datasetVariables.filter((variable) => {
           return variable.id.includes("mag") && variable.id.includes("vel");
         });

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -77,7 +77,7 @@ class DatasetSelector extends React.Component {
     });
 
     const quantum = currentDataset.quantum;
-    const model_class= currentDataset.model_class;
+    const model_class = currentDataset.model_class;
 
     GetVariablesPromise(newDataset).then(variableResult => {
       this.setState({ loadingPercent: 33 });

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -221,6 +221,7 @@ def datasets_query_v1_0():
                     "quantum": config.quantum,
                     "help": config.help,
                     "attribution": config.attribution,
+                    "model_class": config.model_class,
                 }
             )
     data = sorted(data, key=lambda k: k["value"])


### PR DESCRIPTION
## Background
The current Ocean navigator UI, the Quiver variable plot option is only working for "Mercator" model class type dataset. For example : 
"giops_day": {
"name": "01. GIOPS 10 day Forecast 3D - LatLon",
"model_class": "Mercator"
}
or 
"cmems-global-analysis-forecast-phy-001-024_hourly": {
        "name": "15. CMEMS Global Ocean PHYS Analysis (Hourly) 1/12 deg",
        "model_class": "Mercator
"}
There will be ongoing work in the future so that Quiver plot can work with the other model class Like "Nemo" or "fvcom" type dataset, example: 
"riops_fc_3dps": {
        "name": "06. RIOPS Forecast 3D - Polar Stereographic",
        "model_class": "Nemo"
}

## Why did you take this approach?
For the end user, it is essential to hide and restrict the selection of the quiver variables for non  "Mercator" type model class to avoid 500 (INTERNAL SERVER ERROR).  The screen shots are below:
![Capture6](https://user-images.githubusercontent.com/80789651/176599265-cf46850d-708b-4349-91d1-0431ee47b3ba.PNG)

![Capture3](https://user-images.githubusercontent.com/80789651/176599243-bd578279-1062-4164-a991-173d03d8d65e.PNG)

For the  "Mercator" type model class Quiver variable selection and plotting is working as before. The restriction is only implemented in the front end [DatasetSelector.jsx](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/compare/Quiver-variable-restriction-on-model-class?expand=1#diff-9a106321bb811a2c2f7cf5ca0934f1335595c9be3985610f880eec92e61a08fa) file and can be easily modified when other model class dataset (like "Nemo" or "fvcom") will be working. 

## Anything in particular that should be highlighted?
Below is the screen shot when user select "Nemo" model class type dataset "06. RIOPS Forecast 3D - Polar Stereographic".  The user not able to see any Quiver Variables to plot. 
![Capture9](https://user-images.githubusercontent.com/80789651/176599832-8c125108-bdd5-4e27-91e1-5572ff94095a.PNG)

## Screenshot(s)

![Capture](https://user-images.githubusercontent.com/80789651/176596944-8f682fef-9cbe-48ee-831f-8ffb8e0be902.PNG)

## Checks
- [Yes ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
