### PR TITLE
Update Sentry

### DIFF
--- a/config/conda/environment.yml
+++ b/config/conda/environment.yml
@@ -26,11 +26,11 @@ dependencies:
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
   - c-blosc2=2.4.2=h7a311fb_0
-  - ca-certificates=2022.9.24=ha878542_0
+  - ca-certificates=2022.12.7=ha878542_0
   - cachetools=4.2.2=pyhd3eb1b0_0
   - cairo=1.16.0=ha61ee94_1014
   - cartopy=0.21.0=py310hcda3f9e_0
-  - certifi=2022.9.24=pyhd8ed1ab_0
+  - certifi=2022.12.7=pyhd8ed1ab_0
   - cffi=1.15.1=py310h255011f_0
   - cfitsio=4.1.0=hd9d235c_0
   - cftime=1.6.2=py310hde88566_0
@@ -193,7 +193,7 @@ dependencies:
   - numcodecs=0.7.3=py310h295c915_0
   - numpy=1.23.3=py310h53a5b5f_0
   - openjpeg=2.5.0=h7d73246_1
-  - openssl=1.1.1q=h166bdaf_0
+  - openssl=1.1.1s=h0b41bf4_1
   - opentelemetry-api=1.12.0=pyhd8ed1ab_0
   - opentelemetry-instrumentation=0.33b0=pyhd8ed1ab_0
   - opentelemetry-instrumentation-asgi=0.33b0=pyhd8ed1ab_0
@@ -252,7 +252,7 @@ dependencies:
   - scikit-image=0.19.3=py310h769672d_1
   - scipy=1.9.1=py310hdfbd76f_0
   - seawater=3.3.4=py_1
-  - sentry-sdk=1.9.10=pyhd8ed1ab_0
+  - sentry-sdk=1.12.1=pyhd8ed1ab_0
   - setuptools=65.4.1=pyhd8ed1ab_0
   - shapely=1.8.4=py310h5e49deb_0
   - sip=6.6.2=py310hd8f1fbe_0
@@ -265,6 +265,7 @@ dependencies:
   - starlette=0.20.4=pyhd8ed1ab_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tifffile=2022.8.12=pyhd8ed1ab_0
+  - tiledb=2.11.3=h1e4a385_0
   - tk=8.6.12=h27826a3_0
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0

--- a/config/conda/navigator-spec-file.txt
+++ b/config/conda/navigator-spec-file.txt
@@ -3,7 +3,7 @@
 # platform: linux-64
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.9.24-ha878542_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.12.7-ha878542_0.conda
 https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -59,7 +59,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.3-h9c3ff4c_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/nspr-4.32-h9c3ff4c_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1q-h166bdaf_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1s-h0b41bf4_1.conda
 https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
@@ -132,7 +132,7 @@ https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/attrs-22.1.0-pyh71513ae_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_7.tar.bz2
 https://repo.anaconda.com/pkgs/main/noarch/cachetools-4.2.2-pyhd3eb1b0_0.conda
-https://conda.anaconda.org/conda-forge/noarch/certifi-2022.9.24-pyhd8ed1ab_0.tar.bz2
+https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda
 https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/cloudpickle-2.2.0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
@@ -303,7 +303,7 @@ https://conda.anaconda.org/conda-forge/noarch/distributed-2022.9.2-pyhd8ed1ab_0.
 https://conda.anaconda.org/conda-forge/noarch/opentelemetry-instrumentation-asgi-0.33b0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.7-py310h29803b5_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/requests-2.28.1-pyhd8ed1ab_1.tar.bz2
-https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-1.9.10-pyhd8ed1ab_0.tar.bz2
+https://conda.anaconda.org/conda-forge/noarch/sentry-sdk-1.12.1-pyhd8ed1ab_0.conda
 https://conda.anaconda.org/conda-forge/noarch/dask-2022.9.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.6.0-py310hff52083_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/opentelemetry-instrumentation-fastapi-0.33b0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
## Background
Brings Sentry from v1.9.10 to v1.12.1. This is required for a number of new monitoring features. 

## Checks
- [X] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
