### PR TITLE
Add time dim unit API endpoint or add to dataset payload

### DIFF
--- a/routes/api_v1_0.py
+++ b/routes/api_v1_0.py
@@ -67,6 +67,7 @@ from .schemas import (
     GenerateScriptSchema,
     GetDataSchema,
     QuantumSchema,
+    TimedimensionSchema,
     TimestampsSchema,
 )
 
@@ -223,12 +224,25 @@ def datasets_query_v1_0():
                     "attribution": config.attribution,
                     "model_class": config.model_class,
                     "group": config.group,
-                    "subgroup": config.subgroup
+                    "subgroup": config.subgroup,
+                    "time_dim_units": config.time_dim_units
                 }
             )
     resp = jsonify(data)
     return resp
 
+@bp_v1_0.route("/api/v1.0/timeunit/")
+def timedimension_query_v1_0():
+    try:
+        result = TimedimensionSchema().load(request.args)
+    except ValidationError as e:
+        abort(400, str(e))
+
+    config = DatasetConfig(result["dataset"])
+
+    timedimension = config.time_dim_units
+
+    return jsonify(timedimension)
 
 @bp_v1_0.route("/api/v1.0/quantum/")
 def quantum_query_v1_0():

--- a/routes/schemas/__init__.py
+++ b/routes/schemas/__init__.py
@@ -2,4 +2,5 @@ from .depth_schema import DepthSchema
 from .generate_script_schema import GenerateScriptSchema
 from .get_data_schema import GetDataSchema
 from .quantum_schema import QuantumSchema
+from .timedimension_schema import TimedimensionSchema
 from .timestamps_schema import TimestampsSchema

--- a/routes/schemas/timedimension_schema.py
+++ b/routes/schemas/timedimension_schema.py
@@ -1,0 +1,12 @@
+from marshmallow import Schema, fields
+
+
+class TimedimensionSchema(Schema):
+    """
+    Defines the schema for the `/api/v1.0/timedimension/?dataset=...`
+    endpoint.
+
+    * dataset: dataset key (e.g. giops_day)
+    """
+
+    dataset = fields.Str(required=True)

--- a/routes/schemas/timedimension_schema.py
+++ b/routes/schemas/timedimension_schema.py
@@ -10,3 +10,4 @@ class TimedimensionSchema(Schema):
     """
 
     dataset = fields.Str(required=True)
+    


### PR DESCRIPTION
## Background
Add time dim unit API endpoint.
api/v1.0/timeunit/?dataset=????
Finds "time_dim_units" associated with a dataset

Example: 
Query : http://navigator.oceansdata.ca/api/v1.0/timeunit/?dataset=giops_day
Will return time_dim_unit of "GIOPS 10 day Forecast 3D - LatLon" dataset which is "seconds since 1950-01-01 00:00:00"


## Why did you take this approach?
Client requested to implement time dimension unit API endpoint

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
