### PR TITLE
Add "bearing component" in "magwatervel" variable component for multiple quiver variable options in UI

### DIFF
--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -78,6 +78,8 @@ def data_array_to_geojson(
         props = {**attribs, "data": elem.item()}
 
         if bearings is not None:
+            if np.isnan(bearings[multi_idx].item()):
+                continue
             props["bearing"] = bearings[multi_idx].item()
 
         features.append(Feature(geometry=p, properties=props))

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -438,7 +438,7 @@ class VectorVariableConfig(VariableConfig):
             north_vector_component = None
 
         return north_vector_component
-    
+
     @property
     def bearing_component(self) -> str:
         """

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -438,3 +438,18 @@ class VectorVariableConfig(VariableConfig):
             north_vector_component = None
 
         return north_vector_component
+    
+    @property
+    def bearing_component(self) -> str:
+        """
+        Returns the bearing_component for the variable
+        if defined in dataset config file
+        Returns:
+            str -- bearing_component name
+        """
+        try:
+            bearing_component = self.__get_attribute("bearing_component")
+        except KeyError:
+            bearing_component = None
+
+        return bearing_component

--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -469,10 +469,11 @@ def get_data_v1_0():
 
         bearings = None
         if "mag" in result["variable"]:
+            bearings_var = config.variable[result["variable"]].bearing_component or "bearing"   
             with open_dataset(
-                config, variable="bearing", timestamp=result["time"]
+                config, variable=bearings_var, timestamp=result["time"]
             ) as ds_bearing:
-                bearings = ds_bearing.nc_data.get_dataset_variable("bearing")[
+                bearings = ds_bearing.nc_data.get_dataset_variable(bearings_var)[
                     data_slice
                 ].squeeze(drop=True)
 


### PR DESCRIPTION
## Background
This PR added a new feature in the quiver selection for the end user. The user now able to plot multiple quiver variables (one at a time) from the quiver selection menu. The current available quiver variables to plot are:
1. "Water Velocity" ("magwatervel") 
2. "Sea Ice Velocity" ("magicevel")
There was only one variable which is "Water Velocity" ("magwatervel") was available to plot in the quiver variable selection option. This PR made the option available to add more quiver variables if required for the end user.

#Changes Made in the Config File:
- In the datasetconfig.json file ([Add "bearing_component" in "magwatervel" variable component for multiple quiver variable options in UI #38](https://github.com/DFO-Ocean-Navigator/configurations/pull/38)), a component name "bearing_component" was added in the "magwatervel" variable. 

## Anything in particular that should be highlighted?
This PR is linked with Add "bearing_component" in "magwatervel" variable component for multiple quiver variable options in UI #38. The datasetconfig.json file modification mention in [Add "bearing_component" in "magwatervel" variable component for multiple quiver variable options in UI #38](https://github.com/DFO-Ocean-Navigator/configurations/pull/38) is required to see multiple quiver variables in the UI.

## Screenshot(s)
Multiple Quiver variable selection  options in ocean Navigator UI:
![Capture22222](https://user-images.githubusercontent.com/80789651/176732835-8041cf15-1b53-43ff-8031-1c592174b34b.PNG)

## Checks
- [x] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
