### PR TITLE
Plot GDWPS Quivers

### DIFF
--- a/data/calculated_parser/lexer.py
+++ b/data/calculated_parser/lexer.py
@@ -70,8 +70,8 @@ class Lexer:
 
     # Identifiers either function names or variable names
     def t_ID(self, t):
-        """[a-zA-Z_][a-zA-Z_0-9]*"""
-        regex = re.compile("[a-zA-Z][a-zA-Z_0-9]*")
+        """[a-zA-Z_][a-zA-Z_0-9-]*"""
+        regex = re.compile("[a-zA-Z][a-zA-Z_0-9-]*")
         # Look at the functions defined in the functions module, if they match
         # the regular expression (start with upper or lower-case character, and
         # only contain alphanumeric characters, underscores, and the digits 0-9

--- a/data/calculated_parser/lexer.py
+++ b/data/calculated_parser/lexer.py
@@ -74,7 +74,8 @@ class Lexer:
         regex = re.compile("[a-zA-Z][a-zA-Z_0-9-]*")
         # Look at the functions defined in the functions module, if they match
         # the regular expression (start with upper or lower-case character, and
-        # only contain alphanumeric characters, underscores, and the digits 0-9
+        # only contain alphanumeric characters, underscores, hyphens, and the
+        # digits 0-9.
         fnames = filter(regex.match, dir(functions))
         if t.value not in fnames:
             # If the token does not match a function in functions, then we add

--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -74,7 +74,7 @@ async def data_array_to_geojson(
         scale_data[scale_data > 9] = 9
         scale_data[scale_data < 0] = 0
     else:
-        scale = np.full(data.shape(), 2, np.int8)
+        scale_data = np.full(data.shape, 2)
 
     features = []
     for elem, multi_idx in enumerate_nd_array(data):

--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -5,7 +5,7 @@ from geojson import Feature, FeatureCollection, Point
 from data.utils import trunc
 
 
-def data_array_to_geojson(
+async def data_array_to_geojson(
     data_array: xr.DataArray,
     bearings: xr.DataArray,
     lat_var: xr.DataArray,

--- a/data/transformers/geojson.py
+++ b/data/transformers/geojson.py
@@ -10,6 +10,7 @@ async def data_array_to_geojson(
     bearings: xr.DataArray,
     lat_var: xr.DataArray,
     lon_var: xr.DataArray,
+    scale: list,
 ) -> FeatureCollection:
     """
     Converts a given xarray.DataArray, along with lat and lon keys to a
@@ -68,6 +69,13 @@ async def data_array_to_geojson(
             yield it[0], it.multi_index
             it.iternext()
 
+    if bearings is not None:
+        scale_data = np.ceil(10 * (data - scale[0]) / scale[1])
+        scale_data[scale_data > 9] = 9
+        scale_data[scale_data < 0] = 0
+    else:
+        scale = np.full(data.shape(), 2, np.int8)
+
     features = []
     for elem, multi_idx in enumerate_nd_array(data):
         if np.isnan(elem):
@@ -86,6 +94,7 @@ async def data_array_to_geojson(
             if np.isnan(bearings[multi_idx].item()):
                 continue
             props["bearing"] = bearings[multi_idx].item()
+        props["scale"] = int(scale_data[multi_idx])
 
         features.append(Feature(geometry=p, properties=props))
 

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -576,106 +576,118 @@ export default class Map extends React.PureComponent {
       {
         source: null, // set source during update function below
         style: function(feature, resolution) {
-          const velocity = parseFloat(feature.get("data"));
-          const rotationRads = deg2rad(parseFloat(feature.get("bearing")));
-          if (velocity < knotsToMetersPerSecond(0.5)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.3,
-                src: I1,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
-              })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(1.0)) {
+          if (!feature.get("bearing")) { // bearing-only variable (no magnitude)
             return new olstyle.Style({
               image: new olstyle.Icon({
                 scale: 0.35,
                 src: I2,
                 opacity: 1,
                 anchor: anchor,
-                rotation: rotationRads
+                rotation: deg2rad(parseFloat(feature.get("data")))
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(2.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.35,
-                src: I3,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            })          
+          } else {
+            const data = parseFloat(feature.get("data"));
+            const rotationRads = deg2rad(parseFloat(feature.get("bearing")));
+            if (data < knotsToMetersPerSecond(0.5)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.3,
+                  src: I1,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(3.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.4,
-                src: I4,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(1.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.35,
+                  src: I2,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(5.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.5,
-                src: I5,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(2.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.35,
+                  src: I3,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(7.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.7,
-                src: I6,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(3.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.4,
+                  src: I4,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(10.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.75,
-                src: I7,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(5.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.5,
+                  src: I5,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else if (velocity < knotsToMetersPerSecond(13.0)) {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.9,
-                src: I8,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(7.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.7,
+                  src: I6,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
-          }
-          else {
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 1.0,
-                src: I9,
-                opacity: 1,
-                anchor: anchor,
-                rotation: rotationRads
+            }
+            else if (velocity < knotsToMetersPerSecond(10.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.75,
+                  src: I7,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
               })
-            })
+            }
+            else if (velocity < knotsToMetersPerSecond(13.0)) {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 0.9,
+                  src: I8,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
+              })
+            }
+            else {
+              return new olstyle.Style({
+                image: new olstyle.Icon({
+                  scale: 1.0,
+                  src: I9,
+                  opacity: 1,
+                  anchor: anchor,
+                  rotation: rotationRads
+                })
+              })
+            }
           }
         }
       }
@@ -764,12 +776,13 @@ export default class Map extends React.PureComponent {
       if (feature && feature.get("name")) {
         this.overlay.setPosition(e.coordinate);
         if (feature.get("data")) {
+          let bearing = feature.get("bearing")
           this.popupElement.innerHTML = ReactDOMServer.renderToString(
             <table>
               <tr><td>Variable</td><td>{feature.get("name")}</td></tr>
               <tr><td>Data</td><td>{feature.get("data")}</td></tr>
               <tr><td>Units</td><td>{feature.get("units")}</td></tr>
-              <tr><td>Bearing (+ve deg clockwise N)</td><td>{feature.get("bearing")}</td></tr>
+              {bearing && <tr><td>Bearing (+ve deg clockwise N)</td><td>{bearing}</td></tr>}
             </table>
           );
         } else {

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -35,6 +35,8 @@ const I7 = require("../images/s111/I7.svg").default;
 const I8 = require("../images/s111/I8.svg").default;
 const I9 = require("../images/s111/I9.svg").default;
 
+const arrowImages = [I0, I1, I2, I3, I4, I5, I6, I7, I8, I9];
+
 function knotsToMetersPerSecond(knots) {
   return knots * 0.514444;
 }
@@ -576,119 +578,22 @@ export default class Map extends React.PureComponent {
       {
         source: null, // set source during update function below
         style: function(feature, resolution) {
+          let scale = feature.get("scale");
+          let rotation = null;
           if (!feature.get("bearing")) { // bearing-only variable (no magnitude)
-            return new olstyle.Style({
-              image: new olstyle.Icon({
-                scale: 0.35,
-                src: I2,
-                opacity: 1,
-                anchor: anchor,
-                rotation: deg2rad(parseFloat(feature.get("data")))
-              })
-            });          
+            rotation = deg2rad(parseFloat(feature.get("data")))
           } else {
-            const velocity = parseFloat(feature.get("data"));
-            const rotationRads = deg2rad(parseFloat(feature.get("bearing")));
-            if (velocity < knotsToMetersPerSecond(0.5)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.3,
-                  src: I1,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(1.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.35,
-                  src: I2,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(2.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.35,
-                  src: I3,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(3.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.4,
-                  src: I4,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(5.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.5,
-                  src: I5,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(7.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.7,
-                  src: I6,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(10.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.75,
-                  src: I7,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else if (velocity < knotsToMetersPerSecond(13.0)) {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 0.9,
-                  src: I8,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
-            else {
-              return new olstyle.Style({
-                image: new olstyle.Icon({
-                  scale: 1.0,
-                  src: I9,
-                  opacity: 1,
-                  anchor: anchor,
-                  rotation: rotationRads
-                })
-              });
-            }
+            rotation = deg2rad(parseFloat(feature.get("bearing"))); 
           }
+          return new olstyle.Style({
+            image: new olstyle.Icon({
+              scale: (scale+1)/10,
+              src: arrowImages[scale],
+              opacity: 1,
+              anchor: anchor,
+              rotation: rotation
+            })
+          });          
         }
       }
     );

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -200,14 +200,14 @@ export default class Map extends React.PureComponent {
             url = `/api/v2.0/kml/${this.props.state.vectortype}` +
               `/${this.props.state.vectorid}` +
               `?projection=${projection.getCode()}` +
-              `&view_bounds=${extent.map(function (i) { return Math.round(i); })}` 
+              `&view_bounds=${extent.map(function (i) { return Math.round(i); })}`; 
             break;
           case "areas":
             url = `/api/v2.0/kml/${this.props.state.vectortype}` +
               `/${this.props.state.vectorid}` +
               `?projection=${projection.getCode()}` +
               `&resolution=${Math.round(resolution)}` +
-              `&view_bounds=${extent.map(function (i) { return Math.round(i); })}` 
+              `&view_bounds=${extent.map(function (i) { return Math.round(i); })}`; 
             break;
           default:
             url = `/api/v2.0/${this.props.state.vectortype}` +
@@ -585,7 +585,7 @@ export default class Map extends React.PureComponent {
                 anchor: anchor,
                 rotation: deg2rad(parseFloat(feature.get("data")))
               })
-            })          
+            });          
           } else {
             const velocity = parseFloat(feature.get("data"));
             const rotationRads = deg2rad(parseFloat(feature.get("bearing")));
@@ -598,7 +598,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(1.0)) {
               return new olstyle.Style({
@@ -609,7 +609,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(2.0)) {
               return new olstyle.Style({
@@ -620,7 +620,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(3.0)) {
               return new olstyle.Style({
@@ -631,7 +631,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(5.0)) {
               return new olstyle.Style({
@@ -642,7 +642,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(7.0)) {
               return new olstyle.Style({
@@ -653,7 +653,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(10.0)) {
               return new olstyle.Style({
@@ -664,7 +664,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else if (velocity < knotsToMetersPerSecond(13.0)) {
               return new olstyle.Style({
@@ -675,7 +675,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
             else {
               return new olstyle.Style({
@@ -686,7 +686,7 @@ export default class Map extends React.PureComponent {
                   anchor: anchor,
                   rotation: rotationRads
                 })
-              })
+              });
             }
           }
         }
@@ -776,7 +776,7 @@ export default class Map extends React.PureComponent {
       if (feature && feature.get("name")) {
         this.overlay.setPosition(e.coordinate);
         if (feature.get("data")) {
-          let bearing = feature.get("bearing")
+          let bearing = feature.get("bearing");
           this.popupElement.innerHTML = ReactDOMServer.renderToString(
             <table>
               <tr><td>Variable</td><td>{feature.get("name")}</td></tr>
@@ -1234,7 +1234,7 @@ export default class Map extends React.PureComponent {
       this.map.removeInteraction(draw);
       this._drawing = false;
       setTimeout(
-        function () { this.controlDoubleClickZoom(true); this.obsDrawSource.clear() }.bind(this),
+        function () { this.controlDoubleClickZoom(true); this.obsDrawSource.clear(); }.bind(this),
         251
       );
     }.bind(this));
@@ -1276,7 +1276,7 @@ export default class Map extends React.PureComponent {
       this.map.removeInteraction(draw);
       this._drawing = false;
       setTimeout(
-        function () { this.controlDoubleClickZoom(true); this.obsDrawSource.clear() }.bind(this),
+        function () { this.controlDoubleClickZoom(true); this.obsDrawSource.clear(); }.bind(this),
         251
       );
     }.bind(this));

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -587,9 +587,9 @@ export default class Map extends React.PureComponent {
               })
             })          
           } else {
-            const data = parseFloat(feature.get("data"));
+            const velocity = parseFloat(feature.get("data"));
             const rotationRads = deg2rad(parseFloat(feature.get("bearing")));
-            if (data < knotsToMetersPerSecond(0.5)) {
+            if (velocity < knotsToMetersPerSecond(0.5)) {
               return new olstyle.Style({
                 image: new olstyle.Icon({
                   scale: 0.3,

--- a/oceannavigator/frontend/src/components/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map.jsx
@@ -37,10 +37,6 @@ const I9 = require("../images/s111/I9.svg").default;
 
 const arrowImages = [I0, I1, I2, I3, I4, I5, I6, I7, I8, I9];
 
-function knotsToMetersPerSecond(knots) {
-  return knots * 0.514444;
-}
-
 function deg2rad(deg) {
   return deg * Math.PI/180.0;
 }
@@ -587,7 +583,7 @@ export default class Map extends React.PureComponent {
           }
           return new olstyle.Style({
             image: new olstyle.Icon({
-              scale: (scale+1)/10,
+              scale: 0.2 + (scale+1)/16,
               src: arrowImages[scale],
               opacity: 1,
               anchor: anchor,

--- a/oceannavigator/frontend/src/images/s111/I0.svg
+++ b/oceannavigator/frontend/src/images/s111/I0.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.0" width="4" height="13" viewBox="0 0 4 13"><circle cx="2" cy="9" r=".8"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.0" width="4" height="13" viewBox="0 0 4 13"><circle cx="2" cy="9" r="1" fill="#FFFFFF"/><circle cx="2" cy="9" r=".8"/></svg>

--- a/oceannavigator/frontend/src/images/s111/I1.svg
+++ b/oceannavigator/frontend/src/images/s111/I1.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#7652E2" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I2.svg
+++ b/oceannavigator/frontend/src/images/s111/I2.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#4898D3" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I3.svg
+++ b/oceannavigator/frontend/src/images/s111/I3.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#61CBE5" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I4.svg
+++ b/oceannavigator/frontend/src/images/s111/I4.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#6DBC45" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I5.svg
+++ b/oceannavigator/frontend/src/images/s111/I5.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#B4DC00" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I6.svg
+++ b/oceannavigator/frontend/src/images/s111/I6.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#CDC100" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I7.svg
+++ b/oceannavigator/frontend/src/images/s111/I7.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#F8A718" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I8.svg
+++ b/oceannavigator/frontend/src/images/s111/I8.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#F7A29D" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/oceannavigator/frontend/src/images/s111/I9.svg
+++ b/oceannavigator/frontend/src/images/s111/I9.svg
@@ -8,4 +8,5 @@
 </iho:S100SVG>
 </metadata>
 <path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="#FF1E1E" stroke-linecap="round" stroke-linejoin="round" stroke-width=".05"/>
+<path transform="translate(2 5) scale(1)" d="m-0.5 5v0l-0.5-6.5h-1l2-3.5 2 3.5h-1l-0.5 6.5h-1z" fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-width=".2"/>
 </svg>

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -377,7 +377,7 @@ def range(
 
 
 @router.get("/data")
-def data(
+async def data(
     dataset: str = Query(
         ..., description="The key of the dataset.", example="giops_day"
     ),
@@ -435,7 +435,7 @@ def data(
                     data_slice
                 ].squeeze(drop=True)
 
-        d = data_array_to_geojson(
+        d = await data_array_to_geojson(
             data.squeeze(drop=True),
             bearings,  # this is a hack
             lat_var[lat_slice],

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -478,8 +478,8 @@ async def data(
         data = data[data_slice]
 
         bearings = None
-        if variable in config.vector_variables:
-            bearings_var = config.variable[variable].bearing_component or "bearing"
+        bearings_var = config.variable[variable].bearing_component
+        if variable in config.vector_variables and bearings_var:
             with open_dataset(
                 config, variable=bearings_var, timestamp=time
             ) as ds_bearing:

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -492,6 +492,7 @@ async def data(
             bearings,  # this is a hack
             lat_var[lat_slice],
             lon_var[lon_slice],
+            config.variable[variable].scale,
         )
 
         path = pathlib.Path(cached_file_name).parent

--- a/tests/data/transformers/test_geojson.py
+++ b/tests/data/transformers/test_geojson.py
@@ -1,14 +1,10 @@
-"""Unit tests for data.geojson
-"""
-import unittest
-
 import xarray as xr
 from geojson import FeatureCollection
 
 from data.transformers.geojson import data_array_to_geojson
 
 
-class GeoJSONTest(unittest.TestCase):
+class GeoJSONTest:
     def setUp(self) -> None:
         self.data_array: xr.Dataset = xr.open_dataset(
             "tests/testdata/giops_test.nc", decode_times=False
@@ -17,8 +13,10 @@ class GeoJSONTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.data_array.close()
 
-    def test_data_array_to_geojson_builds_correct_feature_collection(self) -> None:
-        result = data_array_to_geojson(
+    async def test_data_array_to_geojson_builds_correct_feature_collection(
+        self,
+    ) -> None:
+        result = await data_array_to_geojson(
             self.data_array.votemper[0, 0, :5, :5],
             None,
             self.data_array["latitude"][:5],
@@ -28,9 +26,9 @@ class GeoJSONTest(unittest.TestCase):
         self.assertIsInstance(result, FeatureCollection)
         self.assertEqual(25, len(result["features"]))
 
-    def test_data_array_to_geojson_raises_when_data_not_2d(self) -> None:
+    async def test_data_array_to_geojson_raises_when_data_not_2d(self) -> None:
         with self.assertRaises(ValueError):
-            data_array_to_geojson(
+            await data_array_to_geojson(
                 self.data_array.votemper[:, 0, :5, :5],
                 None,
                 self.data_array["latitude"][:5],


### PR DESCRIPTION
## Background
There are a few final issues that need to be fixed before we can use GDWPS variables to plot quivers:
1. GDWPS variables from THREDDS include "-" characters which were interpreted as subtraction by the calculated parser. 

This can be resolved by allowing hyphens to pass the regex filter when defining ID tokens in the calculated parser. This does not affect other calculated variable equations that use subtraction operations. 

2. The wave direction variables are given as a bearing only and should be plotted as quivers of uniform size, i.e. no magnitude.

Because we now specify the bearing component in magnitude variables and explicitly list vector variables we can check to see if quiver variables have a 'bearing_componet' attribute in the '/data' endpoint. If not `bearing` is omitted from the GeoJSON data. In the front end if the data used to plot the quivers is missing this component we use the 'data' component as arrow's bearing. 

3. The scale of quiver arrows was decided with the expected range of water velocity in mind. For variables, such as wind velocity, with higher values the quivers are far too large, overlapping each other and obscuring the data underneath. 


## Why did you take this approach?
- THREDDS gets its variable names from a GRIB2 variable table and does not provide any way to rename them so allowing ID tokens to contain hyphen characters looked like the only way to provide some needed calculated variables.
- Allowing the Navigator to return GeoJSON data from bearing variables directly is the most efficient way to produce quiver arrows from that data. 

## Screenshots
Quivers resulting from bearing-only wave direction data:
![image](https://user-images.githubusercontent.com/79917349/203317295-76fe3c8b-9eba-40ca-a0b4-864fdd2c049c.png)

Wind velocity quivers using previous arrow scale:
![image](https://user-images.githubusercontent.com/79917349/203317811-3e7f051b-60b3-4740-a70f-771740040c5e.png)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.