### PR TITLE
Ensure plot contains data before calculating stats

### DIFF
--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -395,13 +395,15 @@ class Plotter(metaclass=ABCMeta):
         return self.dataset_config.variable[v].unit
 
     def get_stats_str(self, data, unit) -> str:
-        stats = (
-            f"Min: {np.nanmin(data):.2f}, "
-            f"Max: {np.nanmax(data):.2f}, "
-            f"Mean: {np.nanmean(data):.2f}, "
-            f"STD: {np.nanstd(data):.2f} ({unit})"
-        )
-        return stats
+        if data.any():
+            return (
+                f"Min: {np.nanmin(data):.2f}, "
+                f"Max: {np.nanmax(data):.2f}, "
+                f"Mean: {np.nanmean(data):.2f}, "
+                f"STD: {np.nanstd(data):.2f} ({unit})"
+            )
+        else:
+            return ""
 
     def clip_value(self, input_value, variable):
         output = input_value


### PR DESCRIPTION
## Background
Some plots are failing during the stats calculation because the selected point/line/area and variable combination contains no data. Generally this only occurs when a user selects and AOI over land but in some scenarios this may prevent a valid plot from being produced. For example, if a user selects multiple variables and one of them is empty for the AOI. This should result in the affected variable plot returning without data but currently causes the query to fail. We just need a simple check to ensure that the plot contains valid data before trying to produce statistics for the plot

## Why did you take this approach?
Checking if the data is empty ensures that the stats calculation will succeed.  If the plot data is empty then the `get_stats_str` function will return an empty string. Something like this should of been added during the initial implementation. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black`.
