### PR TITLE
Fix transect plotting from entered coordinates

### DIFF
--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -96,7 +96,7 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
         maxlat = 90
 
     plot_projection = ccrs.Mercator(
-        central_longitude=np.median(points[1, :]),
+        central_longitude=np.mean([minlon, maxlon]),
         min_latitude=minlat,
         max_latitude=maxlat,
     )

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -96,14 +96,16 @@ def _map_plot(points, grid_loc, path=True, quiver=True):
         maxlat = 90
 
     plot_projection = ccrs.Mercator(
-        central_longitude=np.mean(points[1, :]),
+        central_longitude=np.median(points[1, :]),
         min_latitude=minlat,
         max_latitude=maxlat,
     )
     pc_projection = ccrs.PlateCarree()
 
+    extent = [minlon, maxlon, minlat, maxlat]
+
     m = plt.subplot(grid_loc, projection=plot_projection)
-    m.set_extent([minlon, maxlon, minlat, maxlat])
+    m.set_extent(extent)
     m.coastlines()
 
     if path:


### PR DESCRIPTION
## Background
It appears that users have not been able to produce a transect plot from entered coordinates since we migrated to Cartopy. The issue stems from defining the map portion of the transect plot. Initially we calculated the central longitude of the map by taking the mean of the longitude portion of transect coordinates. However, this did not select the exact centre of the line/resulting plot area and resulted in Cartopy trying to draw outside the map boundaries. If we just calculate the mean using the max/min longitudes instead we get a better approximation of the map's central longitude and Cartopy is able to draw all the necessary features within the map boundary.

## Why did you take this approach?
By only using the latitude's extremities we can centre the map plot more accurately with less work. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
