### PR TITLE
Update quiver arrows when dataset changes

### DIFF
--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -340,7 +340,7 @@ const MainMap = forwardRef((props, ref) => {
       }
       layerQuiver.setSource(source);
     }
-  }, [props.dataset0.quiverVariable]);
+  }, [props.dataset0.id, props.dataset0.quiverVariable]);
 
   useEffect(() => {
     if (map1) {
@@ -351,7 +351,7 @@ const MainMap = forwardRef((props, ref) => {
       }
       quiverLayer.setSource(source);
     }
-  }, [props.dataset1.quiverVariable]);
+  }, [props.dataset1.id, props.dataset1.quiverVariable]);
 
   useEffect(() => {
     if (vectorSource) {


### PR DESCRIPTION
## Background
I noticed that displayed quiver arrows were not changing when the dataset changed. This is because the `useEffect` hook which used to display them was only called when changing to the quiver variable itself and since we're only displaying quiver arrows for `magwatervel` it never updates. Adding the dataset id to the useEffect dependencies fixes the problem.

## Why did you take this approach?
Only way since were using useEffect to trigger quiver arrows.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

