### PR TITLE
Fix subset panel and related timepicker bugs

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -9,7 +9,6 @@ import dateutil.parser
 import geopy
 import netCDF4
 import numpy as np
-import pandas
 import pint
 import pyresample
 import xarray
@@ -349,24 +348,20 @@ class NetCDFData(Data):
         time_var = find_variable("time", list(self.dataset.variables.keys()))
         timestamp = str(
             format_date(
-                pandas.to_datetime(
-                    np.float64(
-                        self.get_dataset_variable(time_var)[time_range[0]].values
-                    )
+                self.timestamp_to_iso_8601(
+                    self.get_dataset_variable(time_var)[time_range[0]].values
                 ),
-                "yyyyMMdd",
+                "yyyMMdd",
             )
         )
         endtimestamp = ""
         if apply_time_range:
             endtimestamp = "-" + str(
                 format_date(
-                    pandas.to_datetime(
-                        np.float64(
-                            self.get_dataset_variable(time_var)[time_range[1]].values
-                        )
+                    self.timestamp_to_iso_8601(
+                        self.get_dataset_variable(time_var)[time_range[1]].values
                     ),
-                    "yyyyMMdd",
+                    "yyyMMdd",
                 )
             )
 
@@ -429,7 +424,6 @@ class NetCDFData(Data):
 
         # "Special" output
         if output_format == "NETCDF3_NC":
-
             GRID_RESOLUTION = 50
 
             # Regrids an input data array according to it's input grid definition
@@ -439,7 +433,6 @@ class NetCDFData(Data):
                 input_def: pyresample.geometry.SwathDefinition,
                 output_def: pyresample.geometry.SwathDefinition,
             ):
-
                 orig_shape = data.shape
 
                 data = np.rollaxis(data, 0, 4)  # Roll time axis backward
@@ -837,7 +830,6 @@ class NetCDFData(Data):
             ds_zarr = xarray.open_zarr(url)
             var_list = []
             for var in list(ds_zarr.data_vars):
-
                 name = var
                 units = (
                     ds_zarr.variables[var].attrs["units"]
@@ -953,7 +945,6 @@ class NetCDFData(Data):
         """
         # If the timestamp cache is empty
         if self.__timestamp_cache.get("timestamps") is None:
-
             var = self.time_variable
 
             # Convert timestamps to UTC
@@ -1013,7 +1004,6 @@ class NetCDFData(Data):
     def __get_variables_to_load(
         self, db: SQLiteDatabase, variable: set, calculated_variables: dict
     ) -> List[str]:
-
         calc_var_keys = set(calculated_variables)
         variables_to_load = variable.difference(calc_var_keys)
         requested_calculated_variables = variable & calc_var_keys
@@ -1032,7 +1022,6 @@ class NetCDFData(Data):
     def __get_requested_timestamps(
         self, db: SQLiteDatabase, variable: str, timestamp, endtime, nearest_timestamp
     ) -> List[int]:
-
         # We assume timestamp and/or endtime have been converted
         # to the same time units as the requested dataset. Otherwise
         # this won't work.

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -13,8 +13,8 @@ import pint
 import pyresample
 import xarray
 import xarray.core.variable
-from cachetools import TTLCache
 from babel.dates import format_date
+from cachetools import TTLCache
 
 import data.calculated
 import data.utils

--- a/data/utils.py
+++ b/data/utils.py
@@ -42,15 +42,17 @@ def find_ge(a, x):
 
 
 def get_data_vars_from_equation(equation: str, data_variables: List[str]) -> List[str]:
-    """Extracts the data variables (i.e. variables that exist in netcdf files, as opposed to
-        "calculated variables") from an equation string for a calculated variable.
+    """Extracts the data variables (i.e. variables that exist in netcdf files, as
+        opposed to "calculated variables") from an equation string for a calculated
+        variable.
 
         We perform a regex to match all variable keys, and then a set-intersection to
         filter out the "calculated" variables.
 
     Arguments:
         equation {str} -- equation string of a calculated variable.
-        data_variables {List[str]} -- list of non-calculated varaible keys in the dataset.
+        data_variables {List[str]} -- list of non-calculated varaible keys in the
+            dataset.
 
     Returns:
         List[str] -- List of strings containing the variable keys

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -119,14 +119,17 @@ function DatasetSelector(props) {
                 ? timeData[timeData.length - 20].id
                 : timeData[0].id;
 
-            if (props.mountedDataset && props.mountedDataset.id === newDataset) {
+            if (
+              props.mountedDataset &&
+              props.mountedDataset.id === newDataset
+            ) {
               newTime =
                 props.mountedDataset.time > 0
                   ? props.mountedDataset.time
                   : newTime;
               newStarttime =
-                props.mountedDataset.startTime > 0
-                  ? props.mountedDataset.startTime
+                props.mountedDataset.starttime > 0
+                  ? props.mountedDataset.starttime
                   : newStarttime;
             }
 
@@ -239,6 +242,26 @@ function DatasetSelector(props) {
     });
   };
 
+  const changeTime = (newTime) => {
+    let newDataset = {};
+    if (dataset.starttime > newTime) {
+      const timeIdx = datasetTimestamps.findIndex((timestamp) => {
+        return timestamp.id === newTime;
+      });
+
+      const newStarttime =
+        timeIdx > 20
+          ? datasetTimestamps[timeIdx - 20].id
+          : datasetTimestamps[0].id;
+
+      newDataset = { ...dataset, time: newTime, starttime: newStarttime };
+    } else {
+      newDataset = { ...dataset, time: newTime };
+    }
+
+    setDataset(newDataset);
+  };
+
   const nothingChanged = (key, value) => {
     return dataset[key] === value;
   };
@@ -249,6 +272,10 @@ function DatasetSelector(props) {
 
   const variableChanged = (key) => {
     return key === "variable";
+  };
+
+  const timeChanged = (key) => {
+    return key === "time";
   };
 
   const updateDataset = (key, value) => {
@@ -263,6 +290,11 @@ function DatasetSelector(props) {
 
     if (variableChanged(key)) {
       changeVariable(value);
+      return;
+    }
+
+    if (timeChanged(key)) {
+      changeTime(value);
       return;
     }
 

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -67,8 +67,8 @@ function SubsetPanel(props) {
       queryString = "&min_range=" + min_range + "&max_range=" + max_range;
     }
     const outputEndtime = outputTimerange
-      ? state.outputEndtime
-      : state.outputStarttime;
+      ? outputEndtime
+      : outputStarttime;
     window.location.href =
       `/api/v2.0/subset/${props.dataset.id}/${outputVariables.join()}?` +
       "&outputFormat=" +

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -66,16 +66,16 @@ function SubsetPanel(props) {
       const max_range = [AABB[1], AABB[3]].join();
       queryString = "&min_range=" + min_range + "&max_range=" + max_range;
     }
-    const outputEndtime = outputTimerange
-      ? outputEndtime
-      : outputStarttime;
+    const starttime = outputTimerange
+      ? outputStarttime
+      : outputEndtime;
     window.location.href =
       `/api/v2.0/subset/${props.dataset.id}/${outputVariables.join()}?` +
-      "&outputFormat=" +
+      "&output_format=" +
       outputFormat +
       queryString +
       "&time=" +
-      [outputStarttime, outputEndtime].join() +
+      [starttime, outputEndtime].join() +
       "&should_zip=" +
       (zip ? 1 : 0);
   };

--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Card } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
@@ -12,44 +12,33 @@ import Icon from "./lib/Icon.jsx";
 import { withTranslation } from "react-i18next";
 import { GetVariablesPromise } from "../remote/OceanNavigator.js";
 
-class SubsetPanel extends React.Component {
-  constructor(props) {
-    super(props);
-    this._mounted = false;
-    this.state = {
-      loading: false,
-      output_timerange: false,
-      output_variables: [],
-      output_starttime: props.dataset.starttime,
-      output_endtime: props.dataset.time,
-      output_format: "NETCDF4", // Subset output format
-      zip: false, // Should subset file(s) be zipped
-      subset_variables: [],
-    };
-    // Function bindings
-    this.subsetArea = this.subsetArea.bind(this);
-    this.saveScript = this.saveScript.bind(this);
-    this.getSubsetVariables = this.getSubsetVariables.bind(this);
-    this.setNewState = this.setNewState.bind(this);
-  }
+function SubsetPanel(props) {
+  const [loading, setLoading] = useState(false);
+  const [outputTimerange, setOutputTimerange] = useState(false);
+  const [outputVariables, setOutputVariables] = useState([]);
+  const [outputStarttime, setOutputStarttime] = useState(
+    props.dataset.starttime
+  );
+  const [outputEndtime, setOutputEndtime] = useState(props.dataset.time);
+  const [outputFormat, setOutputFormat] = useState("NETCDF4");
+  const [zip, setZip] = useState(false);
+  const [subset_variables, setSubset_variables] = useState([]);
 
-  componentDidMount() {
-    this._mounted = true;
-    this.getSubsetVariables();
-  }
+  useEffect(() => {
+    getSubsetVariables();
+  }, [props.dataset.id]);
 
-  componentWillUnmount() {
-    this._mounted = false;
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.dataset.id !== prevProps.dataset.id) {
-      this.getSubsetVariables();
+  useEffect(() => {
+    if (outputTimerange && outputStarttime > outputEndtime) {
+      let newStarttime = outputEndtime;
+      let newEndtime = outputStarttime;
+      setOutputStarttime(newStarttime);
+      setOutputEndtime(newEndtime);
     }
-  }
+  }, [outputStarttime, outputEndtime, outputTimerange]);
 
   // Find max extents of drawn area
-  calculateAreaBoundingBox(area) {
+  const calculateAreaBoundingBox = (area) => {
     let lat_min = area[0][0];
     let long_min = area[0][1];
     let lat_max = area[0][0];
@@ -64,54 +53,46 @@ class SubsetPanel extends React.Component {
     }
 
     return [lat_min, lat_max, long_min, long_max];
-  }
+  };
 
-  subsetArea() {
+  const subsetArea = () => {
     var queryString = [];
     // check if predefined area
-    if (
-      typeof this.props.area === "string" ||
-      this.props.area instanceof String
-    ) {
-      queryString = "&area=" + this.props.area;
+    if (typeof props.area === "string" || props.area instanceof String) {
+      queryString = "&area=" + props.area;
     } else {
-      const AABB = this.calculateAreaBoundingBox(this.props.area);
+      const AABB = calculateAreaBoundingBox(props.area);
       const min_range = [AABB[0], AABB[2]].join();
       const max_range = [AABB[1], AABB[3]].join();
       queryString = "&min_range=" + min_range + "&max_range=" + max_range;
     }
-    const output_endtime = this.state.output_timerange
-      ? this.state.output_endtime
-      : this.state.output_starttime;
+    const outputEndtime = outputTimerange
+      ? state.outputEndtime
+      : state.outputStarttime;
     window.location.href =
-      `/api/v2.0/subset/${
-        this.props.dataset.id
-      }/${this.state.output_variables.join()}?` +
-      "&output_format=" +
-      this.state.output_format +
+      `/api/v2.0/subset/${props.dataset.id}/${outputVariables.join()}?` +
+      "&outputFormat=" +
+      outputFormat +
       queryString +
       "&time=" +
-      [this.state.output_starttime, output_endtime].join() +
+      [outputStarttime, outputEndtime].join() +
       "&should_zip=" +
-      (this.state.zip ? 1 : 0);
-  }
+      (zip ? 1 : 0);
+  };
 
-  saveScript(key) {
+  const saveScript = (key) => {
     let query = {
-      output_format: this.state.output_format,
-      dataset_name: this.props.dataset.id,
-      variables: this.state.output_variables.join(),
-      time: [this.state.output_starttime, this.state.output_endtime].join(),
-      should_zip: this.state.zip ? 1 : 0,
+      outputFormat: outputFormat,
+      dataset_name: props.dataset.id,
+      variables: outputVariables.join(),
+      time: [outputStarttime, outputEndtime].join(),
+      should_zip: zip ? 1 : 0,
     };
     // check if predefined area
-    if (
-      typeof this.props.area === "string" ||
-      this.props.area instanceof String
-    ) {
-      query["area"] = this.props.area;
+    if (typeof props.area === "string" || props.area instanceof String) {
+      query["area"] = props.area;
     } else {
-      const AABB = this.calculateAreaBoundingBox(this.props.area);
+      const AABB = calculateAreaBoundingBox(props.area);
       query["min_range"] = [AABB[0], AABB[2]].join();
       query["max_range"] = [AABB[1], AABB[3]].join();
     }
@@ -123,158 +104,145 @@ class SubsetPanel extends React.Component {
       "&lang=" +
       key +
       "&scriptType=subset";
-  }
+  };
 
-  getSubsetVariables() {
-    this.setState({ loading: true });
-    GetVariablesPromise(this.props.dataset.id).then((variableResult) => {
-      this.setState({
-        loading: false,
-        subset_variables: variableResult.data,
-      });
+  const getSubsetVariables = () => {
+    setLoading(true);
+    GetVariablesPromise(props.dataset.id).then((variableResult) => {
+      setLoading(false);
+      setSubset_variables(variableResult.data);
     });
-    this.setNewState();
-  }
+    setOutputStarttime(props.dataset.starttime);
+    setOutputEndtime(props.dataset.time);
+  };
 
-  setNewState() {
-    let newState = {};
-    newState = {
-      output_starttime: this.props.dataset.starttime,
-      output_endtime: this.props.dataset.time,
-    };
-    this.setState(newState);
-  }
+  return (
+    <div>
+      <Card key="subset" variant="primary">
+        <Card.Header>{__("Subset")}</Card.Header>
+        <Card.Body>
+          {loading ? null : (
+            <>
+              <ComboBox
+                id="variable"
+                key="variable"
+                multiple={true}
+                state={outputVariables}
+                def={"defaults.dataset"}
+                onUpdate={(keys, values) => {
+                  setOutputVariables(values[0]);
+                }}
+                data={subset_variables}
+                title={"Variables"}
+              />
+              <CheckBox
+                id="time_range"
+                key="time_range"
+                checked={outputTimerange}
+                onUpdate={(_, value) => {
+                  setOutputTimerange(value);
+                }}
+                title={__("Select Time Range")}
+              />
+              <div style={{ display: outputTimerange ? "block" : "none" }}>
+                <TimePicker
+                  id="starttime"
+                  key="starttime"
+                  state={outputStarttime}
+                  dataset={props.dataset}
+                  title={
+                    outputTimerange ? __("Start Time (UTC)") : __("Time (UTC)")
+                  }
+                  onUpdate={(_, value) => {
+                    setOutputStarttime(value);
+                  }}
+                  max={outputTimerange ? outputEndtime : null}
+                />
+              </div>
+              <TimePicker
+                id="time"
+                key="time"
+                state={outputEndtime}
+                dataset={props.dataset}
+                title={
+                  outputTimerange ? __("End Time (UTC)") : __("Time (UTC)")
+                }
+                onUpdate={(_, value) => {
+                  setOutputEndtime(value);
+                }}
+                min={outputTimerange ? outputStarttime : null}
+              />
 
-  render() {
-    const subsetPanel = this.state.loading ? null : (
-      <form>
-        <ComboBox
-          id="variable"
-          key="variable"
-          multiple={true}
-          state={this.state.output_variables}
-          def={"defaults.dataset"}
-          onUpdate={(keys, values) => {
-            this.setState({ output_variables: values[0] });
-          }}
-          data={this.state.subset_variables}
-          title={"Variables"}
-        />
-        <CheckBox
-          id="time_range"
-          key="time_range"
-          checked={this.state.output_timerange}
-          onUpdate={(_, value) => {
-            this.setState({ output_timerange: value });
-          }}
-          title={_("Select Time Range")}
-        />
-        <TimePicker
-          id="starttime"
-          key="starttime"
-          state={this.state.output_starttime}
-          dataset={this.props.dataset}
-          title={
-            this.state.output_timerange
-              ? _("Start Time (UTC)")
-              : _("Time (UTC)")
-          }
-          onUpdate={(_, value) => {
-            this.setState({ output_starttime: value });
-          }}
-          max={this.state.output_timerange ? this.state.output_endtime : null}
-        />
-        <div
-          style={{ display: this.state.output_timerange ? "block" : "none" }}
-        >
-          <TimePicker
-            id="time"
-            key="time"
-            state={this.state.output_endtime}
-            dataset={this.props.dataset}
-            title={
-              this.state.output_timerange
-                ? _("End Time (UTC)")
-                : _("Time (UTC)")
-            }
-            onUpdate={(_, value) => {
-              this.setState({ output_endtime: value });
-            }}
-            min={this.state.output_starttime}
-          />
-        </div>
-        <Form.Group controlId="output_format">
-          <Form.Label>{_("Output Format")}</Form.Label>
-          <Form.Select
-            onChange={(e) => {
-              this.setState({ output_format: e.target.value });
-            }}
-            value={"NETCDF4"}
-          >
-            <option value="NETCDF4">{_("NetCDF-4")}</option>
-            <option value="NETCDF3_CLASSIC">{_("NetCDF-3 Classic")}</option>
-            <option value="NETCDF3_64BIT">{_("NetCDF-3 64-bit")}</option>
-            <option
-              value="NETCDF3_NC"
-              disabled={
-                this.props.dataset.id.indexOf("giops") === -1 &&
-                this.props.dataset.id.indexOf("riops") === -1 // Disable if not a giops or riops dataset
-              }
-            >
-              {"NetCDF-3 NC"}
-            </option>
-            <option value="NETCDF4_CLASSIC">{_("NetCDF-4 Classic")}</option>
-          </Form.Select>
-        </Form.Group>
-        <CheckBox
-          id="zip"
-          key="zip"
-          checked={this.state.zip}
-          onUpdate={(_, checked) => {
-            this.setState({ zip: checked });
-          }}
-          title={_("Compress as *.zip")}
-        />
-        <Button
-          variant="default"
-          key="save"
-          id="save"
-          onClick={this.subsetArea}
-          disabled={this.state.output_variables == ""}
-        >
-          <Icon icon="save" /> {_("Save")}
-        </Button>
-        <DropdownButton
-          id="script"
-          title={
-            <span>
-              <Icon icon="file-code-o" /> {_("API Scripts")}
-            </span>
-          }
-          variant={"default"}
-          disabled={this.state.output_variables == ""}
-          onSelect={this.saveScript}
-          drop={"up"}
-        >
-          <Dropdown.Item eventKey="python">
-            <Icon icon="code" /> {_("Python 3")}
-          </Dropdown.Item>
-          <Dropdown.Item eventKey="r">
-            <Icon icon="code" /> {_("R")}
-          </Dropdown.Item>
-        </DropdownButton>
-      </form>
-    );
-
-    return (
-      <div>
-        <Card key="subset" variant="primary">
-          <Card.Header>{_("Subset")}</Card.Header>
-          <Card.Body>{subsetPanel}</Card.Body>
-        </Card>
-      </div>
-    );
-  }
+              <Form.Group controlId="outputFormat">
+                <Form.Label>{__("Output Format")}</Form.Label>
+                <Form.Select
+                  onChange={(e) => {
+                    setOutputFormat(e.target.value);
+                  }}
+                  value={outputFormat}
+                >
+                  <option value="NETCDF4">{__("NetCDF-4")}</option>
+                  <option value="NETCDF3_CLASSIC">
+                    {__("NetCDF-3 Classic")}
+                  </option>
+                  <option value="NETCDF3_64BIT">{__("NetCDF-3 64-bit")}</option>
+                  <option
+                    value="NETCDF3_NC"
+                    disabled={
+                      props.dataset.id.indexOf("giops") === -1 &&
+                      props.dataset.id.indexOf("riops") === -1 // Disable if not a giops or riops dataset
+                    }
+                  >
+                    {"NetCDF-3 NC"}
+                  </option>
+                  <option value="NETCDF4_CLASSIC">
+                    {__("NetCDF-4 Classic")}
+                  </option>
+                </Form.Select>
+              </Form.Group>
+              <CheckBox
+                id="zip"
+                key="zip"
+                checked={zip}
+                onUpdate={(_, checked) => {
+                  setZip(checked);
+                }}
+                title={__("Compress as *.zip")}
+              />
+              <Button
+                variant="default"
+                key="save"
+                id="save"
+                onClick={subsetArea}
+                disabled={outputVariables == ""}
+              >
+                <Icon icon="save" /> {__("Save")}
+              </Button>
+              <DropdownButton
+                id="script"
+                title={
+                  <span>
+                    <Icon icon="file-code-o" /> {__("API Scripts")}
+                  </span>
+                }
+                variant={"default"}
+                disabled={outputVariables == ""}
+                onSelect={saveScript}
+                drop={"up"}
+              >
+                <Dropdown.Item eventKey="python">
+                  <Icon icon="code" /> {__("Python 3")}
+                </Dropdown.Item>
+                <Dropdown.Item eventKey="r">
+                  <Icon icon="code" /> {__("R")}
+                </Dropdown.Item>
+              </DropdownButton>
+            </>
+          )}
+        </Card.Body>
+      </Card>
+    </div>
+  );
 }
 
 //***********************************************************************

--- a/oceannavigator/frontend/src/components/TimePicker.jsx
+++ b/oceannavigator/frontend/src/components/TimePicker.jsx
@@ -53,13 +53,13 @@ function TimePicker(props) {
   useEffect(() => {
     let newData = timestamps;
 
-    if (props.min) {
+    if (props.min && props.min < props.state) {
       newData = newData.filter((item) => {
         return item.id > props.min;
       });
     }
 
-    if (props.max) {
+    if (props.max && props.max > props.state) {
       newData = newData.filter((item) => {
         return item.id < props.max;
       });


### PR DESCRIPTION
## Background
Users notified us of an issue causing the Navigator to crash when trying to make an area plot with an older timestamp from a historical dataset. It turned out that there were several small issues contributing to the crash:

1. Selecting a timestamp older than the current `dataset.starttime` value breaks the `DailyCalendar` component. 

When selecting a dataset with many timestamp options the DatasetSelector component sets the `dataset.starttime` value to the 20th most recent value to prevent overly long timeseries queries. However, this value does not get updated if the user selects a timestamp before it. This results in the start and end time calendar components breaking because the start time value is outside of the expected date range. To resolve this a `changeTime` method was added  to the DatasetSelector which updates the start time value whenever a new time is chosen. This method will check that the current timestamp is greater, if not will select a an earlier start time  from the available time stamps. 

2. The `<form>` component triggered a page refresh whenever a new time was selected

The form was missing an onSubmit method which caused the refresh. This component was replaced by a fragment which doesn't affect appearance or function.

3. Selecting the first timestamp available breaks the calendars. 

This is because the min and max values get filtered out of the available calendar dates list resulting in no dates to display. A check was added to skip filtering if min or max  are equivalent the the selected timestamp,


## Checks
- [x] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
