### PR TITLE
Fix 'MySQL server has gone away' error with pool recycling

### DIFF
--- a/data/observational/__init__.py
+++ b/data/observational/__init__.py
@@ -10,7 +10,8 @@ SQLALCHEMY_DATABASE_URL = settings.sqlalchemy_database_uri
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
-    connect_args={"connect_timeout": 10}
+    connect_args={"connect_timeout": 10},
+    pool_recycle=3600,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()


### PR DESCRIPTION
## Background
It looks like MySQL closes all database connections after some period of inactivity which is causing issues for the Obs functions. In the past the Flask-SQLAlchemy library had a built in mechanism to keep connections alive but since we've migrated to FastAPI we need to recycle the connection pool. See https://sentry.io/organizations/dfo-ocean-navigator/issues/3739259890/?project=5511557&query=is%3Aunresolved&referrer=issue-stream for an example of this error. 

## Why did you take this approach?
MySQL closes connections after 8 hours, by setting `pool_recycle=3600` we ensure that there's always a connection available.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
