### PR TITLE
Remove Basemap MaskOcean from UI

### DIFF
--- a/config/conda/environment.yml
+++ b/config/conda/environment.yml
@@ -9,8 +9,6 @@ dependencies:
   - appdirs=1.4.4=pyh9f0ad1d_0
   - asciitree=0.3.3=py_2
   - babel=2.9.1=pyh44b312d_0
-  - basemap=1.2.2=py38hc951a7f_4
-  - basemap-data-hires=1.2.2=0
   - black=22.1.0=pyhd8ed1ab_0
   - blinker=1.4=py_1
   - blosc=1.21.0=h9c3ff4c_0

--- a/config/conda/navigator-spec-file.txt
+++ b/config/conda/navigator-spec-file.txt
@@ -273,7 +273,6 @@ https://conda.anaconda.org/conda-forge/noarch/starlette-0.19.1-pyhd8ed1ab_0.tar.
 https://conda.anaconda.org/conda-forge/noarch/tifffile-2021.11.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.20.1-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/zarr-2.10.3-pyhd8ed1ab_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/basemap-1.2.2-py38hc951a7f_4.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.20.0-py38hc951a7f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/cmocean-2.0-py_3.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/dask-2021.11.2-pyhd8ed1ab_0.tar.bz2
@@ -286,7 +285,6 @@ https://conda.anaconda.org/conda-forge/noarch/networkx-2.7-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/opentelemetry-instrumentation-0.31b0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.12.3-py38h578d9bd_8.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.8-pyhd8ed1ab_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/basemap-data-hires-1.2.2-0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.5.0-py38h578d9bd_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/opentelemetry-instrumentation-asgi-0.31b0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/requests-2.26.0-pyhd8ed1ab_1.tar.bz2

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -11,7 +11,6 @@ from flask_babel import gettext
 from matplotlib.colors import FuncNorm
 from matplotlib.patches import PathPatch, Polygon
 from matplotlib.path import Path
-from mpl_toolkits.basemap import maskoceans
 from osgeo import gdal, osr
 from shapely.geometry import LinearRing, MultiPolygon, Point
 from shapely.geometry import Polygon as Poly
@@ -435,17 +434,6 @@ class MapPlotter(Plotter):
                 d[np.where(quiver_bathymetry < depth_value)] = np.ma.masked
             for d in self.contour_data:
                 d[np.where(self.bathymetry < depth_value_map)] = np.ma.masked
-        else:
-            mask = maskoceans(
-                self.longitude, self.latitude, self.data, True, "h", 1.25
-            ).mask
-            self.data[~mask] = np.ma.masked
-            for d in self.quiver_data:
-                mask = maskoceans(self.quiver_longitude, self.quiver_latitude, d).mask
-                d[~mask] = np.ma.masked
-            for d in contour_data:
-                mask = maskoceans(self.longitude, self.latitude, d).mask
-                d[~mask] = np.ma.masked
 
         if self.area and self.filetype in ["csv", "odv", "txt", "geotiff"]:
             area_polys = []


### PR DESCRIPTION
## Background
The basemap maskocean function is redundant in map.py file when plotting any selected area.  The maskocean of Add Arrow Function or add Additional Contour Plot option in the plot area also redundant. 

## Why did you take this approach?
In the process of FastAPI migration cleanup we need to remove or replace basemap import because it was causing issue when we were trying to update Python Version to 3.10.

## Anything in particular that should be highlighted?
Basemap is deprecated in favor of the [Cartopy project](http://scitools.org.uk/cartopy/). We are replacing basemap with cartopy 
when possible.
## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
