### PR TITLE
Specify quiver variables in datasetconfig

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -213,16 +213,20 @@ class DatasetConfig:
         """
         Returns any magnitude variables.
         """
+        vectors = self._get_attribute("vector_variables")
         variables = {}
         for key, data in self._get_attribute("variables").items():
             is_hidden = data.get("hide")
-            is_vector = key in self._get_attribute("vector_variables")
 
             if (
-                is_hidden is False
-                or is_hidden is None
-                or is_hidden in ["false", "False"]
-            ) and is_vector:
+                (
+                    is_hidden is False
+                    or is_hidden is None
+                    or is_hidden in ["false", "False"]
+                )
+                and vectors
+                and key in vectors
+            ):
                 variables[key] = data
         return variables
 

--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -216,7 +216,7 @@ class DatasetConfig:
         variables = {}
         for key, data in self._get_attribute("variables").items():
             is_hidden = data.get("hide")
-            is_vector = "mag" in key
+            is_vector = key in self._get_attribute("vector_variables")
 
             if (
                 is_hidden is False

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -414,7 +414,7 @@ class DatasetSelector extends React.Component {
         MODEL_CLASSES_WITH_QUIVER.includes(this.state.model_class)
       ) {
         quiverVariables = this.state.datasetVariables.filter((variable) => {
-          return variable.id.includes("mag") && variable.id.includes("vel");
+          return variable.vector_variable;
         });
       }
       quiverVariables.unshift({ id: "none", value: "None" });

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -234,6 +234,7 @@ def variables(
                     "scale": config.variable[v].scale,
                     "interp": config.variable[v].interpolation,
                     "two_dimensional": v.is_surface_only(),
+                    "vector_variable": v.key in config.vector_variables,
                 }
             )
 
@@ -425,7 +426,7 @@ def data(
         data = data[data_slice]
 
         bearings = None
-        if "mag" in variable:
+        if variable in config.vector_variables:
             bearings_var = config.variable[variable].bearing_component or "bearing"
             with open_dataset(
                 config, variable=bearings_var, timestamp=time

--- a/tests/test_api_v_2_0.py
+++ b/tests/test_api_v_2_0.py
@@ -74,6 +74,7 @@ class TestAPIv2:
                 "scale": [-5, 30],
                 "interp": None,
                 "two_dimensional": False,
+                "vector_variable": False,
             }
         ]
 
@@ -92,6 +93,7 @@ class TestAPIv2:
                 "scale": [-5, 30],
                 "interp": None,
                 "two_dimensional": False,
+                "vector_variable": False,
             }
         ]
 

--- a/tests/test_dataset_config.py
+++ b/tests/test_dataset_config.py
@@ -67,6 +67,7 @@ class TestUtil:
         m.return_value = {
             "key": {
                 "enabled": True,
+                "vector_variables": ["magmyvar", "magnitudemyvar"],
                 "variables": {
                     "magmyvar": {
                         "name": "my_variable",

--- a/tests/testdata/datasetconfigpatch.json
+++ b/tests/testdata/datasetconfigpatch.json
@@ -37,6 +37,7 @@
         "lon_var_key": "longitude",
         "time_dim_units": "seconds since 1950-01-01 00:00:00",
         "attribution": "The Canadian Centre for Meteorological and Environmental Prediction",
+        "vector_variables": ["magwatervel"],
         "variables": {
             "votemper": { "name": "Temperature", "units": "Celsius", "scale": [-5, 30] },
             "vosaline": { "name": "Salinity", "units": "PSU", "scale": [30, 40] },


### PR DESCRIPTION
## Background
The Navigator currently uses the names of variables names to determine whether or not they can be used as vector variables. If a variable's name contains both "mag" and "vel" it is categorized as such. This has worked well before but now that we'd like to pull data from our THREDDS server we may not have control over the names of variables.  Instead, a `vector_variable` attribute will be added to datasets in datasetconfig.json which will list the variables which can be used to plot quivers. 

## Why did you take this approach?
This gives us more flexibility in choosing which variables to display as vectors.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
