### PR TITLE
Disable SSL verification in python scripts

### DIFF
--- a/scripts/pregen_tiles.py
+++ b/scripts/pregen_tiles.py
@@ -11,7 +11,10 @@ parser.add_argument(
     "--url",
     type=str,
     required=True,
-    help="Root URL to Navigator instance. Ex: https://navigator.oceansdata.ca or http://10.5.166.251:5000",
+    help=(
+        "Root URL to Navigator instance. Ex: "
+        + "https://navigator.oceansdata.ca or http://10.5.166.251:5000"
+    ),
 )
 args = parser.parse_args()
 
@@ -31,6 +34,7 @@ def get_tile(
     res = requests.get(
         f"{base_url}/tiles/gaussian/25/10/EPSG:3857/{dataset}/{variable}/{time}/{depth}/{scale}/{z}/{x}/{y}.png",
         timeout=25,
+        verify=False,
     )
 
     if res.status_code != 200:
@@ -45,7 +49,11 @@ if __name__ == "__main__":
     datasets = list(
         filter(
             lambda d: "riops" in d or "giops" in d,
-            map(lambda d: d["id"], requests.get(f"{base_url}/datasets").json()),
+            map(
+                lambda d: d["id"],
+                requests.get(f"{base_url}/datasets").json(),
+                verify=False,
+            ),
         )
     )
 
@@ -53,7 +61,8 @@ if __name__ == "__main__":
         map(
             lambda t: int(t["id"]),
             requests.get(
-                f"{base_url}/timestamps/?dataset=giops_day&variable=votemper"
+                f"{base_url}/timestamps/?dataset=giops_day&variable=votemper",
+                verify=False,
             ).json(),
         )
     )

--- a/scripts/profiling_scripts/api_profiling_driver.py
+++ b/scripts/profiling_scripts/api_profiling_driver.py
@@ -72,7 +72,7 @@ class ONav_Profiling_Driver:
             logging.info(f"Attempt {i+1}:")
             start_time = time.time()
             try:
-                resp = requests.get(url, timeout=self.max_time)
+                resp = requests.get(url, timeout=self.max_time, verify=False)
                 end_time = time.time()
 
                 if resp.status_code == 200:
@@ -148,7 +148,9 @@ class ONav_Profiling_Driver:
         return self.send_req(url)
 
     def get_git_hash(self):
-        resp = requests.get(self.api_url + "git-hash", timeout=self.max_time)
+        resp = requests.get(
+            self.api_url + "gitinfo", timeout=self.max_time, verify=False
+        )
         if resp.status_code == 200:
             return json.loads(resp.content)
         return ""


### PR DESCRIPTION
## Background
Requests made using Python's requests module in pregen_tiles and other scripts have been encountering an error since SSL certs were added to the Naivgator. Setting `verify=false` will let the requests function skip SSL verification and allow the scripts to run without issue. 

## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
