### PR TITLE
API Script R Subset Implementation- The Process Of FastAPI Migration

### DIFF
--- a/plotting/scriptGenerator.py
+++ b/plotting/scriptGenerator.py
@@ -56,8 +56,6 @@ def generateR(url, scriptType: str) -> BytesIO:
 
         if scriptType == "PLOT":
             template = template.format(q=query, var=var)
-        elif scriptType == "SUBSET":
-            template = template.format(q=query, init='{', end='}')
         else:
             template = template.format(q=query)
 

--- a/plotting/scriptGenerator.py
+++ b/plotting/scriptGenerator.py
@@ -56,6 +56,8 @@ def generateR(url, scriptType: str) -> BytesIO:
 
         if scriptType == "PLOT":
             template = template.format(q=query, var=var)
+        elif scriptType == "SUBSET":
+            template = template.format(q=query, init='{', end='}')
         else:
             template = template.format(q=query)
 

--- a/plotting/templates/rSUBSETtemplate.txt
+++ b/plotting/templates/rSUBSETtemplate.txt
@@ -10,7 +10,7 @@ url <- base_url
 
 for (key in names(queryObj))
 {{
- url <- paste(url,"&", key, "=", queryObj[key], sep="")
+   url <- paste(url, "&", key, "=", queryObj[key], sep="")
 }}
 
 url  <- gsub(",[\r\n]", "", url)

--- a/plotting/templates/rSUBSETtemplate.txt
+++ b/plotting/templates/rSUBSETtemplate.txt
@@ -3,7 +3,7 @@ library(jsonlite)
 query <- '{q}'
 
 queryObj <- fromJSON(query)
-fname <- "script_output",".nc"
+fname <- "script_output.nc"
 
 base_url <- "http://navigator.oceansdata.ca/api/v1.0/subset/?"
 url <- base_url

--- a/plotting/templates/rSUBSETtemplate.txt
+++ b/plotting/templates/rSUBSETtemplate.txt
@@ -1,0 +1,17 @@
+library(jsonlite)
+
+query <- '{q}'
+queryObj <- fromJSON(query)
+fname <- paste("script_output",".nc")
+base_url = "http://navigator.oceansdata.ca/api/v1.0/subset/?"
+url <- base_url
+for (key in names(queryObj))
+{init}
+ url <- paste(url,"&", key, "=", queryObj[key], sep="")
+{end}
+
+url  = gsub(",[\r\n]", "", url)
+print(url)
+
+print(paste("Downloading file in location ",getwd(), " and exiting..."))
+download.file(url, fname, method="auto", mode="wb")

--- a/plotting/templates/rSUBSETtemplate.txt
+++ b/plotting/templates/rSUBSETtemplate.txt
@@ -1,16 +1,19 @@
 library(jsonlite)
 
 query <- '{q}'
-queryObj <- fromJSON(query)
-fname <- paste("script_output",".nc")
-base_url = "http://navigator.oceansdata.ca/api/v1.0/subset/?"
-url <- base_url
-for (key in names(queryObj))
-{init}
- url <- paste(url,"&", key, "=", queryObj[key], sep="")
-{end}
 
-url  = gsub(",[\r\n]", "", url)
+queryObj <- fromJSON(query)
+fname <- "script_output",".nc"
+
+base_url <- "http://navigator.oceansdata.ca/api/v1.0/subset/?"
+url <- base_url
+
+for (key in names(queryObj))
+{{
+ url <- paste(url,"&", key, "=", queryObj[key], sep="")
+}}
+
+url  <- gsub(",[\r\n]", "", url)
 print(url)
 
 print(paste("Downloading file in location ",getwd(), " and exiting..."))


### PR DESCRIPTION
## Background
The API R Script for downloading subset variables time series .nc data  was not implemented in the present Ocean navigator UI. This PR added the rSUBSETtemplate.txt for R template to download subset variables .nc data.


## Why did you take this approach?
The client requested to implement the API R script fo subset variables. 

## Anything in particular that should be highlighted?


## Screenshot(s)
![Capture](https://user-images.githubusercontent.com/80789651/182075940-2f47e523-fd88-4b13-b7d3-5f94762f9bbf.PNG)

## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
