### PR TITLE
Rename Old Selecbox React Component->CheckBox and Move >lib folder

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -10,7 +10,7 @@ import {Nav, NavItem, Panel, Row,  Col, Button} from "react-bootstrap";
 import PlotImage from "./PlotImage.jsx";
 import ComboBox from "./ComboBox.jsx";
 import Range from "./Range.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import ContourSelector from "./ContourSelector.jsx";
 import QuiverSelector from "./QuiverSelector.jsx";
 import StatsTable from "./StatsTable.jsx";
@@ -186,10 +186,10 @@ class AreaWindow extends React.Component {
         <Panel.Body>
           <Row>
             <Col xs={9}> 
-              <SelectBox
+              <CheckBox
                 id='dataset_compare'
                 key='dataset_compare'
-                state={this.state.dataset_compare}
+                checked={this.state.dataset_compare}
                 onUpdate={(_, checked) => { this.setState({dataset_compare: checked}); }}
                 title={_("Compare Datasets")}
               />
@@ -244,23 +244,23 @@ class AreaWindow extends React.Component {
           </div>
           {/* End of Compare Datasets options */}
 
-          <SelectBox 
+          <CheckBox 
             key='bathymetry' 
             id='bathymetry' 
-            state={this.state.bathymetry} 
+            checked={this.state.bathymetry} 
             onUpdate={this.onLocalUpdate} 
             title={_("Show Bathymetry Contours")}
           />
 
-          <SelectBox 
+          <CheckBox 
             key='showarea' 
             id='showarea' 
-            state={this.state.showarea} 
+            checked={this.state.showarea} 
             onUpdate={this.onLocalUpdate} 
             title={_("Show Selected Area(s)")}
           >
             {_("showarea_help")}
-          </SelectBox>
+          </CheckBox>
 
           {/* Arror Selector Drop Down menu */}
           <QuiverSelector 

--- a/oceannavigator/frontend/src/components/Class4Window.jsx
+++ b/oceannavigator/frontend/src/components/Class4Window.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Panel, Row, Col} from "react-bootstrap";
 import PlotImage from "./PlotImage.jsx";
 import ComboBox from "./ComboBox.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import ImageSize from "./ImageSize.jsx";
 import Accordion from "./lib/Accordion.jsx";
 import PropTypes from "prop-types";
@@ -123,18 +123,18 @@ class Class4Window extends React.Component {
                     title={_("Forecast")}
                     onUpdate={this.onLocalUpdate}
                   />
-                  <SelectBox
+                  <CheckBox
                     key='showmap'
                     id='showmap'
-                    state={this.state.showmap}
+                    checked={this.state.showmap}
                     onUpdate={this.onLocalUpdate}
-                    title={_("Show Location")}>{_("showmap_help")}</SelectBox>
-                  <SelectBox
+                    title={_("Show Location")}>{_("showmap_help")}</CheckBox>
+                  <CheckBox
                     key='climatology'
                     id='climatology'
-                    state={this.state.climatology}
+                    checked={this.state.climatology}
                     onUpdate={this.onLocalUpdate}
-                    title={_("Show Climatology")}>{_("climatology_help")}</SelectBox>
+                    title={_("Show Climatology")}>{_("climatology_help")}</CheckBox>
                   <ComboBox
                     key='models'
                     id='models'

--- a/oceannavigator/frontend/src/components/ContourSelector.jsx
+++ b/oceannavigator/frontend/src/components/ContourSelector.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ComboBox from "./ComboBox.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
@@ -68,13 +68,13 @@ class ContourSelector extends React.Component {
       <div className='ContourSelector input'>
         <ComboBox id='variable' state={this.props.state.variable} def='' onUpdate={this.onUpdate} url={"/api/v1.0/variables/?dataset=" + this.props.dataset} title={this.props.title}>{this.props.children}</ComboBox>
         <div className='sub' style={{"display": (this.props.state.variable == "none" || this.props.state.variable == "") ? "none" : "block"}}>
-          <SelectBox key='hatch' id='hatch' state={this.props.state.hatch} onUpdate={this.onUpdate} title={_("Crosshatch")}></SelectBox>
+          <CheckBox key='hatch' id='hatch' checked={this.props.state.hatch} onUpdate={this.onUpdate} title={_("Crosshatch")}></CheckBox>
           <div style={{"display": this.props.state.hatch ? "none" : "block"}}>
             <ComboBox key='colormap' id='colormap' state={this.props.state.colormap} def='' onUpdate={this.onUpdate} url='/api/v1.0/colormaps/' title={_("Colourmap")}>There are several colourmaps available. This tool tries to pick an appropriate default based on the variable type (Default For Variable). If you want to use any of the others, they are all selectable.<img src="/colormaps.png" /></ComboBox>
           </div>
-          <SelectBox key='legend' id='legend' state={this.props.state.legend} onUpdate={this.onUpdate} title={_("Show Legend")}></SelectBox>
+          <CheckBox key='legend' id='legend' checked={this.props.state.legend} onUpdate={this.onUpdate} title={_("Show Legend")}></CheckBox>
           <h1>{_("Levels")}</h1>
-          <SelectBox key='autolevels' id='autolevels' state={auto} onUpdate={this.onUpdateAuto} title={_("Auto Levels")}></SelectBox>
+          <CheckBox key='autolevels' id='autolevels' checked={auto} onUpdate={this.onUpdateAuto} title={_("Auto Levels")}></CheckBox>
           <input type="text" style={{"display": this.state.autolevels ? "none" : "inline-block"}} value={this.state.levels} onChange={this.levelsChanged} onBlur={this.updateLevels} />
         </div>
       </div>

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -9,7 +9,7 @@ import {Nav, NavItem, Panel, Row, Col, Button} from "react-bootstrap";
 import PlotImage from "./PlotImage.jsx";
 import ComboBox from "./ComboBox.jsx";
 import Range from "./Range.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import NumberBox from "./NumberBox.jsx";
 import ImageSize from "./ImageSize.jsx";
 import DepthLimit from "./DepthLimit.jsx";
@@ -169,10 +169,10 @@ class LineWindow extends React.Component {
         <Panel.Body>
           <Row>
             <Col xs={9}>
-              <SelectBox
+              <CheckBox
                 id='dataset_compare'
                 key='dataset_compare'
-                state={this.props.dataset_compare}
+                checked={this.props.dataset_compare}
                 onUpdate={this.props.onUpdate}
                 title={_("Compare Datasets")}
               />
@@ -215,15 +215,15 @@ class LineWindow extends React.Component {
             />
           </div>
 
-          <SelectBox
+          <CheckBox
             key='showmap'
             id='showmap'
-            state={this.state.showmap}
+            checked={this.state.showmap}
             onUpdate={this.onLocalUpdate}
             title={_("Show Map Location")}
           >
             {_("showmap_help")}
-          </SelectBox>
+          </CheckBox>
             
           <Accordion id='line_accordion' title={"Plot Options"} content={plotOptions} />
         </Panel.Body>

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -6,7 +6,7 @@
 
 import React from "react";
 import ComboBox from "./ComboBox.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import DatasetSelector from "./DatasetSelector.jsx";
 import {Panel, Button, Row, Col, Tabs, Tab} from "react-bootstrap";
 import Icon from "./lib/Icon.jsx";
@@ -106,9 +106,9 @@ class MapInputs extends React.Component {
                 <Panel.Body>
                   <Row>
                     <Col xs={9}>
-                      <SelectBox
+                      <CheckBox
                         id='dataset_compare'
-                        state={this.props.dataset_compare}
+                        checked={this.props.dataset_compare}
                         onUpdate={this.props.changeHandler}
                         title={_("Compare Datasets")}
                       />
@@ -124,7 +124,7 @@ class MapInputs extends React.Component {
                       </Button>
                     </Col>
                   </Row>
-                  <SelectBox
+                  <CheckBox
                     id='syncRanges'
                     onUpdate={this.props.changeHandler}
                     title={_("Sync Variable Ranges")}

--- a/oceannavigator/frontend/src/components/Options.jsx
+++ b/oceannavigator/frontend/src/components/Options.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Row, FormControl, ControlLabel, Col, Panel, Button } from "react-bootstrap";
 import NumericInput from "react-numeric-input";
 import Icon from "./lib/Icon.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
@@ -112,9 +112,9 @@ class Options extends React.Component {
             <Panel.Body>
               <Row>
                 <Col md={12}>
-                  <SelectBox
+                  <CheckBox
                     id='bathymetry'
-                    state={this.state.bathymetry}
+                    checked={this.state.bathymetry}
                     onUpdate={(e, val) => { this.setState({ "bathymetry": val, }); }}
                     title={_("Show Bathymetry Contours")}
                   />
@@ -151,9 +151,9 @@ class Options extends React.Component {
               </Row>
               <Row>
                 <Col md={12}>
-                  <SelectBox
+                  <CheckBox
                     id='topoShadedRelief'
-                    state={this.state.topoShadedRelief}
+                    checked={this.state.topoShadedRelief}
                     onUpdate={(e, val) => { this.setState({ "topoShadedRelief": val, }); }}
                     title={_("Topography Shaded Relief")}
                   />

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -9,7 +9,7 @@
 import React from "react";
 import {Nav, NavItem, Panel, Row, Col} from "react-bootstrap";
 import PlotImage from "./PlotImage.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import ComboBox from "./ComboBox.jsx";
 import LocationInput from "./LocationInput.jsx";
 import ImageSize from "./ImageSize.jsx";
@@ -236,15 +236,15 @@ class PointWindow extends React.Component {
             mountedVariable={this.props.dataset_0.variable}
           />
 
-          <SelectBox
+          <CheckBox
             key='showmap'
             id='showmap'
-            state={this.state.showmap}
+            checked={this.state.showmap}
             onUpdate={this.onLocalUpdate}
             title={_("Show Location")}
           >
             {_("showmap_help")}
-          </SelectBox>
+          </CheckBox>
 
           <div style={{display: this.props.point.length == 1 ? "block" : "none",}}>
             <LocationInput

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Panel, Button, FormControl, FormGroup, ControlLabel, DropdownButton, MenuItem} from "react-bootstrap";
 import ComboBox from "./ComboBox.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import TimePicker from "./TimePicker.jsx";
 import PropTypes from "prop-types";
 import Icon from "./lib/Icon.jsx";
@@ -153,10 +153,10 @@ render() {
           data={this.state.subset_variables}            
           title={("Variables")}
         />
-        <SelectBox
+        <CheckBox
           id='time_range'
           key='time_range'
-          state={this.state.output_timerange}
+          checked={this.state.output_timerange}
           onUpdate={(_, value) => {this.setState({output_timerange: value,});}}
           title={_("Select Time Range")}
         />
@@ -205,10 +205,10 @@ render() {
             <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
           </FormControl>
         </FormGroup>
-        <SelectBox 
+        <CheckBox 
           id='zip'
           key='zip'
-          state={this.state.zip} 
+          checked={this.state.zip} 
           onUpdate={ (_, checked) => { this.setState({zip: checked}); } }
           title={_("Compress as *.zip")}
         />

--- a/oceannavigator/frontend/src/components/TrackWindow.jsx
+++ b/oceannavigator/frontend/src/components/TrackWindow.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PlotImage from "./PlotImage.jsx";
 import ComboBox from "./ComboBox.jsx";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import ContinousTimePicker from "./ContinousTimePicker.jsx";
 import ImageSize from "./ImageSize.jsx";
 import Accordion from "./lib/Accordion.jsx";
@@ -127,20 +127,20 @@ class TrackWindow extends React.Component {
       url={"/api/v1.0/variables/?dataset="+this.props.dataset}
       title={_("Variable")}
     ><h1>Variable</h1></ComboBox>;
-    var showmap = <SelectBox
+    var showmap = <CheckBox
       key='showmap'
       id='showmap'
-      state={this.state.showmap}
+      checked={this.state.showmap}
       onUpdate={this.onLocalUpdate}
       title={_("Show Map")}
-    >{_("showmap_help")}</SelectBox>;
-    var latlon = <SelectBox
+    >{_("showmap_help")}</CheckBox>;
+    var latlon = <CheckBox
       key='latlon'
       id='latlon'
-      state={this.state.latlon}
+      checked={this.state.latlon}
       onUpdate={this.onLocalUpdate}
       title={_("Show Latitude/Longitude Plots")}
-    >{_("latlon_help")}</SelectBox>;
+    >{_("latlon_help")}</CheckBox>;
     var starttime = <ContinousTimePicker
       key='starttime'
       id='starttime'

--- a/oceannavigator/frontend/src/components/VelocitySelector.jsx
+++ b/oceannavigator/frontend/src/components/VelocitySelector.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import SelectBox from "./SelectBox.jsx";
+import CheckBox from "./lib/CheckBox.jsx";
 import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
@@ -41,35 +41,35 @@ class VelocitySelector extends React.Component {
 
     return (
       <div>
-        <SelectBox
+        <CheckBox
           key='magnitude'
-          state={this.state.velocity_plots[PlotTypes["magnitude"]]}
+          checked={this.state.velocity_plots[PlotTypes["magnitude"]]}
           id='magnitude'
           onUpdate={this.updatePlotType}
           title={_("Magnitude")}
         >
           {_("show_magnitude")}
-        </SelectBox>  
+        </CheckBox>  
 
-        <SelectBox
+        <CheckBox
           key='parallel'
-          state={this.state.velocity_plots[PlotTypes["parallel"]]}
+          checked={this.state.velocity_plots[PlotTypes["parallel"]]}
           id='parallel'
           onUpdate={this.updatePlotType}
           title={_("Parallel")}
         >
           {_("show_parallel")}
-        </SelectBox>
+        </CheckBox>
         
-        <SelectBox
+        <CheckBox
           key='perpendicular'
-          state={this.state.velocity_plots[PlotTypes["perpendicular"]]}
+          checked={this.state.velocity_plots[PlotTypes["perpendicular"]]}
           id='perpendicular'
           onUpdate={this.updatePlotType}
           title={_("Perpendicular")}
         >
           {_("show_perpendicular")}
-        </SelectBox>
+        </CheckBox>
       </div>
 
     );

--- a/oceannavigator/frontend/src/components/lib/CheckBox.jsx
+++ b/oceannavigator/frontend/src/components/lib/CheckBox.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Checkbox} from "react-bootstrap";
 import PropTypes from "prop-types";
 
-export default class SelectBox extends React.PureComponent {
+export default class CheckBox extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -17,9 +17,9 @@ export default class SelectBox extends React.PureComponent {
   render() {
     return (
       <Checkbox
-        id={this.props.id} 
+        id={this.props.id}
         onChange={this.handleChange}
-        checked={this.props.state}
+        checked={this.props.checked}
         style={this.props.style}
       >
         {this.props.title}
@@ -29,11 +29,10 @@ export default class SelectBox extends React.PureComponent {
 }
 
 //***********************************************************************
-SelectBox.propTypes = {
-  title: PropTypes.string,
-  state: PropTypes.bool,
-  id: PropTypes.string,
-  onUpdate: PropTypes.func,
+CheckBox.propTypes = {
+  title: PropTypes.string.isRequired,
+  checked: PropTypes.bool.isRequired,
+  id: PropTypes.string.isRequired,
+  onUpdate: PropTypes.func.isRequired,
   style: PropTypes.object,
 };
-


### PR DESCRIPTION
## Background
Rename Old Selecbox React Component to CheckBox component and Move  that component file to lib folder and made associated changes required to use that component.

## Why did you take this approach?
The use Old SelecBox was used mainly to check the parameters. So the naming was misleading. As part of FAST API migration clean up process we have decided to rename the old SelecBox to CheckBox.

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
