### PR TITLE
Pull datasets from THREDDS

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -741,8 +741,8 @@ class NetCDFData(Data):
             longitude.
         """
         return (
-            self.__find_variable(["nav_lat", "latitude"]),
-            self.__find_variable(["nav_lon", "longitude"]),
+            self.__find_variable(["nav_lat", "latitude", "lat"]),
+            self.__find_variable(["nav_lon", "longitude", "lon"]),
         )
 
     @property

--- a/plotting/colormap.py
+++ b/plotting/colormap.py
@@ -69,17 +69,14 @@ colormaps = {
     "velocity": cmocean.cm.delta,
     "eastward current": cmocean.cm.delta,
     "northward current": cmocean.cm.delta,
-    "waveheight": cmocean.cm.amp,
-    "waveperiod": cmocean.cm.tempo,
+    "wave height": cmocean.cm.amp,
+    "wave period": cmocean.cm.tempo,
+    "wave direction": cmocean.cm.phase,
     "chlorophyll": cmocean.cm.algae,
     "iron": cmocean.cm.amp,
     "oxygen": cmocean.cm.oxy,
-    "phosphate": mcolors.ListedColormap(
-        np.loadtxt(data_dir.joinpath("phosphate.txt"))
-    ),
-    "nitrate": mcolors.ListedColormap(
-        np.loadtxt(data_dir.joinpath("nitrate.txt"))
-    ),
+    "phosphate": mcolors.ListedColormap(np.loadtxt(data_dir.joinpath("phosphate.txt"))),
+    "nitrate": mcolors.ListedColormap(np.loadtxt(data_dir.joinpath("nitrate.txt"))),
     "nitrate concentration": cmocean.cm.tempo,
     "ice": cmocean.cm.ice,
     "phytoplankton": cmocean.cm.deep_r,
@@ -285,9 +282,7 @@ colormaps = {
     "grey": make_colormap([_c("#ffffff"), _c("#000000")]),
     "potential sub surface channel": mcolors.ListedColormap(["#ecf0f1", "#f57732"]),
     "thermal": cmocean.cm.thermal,
-    "neo_sst": mcolors.ListedColormap(
-        np.loadtxt(data_dir.joinpath("neo_sst.txt"))
-    ),
+    "neo_sst": mcolors.ListedColormap(np.loadtxt(data_dir.joinpath("neo_sst.txt"))),
     "BuYlRd": mcolors.ListedColormap(np.loadtxt(data_dir.joinpath("BuYlRd.txt"))),
     "temperature": mcolors.ListedColormap(
         np.loadtxt(data_dir.joinpath("temperature.txt"))

--- a/plotting/tile.py
+++ b/plotting/tile.py
@@ -161,7 +161,7 @@ def scale(args):
     return buf
 
 
-def plot(projection: str, x: int, y: int, z: int, args: dict) -> BytesIO:
+async def plot(projection: str, x: int, y: int, z: int, args: dict) -> BytesIO:
     settings = get_settings()
 
     lat, lon = get_latlon_coords(projection, x, y, z)
@@ -233,11 +233,7 @@ def plot(projection: str, x: int, y: int, z: int, args: dict) -> BytesIO:
     img = sm.to_rgba(np.ma.masked_invalid(np.squeeze(data)))
     im = Image.fromarray((img * 255.0).astype(np.uint8))
 
-    buf = BytesIO()
-    im.save(buf, format="PNG", optimize=True)
-    buf.seek(0)
-
-    return buf
+    return im
 
 
 def topo(projection: str, x: int, y: int, z: int, shaded_relief: bool) -> BytesIO:

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -841,10 +841,14 @@ def timestamps(
                 vals = db.get_timestamps(data_vars[0])
             else:
                 vals = db.get_timestamps(variable)
+            time_dim_units = config.time_dim_units
     else:
         with open_dataset(config, variable=variable) as ds:
             vals = list(map(int, ds.nc_data.time_variable.values))
-    converted_vals = time_index_to_datetime(vals, config.time_dim_units)
+            time_dim_units = (
+                config.time_dim_units or ds.nc_data.time_variable.attrs["units"]
+            )
+    converted_vals = time_index_to_datetime(vals, time_dim_units)
 
     result = []
     for idx, date in enumerate(converted_vals):


### PR DESCRIPTION
## Background
We've been asked to add the GDWPS dataset to the Navigator which is in Grib2 format. Rather than update or develop a new indexing tool to ingest the data we opted to host the dataset on our THREDDS server which will index the data for us. 

While we can specify a url to THREDDS in the datasetconfig.json file for the Navigator to pull from some changes needed. Timestamps in Grib2 format, or at least the GDWPS dataset, appear to be dynamic and are given relative to the time of production. Logic has been added to pull the time dimension unit from the timestamps query in the event that it has not been provided in the datasetconfig.json file. I also found that the async FastAPI framework lead to I/O errors via the data tiles endpoint when pulling from THREDDS. This endpoint was restructured a little so that it could be made asynchronous which seems to have fixed the issue.

New colormaps for GDWPS variables are also added in this PR. 

## Why did you take this approach?
The other options to being in the GDWPS dataset were to either convert the Grib data to NetCDF or update/create a new indexing tool. While the later may be something to explore down the road it was not practical at the time. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
