### PR TITLE
Fix /range API endpoint

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -544,8 +544,7 @@ class DatasetSelector extends React.Component {
             "/" +
             this.state.depth +
             "/" +
-            this.state.time +
-            ".json"
+            this.state.time
           }
         />
       );

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -634,7 +634,8 @@ async def plot(
     db: Session = Depends(get_db),
 ):
     """
-    Interface for all plotting operations. Update example query with valid timestamp to test.
+    Interface for all plotting operations. Update example query with valid timestamp to
+    test.
     """
 
     if format == "json":

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -316,7 +316,10 @@ def scale(
     )
 
 
-@router.get("/range")
+@router.get(
+    "/range/{dataset}/{variable}/{interp}/{radius}/{neighbours}"
+    "/{projection}/{extent}/{depth}/{time}"
+)
 def range(
     dataset: str = Query(
         ..., description="The key of the dataset.", example="giops_day"
@@ -631,7 +634,7 @@ async def plot(
     db: Session = Depends(get_db),
 ):
     """
-    Interface for all plotting operations.
+    Interface for all plotting operations. Update example query with valid timestamp to test.
     """
 
     if format == "json":

--- a/tests/test_api_v_2_0.py
+++ b/tests/test_api_v_2_0.py
@@ -144,14 +144,8 @@ class TestAPIv2:
 
     def test_range(self) -> None:
         response = self.client.get(
-            "/api/v2.0/range",
-            params={
-                "dataset": "giops_real",
-                "variable": "votemper",
-                "depth": "0",
-                "time": 2212704000,
-                "extent": "-14958556.575,2726984.185,3826607.496,11239011.655",
-            },
+            "/api/v2.0/range/giops_real/votemper/gaussian/25/10/EPSG:3857"
+            "/-14958556.575,2726984.185,3826607.496,11239011.655/0/2212704000"
         )
 
         expected = {"min": -1.169886341970023, "max": 9.347870007228384}


### PR DESCRIPTION
## Background
The `/range` API endpoint was missed during the FastAPI migration and the query path was not properly defined which broke the "Auto" button in the dataset selector. This PR provides the full endpoint path which restores the "Auto" button functionality.

## Why did you take this approach?
The endpoint requires the complete query path to work. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
