### PR TITLE
Set class4 calendar range using available data

### DIFF
--- a/oceannavigator/frontend/src/components/MapToolbar.jsx
+++ b/oceannavigator/frontend/src/components/MapToolbar.jsx
@@ -81,24 +81,19 @@ class MapToolbar extends React.Component {
     let button = null;
     let div = null;
     let class4Files = null;
-    let minDate = null;
-    let maxDate = null;
     switch (type){
       case "ocean_predict":
         button = $(ReactDOM.findDOMNode(this.class4OPButton));
         div = this.class4OpDiv;
         class4Files = this.state.class4OPFiles;
-        minDate = new Date(2019, 1, 1); 
-        maxDate = new Date(2022, 1, 27);
         break;
       case "riops_obs":
         button = $(ReactDOM.findDOMNode(this.class4RAOButton));
         div = this.class4RAODiv;
         class4Files = this.state.class4RAOFiles;
-        minDate = new Date(2022, 1, 1);
-        maxDate = new Date(2022, 4, 30);
         break;
     }
+    let dates = Object.keys(class4Files).sort()
     this.class4Picker = $(div).datepicker({
       dateFormat: "yy-mm-dd",
       beforeShowDay: (d) => this.beforeShowDay(d,type),
@@ -106,8 +101,8 @@ class MapToolbar extends React.Component {
       onSelect: function(text, picker) {
         this.props.action("show", "class4", class4Files[text], type);
       }.bind(this),
-      minDate: minDate,
-      maxDate: maxDate
+      minDate: new Date(dates[0]),
+      maxDate: new Date(dates[dates.length - 1])
     }); 
     $(div).css("left", button.offset() + "px");
     this.forceUpdate();

--- a/oceannavigator/frontend/src/components/MapToolbar.jsx
+++ b/oceannavigator/frontend/src/components/MapToolbar.jsx
@@ -93,7 +93,7 @@ class MapToolbar extends React.Component {
         class4Files = this.state.class4RAOFiles;
         break;
     }
-    let dates = Object.keys(class4Files).sort()
+    let dates = Object.keys(class4Files).sort();
     this.class4Picker = $(div).datepicker({
       dateFormat: "yy-mm-dd",
       beforeShowDay: (d) => this.beforeShowDay(d,type),
@@ -307,8 +307,8 @@ class MapToolbar extends React.Component {
 
   // Instructs the OceanNavigator to fetch point data
   applyPointCoords() {
-    let latitude = this.state.coordinate[0]
-    let longitude = this.state.coordinate[1]
+    let latitude = this.state.coordinate[0];
+    let longitude = this.state.coordinate[1];
     //Latitude ranges between -90 and 90 degrees, inclusive. 
     //Values above or below this range will be clamped to the range [-90, 90]. 
     //This means that if the value specified is less than -90, it will be set to -90. 
@@ -321,7 +321,7 @@ class MapToolbar extends React.Component {
     //This reflects the fact that longitudes wrap around the globe.//
     longitude = (longitude >180) ? longitude - 360: longitude;
     longitude = (longitude <-180) ? 360 + longitude: longitude;
-    let appliedPointCords = [latitude, longitude]
+    let appliedPointCords = [latitude, longitude];
     // Draw points on map(s)
     this.props.action("add", "point", [appliedPointCords]);
     // We send "enterPoint" too so that the coordinates do not get

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -666,7 +666,7 @@ class OceanNavigator extends React.Component {
             observationArea={this.state.observationArea}
             disablePlotInteraction={this.removeMapInteraction}
           />
-          <WarningBar />
+          {/* <WarningBar /> */}
           {map}
         </div>
 

--- a/oceannavigator/frontend/src/components/WarningBar.jsx
+++ b/oceannavigator/frontend/src/components/WarningBar.jsx
@@ -23,9 +23,7 @@ class WarningBar extends React.PureComponent {
     if(this.state.show){
       return (
         <Alert bsStyle="warning" onDismiss={this.handleDismiss}>
-              Class 4 datasets currently static. Temporal Coverage: Jan 2019 
-              to Jan 2022, partial coverage Feb-May 2022 (Ocean Predict) and 
-              Feb 2022 to May 2022 (RIOPS Assimilation Observation).
+          *** Add warning here ***
         </Alert>
       );
     }


### PR DESCRIPTION
## Background
In #1052 the date ranges of both Class4 calendars were limited as the class4 data pipeline had stopped. Now that Class4 production has resumed this PR removes the hardcoded date range and replaces it with a range pulled from the list of available Class4 data. The warning banner has also been removed since it is no longer relevant. 

## Why did you take this approach?
Dynamically setting the date range will keep the calendars in sync with the available Class4 data.  

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
