### PR TITLE
Limit the date ranges of class4 calendars

### DIFF
--- a/kml
+++ b/kml
@@ -1,1 +1,1 @@
-/data/kml
+E:/data/kml

--- a/oceannavigator/frontend/package.json
+++ b/oceannavigator/frontend/package.json
@@ -29,7 +29,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "glob-parent": "^5.1.2",
     "jquery": "~3.5.0",
-    "jquery-ui": "^1.13.2",
+    "jquery-ui": "^1.12.1",
     "jquery-ui-month-picker": "kidsysco/jquery-ui-month-picker",
     "ol": "^6.6.1",
     "papaparse": "^5.2.0",

--- a/oceannavigator/frontend/src/components/MapToolbar.jsx
+++ b/oceannavigator/frontend/src/components/MapToolbar.jsx
@@ -81,16 +81,22 @@ class MapToolbar extends React.Component {
     let button = null;
     let div = null;
     let class4Files = null;
+    let minDate = null;
+    let maxDate = null;
     switch (type){
       case "ocean_predict":
         button = $(ReactDOM.findDOMNode(this.class4OPButton));
         div = this.class4OpDiv;
         class4Files = this.state.class4OPFiles
+        minDate = new Date(2019, 1, 1) 
+        maxDate = new Date(2022, 1, 27)
         break;
       case "riops_obs":
         button = $(ReactDOM.findDOMNode(this.class4RAOButton));
         div = this.class4RAODiv;
         class4Files = this.state.class4RAOFiles
+        minDate = new Date(2022, 1, 1)
+        maxDate = new Date(2022, 4, 30)
         break;
     }
     this.class4Picker = $(div).datepicker({
@@ -100,7 +106,8 @@ class MapToolbar extends React.Component {
       onSelect: function(text, picker) {
         this.props.action("show", "class4", class4Files[text], type);
       }.bind(this),
-      defaultDate: this.state.class4Current,
+      minDate: minDate,
+      maxDate: maxDate
     }); 
     $(div).css("left", button.offset() + "px");
     this.forceUpdate();

--- a/oceannavigator/frontend/src/components/MapToolbar.jsx
+++ b/oceannavigator/frontend/src/components/MapToolbar.jsx
@@ -87,16 +87,16 @@ class MapToolbar extends React.Component {
       case "ocean_predict":
         button = $(ReactDOM.findDOMNode(this.class4OPButton));
         div = this.class4OpDiv;
-        class4Files = this.state.class4OPFiles
-        minDate = new Date(2019, 1, 1) 
-        maxDate = new Date(2022, 1, 27)
+        class4Files = this.state.class4OPFiles;
+        minDate = new Date(2019, 1, 1); 
+        maxDate = new Date(2022, 1, 27);
         break;
       case "riops_obs":
         button = $(ReactDOM.findDOMNode(this.class4RAOButton));
         div = this.class4RAODiv;
-        class4Files = this.state.class4RAOFiles
-        minDate = new Date(2022, 1, 1)
-        maxDate = new Date(2022, 4, 30)
+        class4Files = this.state.class4RAOFiles;
+        minDate = new Date(2022, 1, 1);
+        maxDate = new Date(2022, 4, 30);
         break;
     }
     this.class4Picker = $(div).datepicker({
@@ -118,9 +118,9 @@ class MapToolbar extends React.Component {
     const formatted = $.datepicker.formatDate("yy-mm-dd", d);
     var date = null;
     if (type == 'ocean_predict') {
-      date = this.state.class4OPFiles.hasOwnProperty(formatted)
+      date = this.state.class4OPFiles.hasOwnProperty(formatted);
     } else {
-      date = this.state.class4RAOFiles.hasOwnProperty(formatted)
+      date = this.state.class4RAOFiles.hasOwnProperty(formatted);
     }
     return [date, "", null];
   }

--- a/oceannavigator/frontend/yarn.lock
+++ b/oceannavigator/frontend/yarn.lock
@@ -2897,17 +2897,10 @@ jquery-ui-month-picker@kidsysco/jquery-ui-month-picker:
   version "3.0.4"
   resolved "https://codeload.github.com/kidsysco/jquery-ui-month-picker/tar.gz/6bf5fcb6a38b07206162383468283e68d3e10e97"
 
-jquery-ui@^1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.2.tgz#de03580ae6604773602f8d786ad1abfb75232034"
-  integrity sha512-wBZPnqWs5GaYJmo1Jj0k/mrSkzdQzKDwhXNtHKcBdAcKVxMM3KNYFq+iJ2i1rwiG53Z8M4mTn3Qxrm17uH1D4Q==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
-
-"jquery@>=1.8.0 <4.0.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+jquery-ui@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
 jquery@~3.5.0:
   version "3.5.1"


### PR DESCRIPTION
## Background

Users can currently scroll through the class4 calendars indefinitely. Since we have a limited range of class 4 data available, date ranges limits were added to prevent users from scrolling past the available data. The ranges are:
Ocean Predict
 - Jan 2019 - Feb 2022
 
RIOPS Assimilated Observations
 - Feb 2022  - May 2022

## Why did you take this approach?
The jQuery datepicker provides arguments to specify max and min dates, we just need to provide date ranges.

## Anything in particular that should be highlighted?
The max date limit will be removed once new Class4 data becomes available.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
