### PR TITLE
Add axis range controls to profile plots

### DIFF
--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -1,14 +1,13 @@
 /* eslint react/no-deprecated: 0 */
 
 import React from "react";
-import {Button, ButtonToolbar, Checkbox} from "react-bootstrap";
+import { Button, Checkbox } from "react-bootstrap";
 import NumericInput from "react-numeric-input";
 import PropTypes from "prop-types";
 
 import Icon from "./lib/Icon.jsx";
 
 import { withTranslation } from "react-i18next";
-const stringify = require("fast-stable-stringify");
 
 class AxisRange extends React.Component {
 
@@ -17,12 +16,12 @@ class AxisRange extends React.Component {
 
     this.state = {
       auto: false,
-      min: this.props.range[0], 
+      min: this.props.range[0],
       max: this.props.range[1],
     };
 
     // Function bindings
-    // this.updateParent = this.updateParent.bind(this);
+    this.updateParent = this.updateParent.bind(this);
     this.keyPress = this.keyPress.bind(this);
     this.autoChanged = this.autoChanged.bind(this);
     this.handleResetButton = this.handleResetButton.bind(this);
@@ -31,16 +30,16 @@ class AxisRange extends React.Component {
 
 
   updateParent() {
-    this.props.onUpdate("variable_scale", [this.props.index, [this.state.min, this.state.max]])
+    this.props.onUpdate("variable_scale", [this.props.index, [this.state.min, this.state.max]]);
   }
 
-  changed(key, value) {    
+  changed(key, value) {
     clearTimeout(this.timeout);
-    
+
     let state = {};
     state[key] = value;
     this.setState(state);
-    
+
     this.timeout = setTimeout(this.updateParent, 1000);
   }
 
@@ -61,15 +60,15 @@ class AxisRange extends React.Component {
     if (e.target.checked) {
       this.props.onUpdate("variable_scale", [this.props.index, null]);
     } else {
-      this.updateParent()
+      this.updateParent();
     }
   }
 
   handleResetButton() {
     this.setState({
-      min: this.props.range[0], 
+      min: this.props.range[0],
       max: this.props.range[1],
-    })
+    });
   }
 
   render() {
@@ -79,7 +78,7 @@ class AxisRange extends React.Component {
         <Checkbox>
           <input type='checkbox' id={this.props.id + "_auto"} checked={this.state.auto} onChange={this.autoChanged.bind(this)} />
           {_("Auto")}
-        </Checkbox>        
+        </Checkbox>
         <table>
           <tbody>
             <tr>
@@ -107,7 +106,7 @@ class AxisRange extends React.Component {
               </td>
               <td>
                 <Button name='default' onClick={this.handleResetButton}><Icon icon='undo' alt={_("Reset")} /></Button>
-              </td>              
+              </td>
             </tr>
           </tbody>
         </table>
@@ -121,6 +120,8 @@ AxisRange.propTypes = {
   id: PropTypes.string,
   title: PropTypes.string,
   range: PropTypes.array,
+  onUpdate: PropTypes.func,
+  index: propTypes.number,
 };
 
 export default withTranslation()(AxisRange);

--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -1,0 +1,120 @@
+/* eslint react/no-deprecated: 0 */
+
+import React from "react";
+import {Button, ButtonToolbar, Checkbox} from "react-bootstrap";
+import NumericInput from "react-numeric-input";
+import PropTypes from "prop-types";
+
+import Icon from "./lib/Icon.jsx";
+
+import { withTranslation } from "react-i18next";
+const stringify = require("fast-stable-stringify");
+
+class AxisRange extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      min: this.props.range[0], 
+      max: this.props.range[1],
+    };
+
+    // Function bindings
+    // this.updateParent = this.updateParent.bind(this);
+    this.keyPress = this.keyPress.bind(this);
+    this.autoChanged = this.autoChanged.bind(this);
+    this.handleResetButton = this.handleResetButton.bind(this);
+    this.updateParent = this.updateParent.bind(this);
+  }
+
+
+  updateParent() {
+    this.props.onUpdate("variable_scale", [this.props.index, [this.state.min, this.state.max]])
+  }
+
+  changed(key, value) {    
+    clearTimeout(this.timeout);
+    
+    let state = {};
+    state[key] = value;
+    this.setState(state);
+    
+    this.timeout = setTimeout(this.updateParent, 1000);
+  }
+
+  keyPress(e) {
+    const key = e.which || e.keyCode;
+    if (key == 13) {
+      this.updateParent();
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  autoChanged(e) {
+    this.setState({
+      auto: e.target.checked
+    });
+  }
+
+  handleResetButton() {
+    this.setState({
+      min: this.props.range[0], 
+      max: this.props.range[1],
+    })
+  }
+
+  render() {
+    return (
+      <div className='Range input'>
+        <h1>{this.props.title}</h1>
+        <Checkbox>
+          <input type='checkbox' id={this.props.id + "_auto"} checked={this.state.auto} onChange={this.autoChanged.bind(this)} />
+          {_("Auto")}
+        </Checkbox>        
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <NumericInput
+                  value={this.state.min}
+                  onChange={(n, s) => this.changed("min", n)}
+                  step={0.1}
+                  precision={2}
+                  onBlur={this.updateParent}
+                  disabled={this.state.auto}
+                  onKeyPress={this.keyPress}
+                />
+              </td>
+              <td>
+                <NumericInput
+                  value={this.state.max}
+                  onChange={(n, s) => this.changed("max", n)}
+                  step={0.1}
+                  precision={2}
+                  onBlur={this.updateParent}
+                  disabled={this.state.auto}
+                  onKeyPress={this.keyPress}
+                />
+              </td>
+              <td>
+                <Button name='default' onClick={this.handleResetButton}><Icon icon='undo' alt={_("Reset")} /></Button>
+              </td>              
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+//***********************************************************************
+AxisRange.propTypes = {
+  id: PropTypes.string,
+  title: PropTypes.string,
+  range: PropTypes.array,
+};
+
+export default withTranslation()(AxisRange);

--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -16,6 +16,7 @@ class AxisRange extends React.Component {
     super(props);
 
     this.state = {
+      auto: false,
       min: this.props.range[0], 
       max: this.props.range[1],
     };
@@ -57,6 +58,11 @@ class AxisRange extends React.Component {
     this.setState({
       auto: e.target.checked
     });
+    if (e.target.checked) {
+      this.props.onUpdate("variable_scale", [this.props.index, null]);
+    } else {
+      this.updateParent()
+    }
   }
 
   handleResetButton() {

--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -28,9 +28,10 @@ class AxisRange extends React.Component {
     this.updateParent = this.updateParent.bind(this);
   }
 
-
   updateParent() {
-    this.props.onUpdate("variable_scale", [this.props.index, [this.state.min, this.state.max]]);
+    this.props.onUpdate(
+      "variable_range", [this.props.variable, [this.state.min, this.state.max]]
+    );
   }
 
   changed(key, value) {
@@ -58,7 +59,7 @@ class AxisRange extends React.Component {
       auto: e.target.checked
     });
     if (e.target.checked) {
-      this.props.onUpdate("variable_scale", [this.props.index, null]);
+      this.props.onUpdate("variable_range", [this.props.variable, null]);
     } else {
       this.updateParent();
     }
@@ -119,9 +120,9 @@ class AxisRange extends React.Component {
 AxisRange.propTypes = {
   id: PropTypes.string,
   title: PropTypes.string,
+  variable: PropTypes.string,
   range: PropTypes.array,
   onUpdate: PropTypes.func,
-  index: PropTypes.number,
 };
 
 export default withTranslation()(AxisRange);

--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -121,7 +121,7 @@ AxisRange.propTypes = {
   title: PropTypes.string,
   range: PropTypes.array,
   onUpdate: PropTypes.func,
-  index: propTypes.number,
+  index: PropTypes.number,
 };
 
 export default withTranslation()(AxisRange);

--- a/oceannavigator/frontend/src/components/AxisRange.jsx
+++ b/oceannavigator/frontend/src/components/AxisRange.jsx
@@ -15,7 +15,7 @@ class AxisRange extends React.Component {
     super(props);
 
     this.state = {
-      auto: false,
+      auto: true,
       min: this.props.range[0],
       max: this.props.range[1],
     };
@@ -41,7 +41,7 @@ class AxisRange extends React.Component {
     state[key] = value;
     this.setState(state);
 
-    this.timeout = setTimeout(this.updateParent, 1000);
+    this.timeout = setTimeout(this.updateParent, 500);
   }
 
   keyPress(e) {
@@ -66,10 +66,14 @@ class AxisRange extends React.Component {
   }
 
   handleResetButton() {
+    clearTimeout(this.timeout);
+
     this.setState({
       min: this.props.range[0],
       max: this.props.range[1],
     });
+    
+    this.timeout = setTimeout(this.updateParent, 500);
   }
 
   render() {

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -231,10 +231,13 @@ class DatasetSelector extends React.Component {
       const variable = this.state.datasetVariables.find(
         (v) => v.id === newVariable
       );
+      let newVariableRange = {};
+      newVariableRange[newVariable] = variable.scale;
 
       newState = {
         variable: newVariable,
         variable_scale: [variable.scale],
+        variable_range: newVariableRange,
         variable_two_dimensional: variable.two_dimensional,
         options: {
           ...this.state.options,
@@ -349,7 +352,6 @@ class DatasetSelector extends React.Component {
   }
 
   render() {
-    console.log(this.state.variable_range)
     _("Dataset");
     _("Variable");
     _("Depth");

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -210,8 +210,11 @@ class DatasetSelector extends React.Component {
     // Multiple variables were selected
     // so don't update everything else
     if (newVariable instanceof HTMLCollection) {
+      let variables = Array.from(newVariable).map((o) => o.value);
+      let variableData = this.state.datasetVariables.filter(item => variables.includes(item.id)); 
       newState = {
-        variable: Array.from(newVariable).map((o) => o.value),
+        variable: variables,
+        variable_scale: variableData.map((o) => o.scale),
         variable_two_dimensional: false,
       };
     } else {

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -147,7 +147,8 @@ class DatasetSelector extends React.Component {
 
                     datasetVariables: variableResult.data,
                     variable: newVariable,
-                    variable_scale: [newVariableScale],
+                    variable_scale: newVariableScale,
+                    variable_range: [newVariableScale],
                     quiverVariable: "none",
 
                     time: newTime,
@@ -215,7 +216,7 @@ class DatasetSelector extends React.Component {
       let variableData = this.state.datasetVariables.filter(item => variables.includes(item.id));
       newState = {
         variable: variables,
-        variable_scale: variableData.map((o) => o.scale),
+        variable_range: variableData.map((o) => o.scale),
         variable_two_dimensional: false,
       };
     } else {
@@ -301,10 +302,10 @@ class DatasetSelector extends React.Component {
       return;
     }
 
-    if (key == "variable_scale") {
-      let scale = this.state.variable_scale;
-      scale[value[0]] = value[1]
-      this.setState({variable_scale: scale})
+    if (key == "variable_range") {
+      let range = this.state.variable_range;
+      range[value[0]] = value[1]
+      this.setState({variable_range: range})
       return;
     }
 
@@ -570,14 +571,14 @@ class DatasetSelector extends React.Component {
     ) {
       let axisVariables = Array.isArray(this.state.variable) ? this.state.variable : [this.state.variable];
       let variableData = this.state.datasetVariables.filter((v) => axisVariables.includes(v.id));
-      let axisVariableScales = variableData.map((v) => v.scale);
+      let axisVariableRanges = variableData.map((v) => v.scale);
       let axisVariableNames = variableData.map((v) => v.value);
       for (let i = 0; i < axisVariables.length; ++i) {
         let range = <AxisRange
           key={axisVariables[i] + "_axis_range"}
           id={axisVariables[i] + "_axis_range"}
           title={axisVariableNames[i] + " Range"}
-          range={axisVariableScales[i]}
+          range={axisVariableRanges[i]}
           index={i}
           onUpdate={this.onUpdate}
         />

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -282,9 +282,11 @@ class DatasetSelector extends React.Component {
 
   componentWillUpdate(nextProps) {
     if (!nextProps.multipleVariables && this.props.multipleVariables && Array.isArray(this.state.variable)) {
+      let variable_range = {}
+      variable_range[this.state.variable[0]] = this.state.variable_range[this.state.variable[0]];
       this.setState({
         variable: [this.state.variable[0]],
-        variable_range: [this.state.variable_range[this.state.variable[0]]]
+        variable_range: variable_range
       });
     }
   }
@@ -347,6 +349,7 @@ class DatasetSelector extends React.Component {
   }
 
   render() {
+    console.log(this.state.variable_range)
     _("Dataset");
     _("Variable");
     _("Depth");
@@ -596,8 +599,8 @@ class DatasetSelector extends React.Component {
           key={axisVariables[i] + "_axis_range"}
           id={axisVariables[i] + "_axis_range"}
           title={axisVariableNames[i] + " Range"}
+          variable={axisVariables[i]}
           range={axisVariableRanges[i]}
-          index={i}
           onUpdate={this.onUpdate}
         />
         axisRange.push(range)

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -280,11 +280,11 @@ class DatasetSelector extends React.Component {
     );
   }
 
-  componentDidUpdate(prevProps) {
-    if (!this.props.multipleVariables && Array.isArray(this.state.variable)) {
-      this.setState({ 
-        variable: this.state.variable[0],
-        variable_range: this.state.variable_range[this.state.variable[0]] 
+  componentWillUpdate(nextProps) {
+    if (!nextProps.multipleVariables && this.props.multipleVariables && Array.isArray(this.state.variable)) {
+      this.setState({
+        variable: [this.state.variable[0]],
+        variable_range: [this.state.variable_range[this.state.variable[0]]]
       });
     }
   }

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -92,7 +92,7 @@ class DatasetSelector extends React.Component {
         let newVariable = currentVariable;
         let newVariableScale = this.state.variable_scale;
         let variable_range = {};
-        variable_range[newVariable] = newVariableScale;
+        variable_range[newVariable] = null;
         let interpType = this.state.options.interpType;
         let interpRadius = this.state.options.interpRadius;
         let interpNeighbours = this.state.options.interpNeighbours;
@@ -102,7 +102,7 @@ class DatasetSelector extends React.Component {
         if (!variableIds.includes(currentVariable)) {
           newVariable = variableResult.data[0].id;
           newVariableScale = variableResult.data[0].scale;
-          variable_range[newVariable] = newVariableScale;
+          variable_range[newVariable] = null;
           interpType =
             variableResult.data[0].interp?.interpType || this.DEF_INTERP_TYPE;
           interpRadius =
@@ -220,7 +220,7 @@ class DatasetSelector extends React.Component {
       let variables = Array.from(newVariable).map((o) => o.value);
       let variableRanges = {};
       variables.forEach(v => {
-        variableRanges[v] = this.state.datasetVariables.find(item => item.id === v).scale;
+        variableRanges[v] = null;
       });
       newState = {
         variable: variables,
@@ -232,7 +232,7 @@ class DatasetSelector extends React.Component {
         (v) => v.id === newVariable
       );
       let newVariableRange = {};
-      newVariableRange[newVariable] = variable.scale;
+      newVariableRange[newVariable] = null;
 
       newState = {
         variable: newVariable,

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -72,8 +72,8 @@ class PlotImage extends React.PureComponent {
     this.loadImage(...this.generateQuery(this.props.query));
   }
 
-  componentDidUpdate(nextProps) {
-    this.loadImage(...this.generateQuery(nextProps.query));
+  componentDidUpdate() {
+    this.loadImage(...this.generateQuery(this.props.query));
   }
 
   componentWillUnmount() {

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -173,6 +173,7 @@ class PlotImage extends React.PureComponent {
         query.showmap = q.showmap;
         query.station = q.point;
         query.variable = q.variable;
+        query.variable_scale = q.variable_scale;
         query.depth = q.depth;
         query.starttime = q.starttime;
         query.endtime = q.endtime;

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -153,7 +153,7 @@ class PlotImage extends React.PureComponent {
 
     switch (q.type) {
       case "profile":
-        query.variable_scale = q.variable_scale;
+        query.variable_range = q.variable_range;
       case "ts":
       case "sound":
         query.variable = q.variable;
@@ -173,7 +173,7 @@ class PlotImage extends React.PureComponent {
         query.showmap = q.showmap;
         query.station = q.point;
         query.variable = q.variable;
-        query.variable_scale = q.variable_scale;
+        query.variable_range = q.variable_range;
         query.depth = q.depth;
         query.starttime = q.starttime;
         query.endtime = q.endtime;

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -72,10 +72,8 @@ class PlotImage extends React.PureComponent {
     this.loadImage(...this.generateQuery(this.props.query));
   }
 
-  componentWillReceiveProps(props) {
-    if (stringify(this.props.query) !== stringify(props.query)) {
-      this.loadImage(...this.generateQuery(props.query));
-    }
+  componentDidUpdate(nextProps) {
+    this.loadImage(...this.generateQuery(nextProps.query));
   }
 
   componentWillUnmount() {

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -155,6 +155,7 @@ class PlotImage extends React.PureComponent {
 
     switch (q.type) {
       case "profile":
+        query.variable_scale = q.variable_scale;
       case "ts":
       case "sound":
         query.variable = q.variable;

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -71,7 +71,7 @@ class PointWindow extends React.Component {
 
   componentWillMount() {
     let dataset_0 = this.state.dataset_0;
-    dataset_0.variable_range[this.props.dataset_0.variable] = this.props.dataset_0.variable_scale;
+    dataset_0.variable_range[this.props.dataset_0.variable] = null;
     this.setState({ dataset_0: dataset_0 })
   }
 

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -51,7 +51,7 @@ class PointWindow extends React.Component {
       dataset_0: {
         dataset: props.dataset_0.dataset,
         variable: [props.dataset_0.variable],
-        variable_range: props.dataset_0.variable_scale,
+        variable_range: {},
         time: props.dataset_0.time,
         depth: props.dataset_0.depth,
         starttime: props.dataset_0.starttime,
@@ -67,6 +67,12 @@ class PointWindow extends React.Component {
     this.onLocalUpdate = this.onLocalUpdate.bind(this);
     this.onSelect = this.onSelect.bind(this);
     this.updatePlotTitle = this.updatePlotTitle.bind(this);
+  }
+
+  componentWillMount() {
+    let dataset_0 = this.state.dataset_0;
+    dataset_0.variable_range[this.props.dataset_0.variable] = this.props.dataset_0.variable_scale;
+    this.setState({ dataset_0: dataset_0 })
   }
 
   componentDidMount() {
@@ -202,7 +208,7 @@ class PointWindow extends React.Component {
       this.state.selected === TabEnum.PROFILE ||
       this.state.selected === TabEnum.MOORING;
     const showMultiVariableSelector = this.state.selected === TabEnum.PROFILE;
-    const showAxisRange = 
+    const showAxisRange =
       this.state.selected === TabEnum.PROFILE ||
       this.state.selected === TabEnum.MOORING;
 
@@ -255,15 +261,15 @@ class PointWindow extends React.Component {
               mountedVariable={this.props.dataset_0.variable}
             />
 
-          <CheckBox
-            key='showmap'
-            id='showmap'
-            checked={this.state.showmap}
-            onUpdate={this.onLocalUpdate}
-            title={_("Show Location")}
-          >
-            {_("showmap_help")}
-          </CheckBox>
+            <CheckBox
+              key='showmap'
+              id='showmap'
+              checked={this.state.showmap}
+              onUpdate={this.onLocalUpdate}
+              title={_("Show Location")}
+            >
+              {_("showmap_help")}
+            </CheckBox>
 
             <div
               style={{
@@ -392,7 +398,7 @@ class PointWindow extends React.Component {
         plot_query.type = "profile";
         plot_query.time = this.state.dataset_0.time;
         plot_query.variable = this.state.dataset_0.variable;
-        plot_query.variable_range = this.state.dataset_0.variable_range;
+        plot_query.variable_range = Object.values(this.state.dataset_0.variable_range);
         inputs = [global];
         break;
 
@@ -438,7 +444,7 @@ class PointWindow extends React.Component {
       case TabEnum.MOORING:
         plot_query.type = "timeseries";
         plot_query.variable = this.state.dataset_0.variable;
-        plot_query.variable_range = this.state.dataset_0.variable_range;
+        plot_query.variable_range = Object.values(this.state.dataset_0.variable_range);
         plot_query.starttime = this.state.dataset_0.starttime;
         plot_query.endtime = this.state.dataset_0.time;
         plot_query.depth = this.state.dataset_0.depth;

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -51,6 +51,7 @@ class PointWindow extends React.Component {
       dataset_0: {
         dataset: props.dataset_0.dataset,
         variable: [props.dataset_0.variable],
+        variable_scale: props.dataset_0.variable_scale,
         time: props.dataset_0.time,
         depth: props.dataset_0.depth,
         starttime: props.dataset_0.starttime,
@@ -239,6 +240,7 @@ class PointWindow extends React.Component {
               onUpdate={this.onLocalUpdate}
               showQuiverSelector={false}
               showVariableRange={false}
+              showAxisRange={this.state.selected === TabEnum.PROFILE}
               showTimeRange={showTimeRange}
               showDepthSelector={showDepthSelector}
               options={this.props.options}
@@ -387,6 +389,7 @@ class PointWindow extends React.Component {
         plot_query.type = "profile";
         plot_query.time = this.state.dataset_0.time;
         plot_query.variable = this.state.dataset_0.variable;
+        plot_query.variable_scale = this.state.dataset_0.variable_scale;
         inputs = [global];
         break;
 

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -202,6 +202,9 @@ class PointWindow extends React.Component {
       this.state.selected === TabEnum.PROFILE ||
       this.state.selected === TabEnum.MOORING;
     const showMultiVariableSelector = this.state.selected === TabEnum.PROFILE;
+    const showAxisRange = 
+      this.state.selected === TabEnum.PROFILE ||
+      this.state.selected === TabEnum.MOORING;
 
     const plotOptions = (
       <div>
@@ -240,7 +243,7 @@ class PointWindow extends React.Component {
               onUpdate={this.onLocalUpdate}
               showQuiverSelector={false}
               showVariableRange={false}
-              showAxisRange={this.state.selected === TabEnum.PROFILE}
+              showAxisRange={showAxisRange}
               showTimeRange={showTimeRange}
               showDepthSelector={showDepthSelector}
               options={this.props.options}
@@ -435,6 +438,7 @@ class PointWindow extends React.Component {
       case TabEnum.MOORING:
         plot_query.type = "timeseries";
         plot_query.variable = this.state.dataset_0.variable;
+        plot_query.variable_scale = this.state.dataset_0.variable_scale;
         plot_query.starttime = this.state.dataset_0.starttime;
         plot_query.endtime = this.state.dataset_0.time;
         plot_query.depth = this.state.dataset_0.depth;

--- a/oceannavigator/frontend/src/components/PointWindow.jsx
+++ b/oceannavigator/frontend/src/components/PointWindow.jsx
@@ -51,7 +51,7 @@ class PointWindow extends React.Component {
       dataset_0: {
         dataset: props.dataset_0.dataset,
         variable: [props.dataset_0.variable],
-        variable_scale: props.dataset_0.variable_scale,
+        variable_range: props.dataset_0.variable_scale,
         time: props.dataset_0.time,
         depth: props.dataset_0.depth,
         starttime: props.dataset_0.starttime,
@@ -392,7 +392,7 @@ class PointWindow extends React.Component {
         plot_query.type = "profile";
         plot_query.time = this.state.dataset_0.time;
         plot_query.variable = this.state.dataset_0.variable;
-        plot_query.variable_scale = this.state.dataset_0.variable_scale;
+        plot_query.variable_range = this.state.dataset_0.variable_range;
         inputs = [global];
         break;
 
@@ -438,7 +438,7 @@ class PointWindow extends React.Component {
       case TabEnum.MOORING:
         plot_query.type = "timeseries";
         plot_query.variable = this.state.dataset_0.variable;
-        plot_query.variable_scale = this.state.dataset_0.variable_scale;
+        plot_query.variable_range = this.state.dataset_0.variable_range;
         plot_query.starttime = this.state.dataset_0.starttime;
         plot_query.endtime = this.state.dataset_0.time;
         plot_query.depth = this.state.dataset_0.depth;

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -84,6 +84,8 @@ class Plotter(metaclass=ABCMeta):
 
         self.variables = self.__get_variables(query.get("variable"))
 
+        self.axis_range = query.get("variable_scale")
+
         # Parse right-view if in compare mode
         if query.get("compare_to") is not None:
             self.compare = query.get("compare_to")

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -84,7 +84,7 @@ class Plotter(metaclass=ABCMeta):
 
         self.variables = self.__get_variables(query.get("variable"))
 
-        self.axis_range = query.get("variable_scale")
+        self.axis_range = query.get("variable_range")
 
         # Parse right-view if in compare mode
         if query.get("compare_to") is not None:

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -259,7 +259,7 @@ class Plotter(metaclass=ABCMeta):
         with contextlib.closing(StringIO()) as buf:
             buf.write("\n".join(["// %s: %s" % (h[0], h[1]) for h in header]))
             buf.write("\n")
-            buf.write(", ".join(columns))   
+            buf.write(", ".join(columns))
             buf.write("\n")
 
             for line in data:

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -187,7 +187,7 @@ class ProfilePlotter(PointPlotter):
             if self.compare:
                 xlim = np.abs(plt.gca().get_xlim()).max()
                 plt.gca().set_xlim([-xlim, xlim])
-            elif self.axis_range:
+            elif self.axis_range[idx]:
                 plt.gca().set_xlim(self.axis_range[idx])
 
             subplot += 1

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -187,7 +187,7 @@ class ProfilePlotter(PointPlotter):
             if self.compare:
                 xlim = np.abs(plt.gca().get_xlim()).max()
                 plt.gca().set_xlim([-xlim, xlim])
-            elif self.axis_range[idx]:
+            elif self.axis_range:
                 plt.gca().set_xlim(self.axis_range[idx])
 
             subplot += 1

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -23,7 +23,7 @@ class ProfilePlotter(PointPlotter):
                 self.load_misc(ds, self.variables)
             except IndexError as e:
                 raise ClientError(
-                    ( #gettext(
+                    (  # gettext(
                         "The selected variable(s) were not found in the dataset. \
                         Most likely, this variable is a derived product from \
                         existing dataset variables. Please select another variable. "
@@ -180,12 +180,15 @@ class ProfilePlotter(PointPlotter):
 
             # Put y-axis label on left-most graph (but after the point location)
             if not is_y_label_plotted and (subplot == 0 or subplot == 1):
-                current_axis.set_ylabel("Depth (m)", fontsize=14) # current_axis.set_ylabel(gettext("Depth (m)"), fontsize=14)
+                current_axis.set_ylabel("Depth (m)", fontsize=14)
+                # current_axis.set_ylabel(gettext("Depth (m)"), fontsize=14)
                 is_y_label_plotted = True
 
             if self.compare:
                 xlim = np.abs(plt.gca().get_xlim()).max()
                 plt.gca().set_xlim([-xlim, xlim])
+            elif self.axis_range[idx]:
+                plt.gca().set_xlim(self.axis_range[idx])
 
             subplot += 1
 
@@ -195,7 +198,7 @@ class ProfilePlotter(PointPlotter):
             plt.suptitle(
                 "%s(%s)\n%s\n%s"
                 % (
-                    "Profile for ", # gettext("Profile for "),
+                    "Profile for ",  # gettext("Profile for "),
                     ", ".join(self.names),
                     ", ".join(self.variable_names),
                     self.date_formatter(self.iso_timestamp),

--- a/plotting/sound.py
+++ b/plotting/sound.py
@@ -104,6 +104,7 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
         self.plot_legend(fig, self.names)
 
         ylim = ax.get_ylim()
+        ax.set_xlim([1410, 1560])
         ax2 = ax.twinx()
         ureg = pint.UnitRegistry()
         ax2.set_ylim((ylim * ureg.meters).to(ureg.feet).magnitude)

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -513,6 +513,6 @@ class TimeseriesPlotter(PointPlotter):
             )
 
             if self.axis_range:
-                plt.gca().set_ylim(self.axis_range[idx])
+                plt.gca().set_ylim(self.axis_range[0])
 
         return super(TimeseriesPlotter, self).plot(fig)

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -512,7 +512,7 @@ class TimeseriesPlotter(PointPlotter):
                 transform=ax.transAxes,
             )
 
-            if self.axis_range[0]:
+            if self.axis_range:
                 plt.gca().set_ylim(self.axis_range[0])
 
         return super(TimeseriesPlotter, self).plot(fig)

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -512,4 +512,7 @@ class TimeseriesPlotter(PointPlotter):
                 transform=ax.transAxes,
             )
 
+            if self.axis_range:
+                plt.gca().set_ylim(self.axis_range[idx])
+
         return super(TimeseriesPlotter, self).plot(fig)

--- a/plotting/timeseries.py
+++ b/plotting/timeseries.py
@@ -512,7 +512,7 @@ class TimeseriesPlotter(PointPlotter):
                 transform=ax.transAxes,
             )
 
-            if self.axis_range:
+            if self.axis_range[0]:
                 plt.gca().set_ylim(self.axis_range[0])
 
         return super(TimeseriesPlotter, self).plot(fig)


### PR DESCRIPTION
## Background
This PR adds variable range controls to the point window per user requests. A new `AxisRange` component which allows users to set a specified range for the plot axis range. By default these ranges are set to the values specified within the datasetconfig.json file but the provided controls include a reset button and an _Auto_ option. This component adds the range values to the plot query, if _Auto_ is checked or values are not provided in the query the backend will select the appropriate axis range as before.

## Why did you take this approach?
The `AxisRange` component is based on the `Range` component which is used to specify the colorscale on the main map. The functionality needed is similar to the colormap range selector but there were a few important differences that necessitated a new component.

## Screenshot(s)
![image](https://user-images.githubusercontent.com/79917349/210351942-62d5ebab-469c-4d37-889c-51438cbd1289.png)
![image](https://user-images.githubusercontent.com/79917349/210352195-5159f97d-ab6b-40ba-b609-9d57dd2d3f78.png)

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
