### PR TITLE
Add beginning and ending time buttons to Timeslider component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ ENV/
 
 *.out
 data/calculated_parser/parsetab.py
-node_modules/
 
-oceannavigator/frontend-old
+node_modules/
+oceannavigator/frontend/public/
+

--- a/config/conda/environment.yml
+++ b/config/conda/environment.yml
@@ -265,7 +265,6 @@ dependencies:
   - starlette=0.20.4=pyhd8ed1ab_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tifffile=2022.8.12=pyhd8ed1ab_0
-  - tiledb=2.11.3=h1e4a385_0
   - tk=8.6.12=h27826a3_0
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0

--- a/oceannavigator/frontend/src/components/TimeSlider.jsx
+++ b/oceannavigator/frontend/src/components/TimeSlider.jsx
@@ -24,6 +24,8 @@ function TimeSlider(props) {
     let newNTicks = 20;
     if (props.dataset.quantum === "hour") {
       newNTicks = 48;
+    } else if (props.timestamps.length < newNTicks) {
+      newNTicks = props.timestamps.length;
     }
     setMin(
       props.timestamps.length < newNTicks
@@ -233,23 +235,63 @@ function TimeSlider(props) {
     setSelectedIndex(selectedIndex + 1);
   };
 
+  let firstFrameTime = null;
+  let lastFrameTime = null;
+  let prevFrameTime = null;
+  let nextFrameTime = null;
+
+  if (props.timestamps.length > 0) {
+    let prevIdx = min - nTicks;
+    prevIdx = prevIdx < 0 ? 0 : prevIdx;
+
+    let nextIdx = max + nTicks;
+    nextIdx =
+      nextIdx >= props.timestamps.length
+        ? props.timestamps.length - 1
+        : nextIdx;
+
+    firstFrameTime = getFormattedTime(new Date(props.timestamps[0].value));
+    lastFrameTime = getFormattedTime(
+      new Date(props.timestamps[props.timestamps.length - 1].value)
+    );
+
+    prevFrameTime = getFormattedTime(new Date(props.timestamps[prevIdx].value));
+    nextFrameTime = getFormattedTime(new Date(props.timestamps[nextIdx].value));
+  }
+
   return (
     <div className="time-slider">
       <div className="button-container">
-        <Button
-          className="slider-button"
-          onClick={firstFrame}
-          disabled={min === 0 || props.loading}
+        <OverlayTrigger
+          key={`firstFrameButton-overlay`}
+          placement="top"
+          overlay={<Tooltip id="firsFrameButton">{firstFrameTime}</Tooltip>}
         >
-          <ChevronBarLeft />
-        </Button>
-        <Button
-          className="slider-button"
-          onClick={prevFrame}
-          disabled={min === 0 || props.loading}
+          <span>
+            <Button
+              className="slider-button"
+              onClick={firstFrame}
+              disabled={min === 0 || props.loading}
+            >
+              <ChevronBarLeft />
+            </Button>
+          </span>
+        </OverlayTrigger>
+        <OverlayTrigger
+          key={`prevFrameButton-overlay`}
+          placement="top"
+          overlay={<Tooltip id="prevFrameButton">{prevFrameTime}</Tooltip>}
         >
-          <ChevronDoubleLeft />
-        </Button>
+          <span>
+            <Button
+              className="slider-button"
+              onClick={prevFrame}
+              disabled={min === 0 || props.loading}
+            >
+              <ChevronDoubleLeft />
+            </Button>
+          </span>
+        </OverlayTrigger>
         <Button
           className="slider-button"
           onClick={prevValue}
@@ -272,20 +314,36 @@ function TimeSlider(props) {
         >
           <ChevronRight />
         </Button>
-        <Button
-          className="slider-button"
-          onClick={nextFrame}
-          disabled={max === props.timestamps.length || props.loading}
+        <OverlayTrigger
+          key={`nextFrameButton-overlay`}
+          placement="top"
+          overlay={<Tooltip id="nextFrameButton">{nextFrameTime}</Tooltip>}
         >
-          <ChevronDoubleRight />
-        </Button>
-        <Button
-          className="slider-button"
-          onClick={lastFrame}
-          disabled={max === props.timestamps.length || props.loading}
+          <span>
+            <Button
+              className="slider-button"
+              onClick={nextFrame}
+              disabled={max === props.timestamps.length || props.loading}
+            >
+              <ChevronDoubleRight />
+            </Button>
+          </span>
+        </OverlayTrigger>
+        <OverlayTrigger
+          key={`lastFrameButton-overlay`}
+          placement="top"
+          overlay={<Tooltip id="lastFrameButton">{lastFrameTime}</Tooltip>}
         >
-          <ChevronBarRight />
-        </Button>
+          <span>
+            <Button
+              className="slider-button"
+              onClick={lastFrame}
+              disabled={max === props.timestamps.length || props.loading}
+            >
+              <ChevronBarRight />
+            </Button>
+          </span>
+        </OverlayTrigger>
       </div>
     </div>
   );

--- a/oceannavigator/frontend/src/components/TimeSlider.jsx
+++ b/oceannavigator/frontend/src/components/TimeSlider.jsx
@@ -14,8 +14,8 @@ import {
 import { withTranslation } from "react-i18next";
 
 function TimeSlider(props) {
-  const [min, setMin] = useState(0);
-  const [max, setMax] = useState(1);
+  const [minTick, setMinTick] = useState(0);
+  const [maxTick, setMaxTick] = useState(1);
   const [nTicks, setNTicks] = useState(48);
   const [selectedIndex, setSelectedIndex] = useState(1);
   const [climatology, setClimatology] = useState(false);
@@ -27,12 +27,12 @@ function TimeSlider(props) {
     } else if (props.timestamps.length < newNTicks) {
       newNTicks = props.timestamps.length;
     }
-    setMin(
+    setMinTick(
       props.timestamps.length < newNTicks
         ? 0
         : props.timestamps.length - newNTicks
     );
-    setMax(props.timestamps.length);
+    setMaxTick(props.timestamps.length);
     let newIndex = props.timestamps.findIndex((timestamp) => {
       return timestamp.id === props.selected;
     });
@@ -142,12 +142,12 @@ function TimeSlider(props) {
 
   const sliderRail = <div className="slider-rail" />;
 
-  const ticks = props.timestamps.slice(min, max).map((timestamp, index) => {
+  const ticks = props.timestamps.slice(minTick, maxTick).map((timestamp, index) => {
     let time = new Date(timestamp.value);
     let tickLabel = null;
     let tickClass = "slider-minor-tick";
     let tooltipLabel = getFormattedTime(time);
-    index = index + min;
+    index = index + minTick;
     if (setMajorTick(time)) {
       tickLabel = tooltipLabel;
       tickClass = "slider-major-tick";
@@ -183,31 +183,31 @@ function TimeSlider(props) {
 
   const firstFrame = () => {
     if (props.timestamps.length > nTicks) {
-      setMin(0);
-      setMax(nTicks);
+      setMinTick(0);
+      setMaxTick(nTicks);
     } else {
-      setMin(0);
-      setMax(props.timestamps.length);
+      setMinTick(0);
+      setMaxTick(props.timestamps.length);
     }
   };
 
   const lastFrame = () => {
     if (props.timestamps.length - nTicks > 0) {
-      setMin(props.timestamps.length - nTicks);
-      setMax(props.timestamps.length);
+      setMinTick(props.timestamps.length - nTicks);
+      setMaxTick(props.timestamps.length);
     } else {
-      setMin(0);
-      setMax(props.timestamps.length);
+      setMinTick(0);
+      setMaxTick(props.timestamps.length);
     }
   };
 
   const prevFrame = () => {
-    if (min >= nTicks) {
-      setMin(min - nTicks);
-      setMax(min);
+    if (minTick >= nTicks) {
+      setMinTick(minTick - nTicks);
+      setMaxTick(minTick);
     } else if (props.timestamps.length > nTicks) {
-      setMin(0);
-      setMax(nTicks);
+      setMinTick(0);
+      setMaxTick(nTicks);
     } else {
       setMin(0);
       setMax(props.timestamps.length);
@@ -215,24 +215,32 @@ function TimeSlider(props) {
   };
 
   const nextFrame = () => {
-    if (props.timestamps.length - max >= nTicks) {
-      setMin(max);
-      setMax(max + nTicks);
+    if (props.timestamps.length - maxTick >= nTicks) {
+      setMinTick(maxTick);
+      setMaxTick(maxTick + nTicks);
     } else if (props.timestamps.length - nTicks > 0) {
-      setMin(props.timestamps.length - nTicks);
-      setMax(props.timestamps.length);
+      setMinTick(props.timestamps.length - nTicks);
+      setMaxTick(props.timestamps.length);
     } else {
-      setMin(0);
-      setMax(props.timestamps.length);
+      setMinTick(0);
+      setMaxTick(props.timestamps.length);
     }
   };
 
   const prevValue = () => {
-    setSelectedIndex(selectedIndex - 1);
+    let newIdx = selectedIndex - 1
+    if (newIdx < minTick) {
+      prevFrame();
+    }
+    setSelectedIndex(newIdx);
   };
 
   const nextValue = () => {
-    setSelectedIndex(selectedIndex + 1);
+    let newIdx = selectedIndex + 1
+    if (newIdx >= maxTick) {
+      nextFrame();
+    }
+    setSelectedIndex(newIdx);
   };
 
   let firstFrameTime = null;
@@ -241,10 +249,10 @@ function TimeSlider(props) {
   let nextFrameTime = null;
 
   if (props.timestamps.length > 0) {
-    let prevIdx = min - nTicks;
+    let prevIdx = minTick - nTicks;
     prevIdx = prevIdx < 0 ? 0 : prevIdx;
 
-    let nextIdx = max + nTicks;
+    let nextIdx = maxTick + nTicks;
     nextIdx =
       nextIdx >= props.timestamps.length
         ? props.timestamps.length - 1
@@ -271,7 +279,7 @@ function TimeSlider(props) {
             <Button
               className="slider-button"
               onClick={firstFrame}
-              disabled={min === 0 || props.loading}
+              disabled={minTick === 0 || props.loading}
             >
               <ChevronBarLeft />
             </Button>
@@ -286,7 +294,7 @@ function TimeSlider(props) {
             <Button
               className="slider-button"
               onClick={prevFrame}
-              disabled={min === 0 || props.loading}
+              disabled={minTick === 0 || props.loading}
             >
               <ChevronDoubleLeft />
             </Button>
@@ -323,7 +331,7 @@ function TimeSlider(props) {
             <Button
               className="slider-button"
               onClick={nextFrame}
-              disabled={max === props.timestamps.length || props.loading}
+              disabled={maxTick === props.timestamps.length || props.loading}
             >
               <ChevronDoubleRight />
             </Button>
@@ -338,7 +346,7 @@ function TimeSlider(props) {
             <Button
               className="slider-button"
               onClick={lastFrame}
-              disabled={max === props.timestamps.length || props.loading}
+              disabled={maxTick === props.timestamps.length || props.loading}
             >
               <ChevronBarRight />
             </Button>

--- a/oceannavigator/frontend/src/components/TimeSlider.jsx
+++ b/oceannavigator/frontend/src/components/TimeSlider.jsx
@@ -3,6 +3,8 @@ import { Button } from "react-bootstrap";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import {
+  ChevronBarLeft,
+  ChevronBarRight,
   ChevronLeft,
   ChevronDoubleLeft,
   ChevronRight,
@@ -19,7 +21,7 @@ function TimeSlider(props) {
   const [climatology, setClimatology] = useState(false);
 
   useEffect(() => {
-    let newNTicks = 24;
+    let newNTicks = 20;
     if (props.dataset.quantum === "hour") {
       newNTicks = 48;
     }
@@ -177,6 +179,26 @@ function TimeSlider(props) {
     );
   });
 
+  const firstFrame = () => {
+    if (props.timestamps.length > nTicks) {
+      setMin(0);
+      setMax(nTicks);
+    } else {
+      setMin(0);
+      setMax(props.timestamps.length);
+    }
+  };
+
+  const lastFrame = () => {
+    if (props.timestamps.length - nTicks > 0) {
+      setMin(props.timestamps.length - nTicks);
+      setMax(props.timestamps.length);
+    } else {
+      setMin(0);
+      setMax(props.timestamps.length);
+    }
+  };
+
   const prevFrame = () => {
     if (min >= nTicks) {
       setMin(min - nTicks);
@@ -216,6 +238,13 @@ function TimeSlider(props) {
       <div className="button-container">
         <Button
           className="slider-button"
+          onClick={firstFrame}
+          disabled={min === 0 || props.loading}
+        >
+          <ChevronBarLeft />
+        </Button>
+        <Button
+          className="slider-button"
           onClick={prevFrame}
           disabled={min === 0 || props.loading}
         >
@@ -249,6 +278,13 @@ function TimeSlider(props) {
           disabled={max === props.timestamps.length || props.loading}
         >
           <ChevronDoubleRight />
+        </Button>
+        <Button
+          className="slider-button"
+          onClick={lastFrame}
+          disabled={max === props.timestamps.length || props.loading}
+        >
+          <ChevronBarRight />
         </Button>
       </div>
     </div>

--- a/oceannavigator/frontend/src/components/TimeSlider.jsx
+++ b/oceannavigator/frontend/src/components/TimeSlider.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { Button } from "react-bootstrap";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import {
@@ -10,6 +9,8 @@ import {
   ChevronRight,
   ChevronDoubleRight,
 } from "react-bootstrap-icons";
+
+import TimeSliderButton from "./TimeSliderButton.jsx";
 
 import { withTranslation } from "react-i18next";
 
@@ -142,44 +143,45 @@ function TimeSlider(props) {
 
   const sliderRail = <div className="slider-rail" />;
 
-  const ticks = props.timestamps.slice(minTick, maxTick).map((timestamp, index) => {
-    let time = new Date(timestamp.value);
-    let tickLabel = null;
-    let tickClass = "slider-minor-tick";
-    let tooltipLabel = getFormattedTime(time);
-    index = index + minTick;
-    if (setMajorTick(time)) {
-      tickLabel = tooltipLabel;
-      tickClass = "slider-major-tick";
-    }
+  const ticks = props.timestamps
+    .slice(minTick, maxTick)
+    .map((timestamp, index) => {
+      let time = new Date(timestamp.value);
+      let tickLabel = null;
+      let tickClass = "slider-minor-tick";
+      let tooltipLabel = getFormattedTime(time);
+      index = index + minTick;
+      if (setMajorTick(time)) {
+        tickLabel = tooltipLabel;
+        tickClass = "slider-major-tick";
+      }
 
-    let thumb = null;
-    if (timestamp.id === props.selected) {
-      thumb = <SliderHandle />;
-    }
+      let thumb = null;
+      if (timestamp.id === props.selected) {
+        thumb = <SliderHandle />;
+      }
 
-    return (
-      <OverlayTrigger
-        key={`overlay-${index}`}
-        placement="top"
-        overlay={<Tooltip id={`tooltip-${index}`}>{tooltipLabel}</Tooltip>}
-      >
-        <div
-          key={`span-${index}`}
-          id={index}
-          onClick={handleClick}
-          className="slider-span"
+      return (
+        <OverlayTrigger
+          key={`overlay-${index}`}
+          placement="top"
+          overlay={<Tooltip id={`tooltip-${index}`}>{tooltipLabel}</Tooltip>}
         >
-          <div key={`tick-${index}`} id={index} className={tickClass} />
-
-          {thumb}
-          <label className="slider-major-tick-text" id={index}>
-            {tickLabel}
-          </label>
-        </div>
-      </OverlayTrigger>
-    );
-  });
+          <div
+            key={`span-${index}`}
+            id={index}
+            onClick={handleClick}
+            className="slider-span"
+          >
+            <div key={`tick-${index}`} id={index} className={tickClass} />
+            {thumb}
+            <label className="slider-major-tick-text" id={index}>
+              {tickLabel}
+            </label>
+          </div>
+        </OverlayTrigger>
+      );
+    });
 
   const firstFrame = () => {
     if (props.timestamps.length > nTicks) {
@@ -228,7 +230,7 @@ function TimeSlider(props) {
   };
 
   const prevValue = () => {
-    let newIdx = selectedIndex - 1
+    let newIdx = selectedIndex - 1;
     if (newIdx < minTick) {
       prevFrame();
     }
@@ -236,122 +238,100 @@ function TimeSlider(props) {
   };
 
   const nextValue = () => {
-    let newIdx = selectedIndex + 1
+    let newIdx = selectedIndex + 1;
     if (newIdx >= maxTick) {
       nextFrame();
     }
     setSelectedIndex(newIdx);
   };
 
+  let prevTime = null;
+  let nextTime = null;
   let firstFrameTime = null;
   let lastFrameTime = null;
   let prevFrameTime = null;
   let nextFrameTime = null;
 
   if (props.timestamps.length > 0) {
-    let prevIdx = minTick - nTicks;
-    prevIdx = prevIdx < 0 ? 0 : prevIdx;
+    let prevTimeIdx = selectedIndex - 1;
+    prevTimeIdx = prevTimeIdx < 0 ? 0 : prevTimeIdx;
 
-    let nextIdx = maxTick + nTicks;
-    nextIdx =
-      nextIdx >= props.timestamps.length
+    let nextTimeIdx = selectedIndex + 1;
+    nextTimeIdx =
+      nextTimeIdx >= props.timestamps.length
         ? props.timestamps.length - 1
-        : nextIdx;
+        : nextTimeIdx;
 
+    let prevFrameIdx = minTick - nTicks;
+    prevFrameIdx = prevFrameIdx < 0 ? 0 : prevFrameIdx;
+
+    let nextFrameIdx = maxTick + nTicks;
+    nextFrameIdx =
+      nextFrameIdx >= props.timestamps.length
+        ? props.timestamps.length - 1
+        : nextFrameIdx;
+
+    prevTime = getFormattedTime(new Date(props.timestamps[prevTimeIdx].value));
+    nextTime = getFormattedTime(new Date(props.timestamps[nextTimeIdx].value));        
     firstFrameTime = getFormattedTime(new Date(props.timestamps[0].value));
     lastFrameTime = getFormattedTime(
       new Date(props.timestamps[props.timestamps.length - 1].value)
     );
-
-    prevFrameTime = getFormattedTime(new Date(props.timestamps[prevIdx].value));
-    nextFrameTime = getFormattedTime(new Date(props.timestamps[nextIdx].value));
+    prevFrameTime = getFormattedTime(
+      new Date(props.timestamps[prevFrameIdx].value)
+    );
+    nextFrameTime = getFormattedTime(
+      new Date(props.timestamps[nextFrameIdx].value)
+    );
   }
 
   return (
     <div className="time-slider">
       <div className="button-container">
-        <OverlayTrigger
-          key={`firstFrameButton-overlay`}
-          placement="top"
-          overlay={<Tooltip id="firsFrameButton">{firstFrameTime}</Tooltip>}
-        >
-          <span>
-            <Button
-              className="slider-button"
-              onClick={firstFrame}
-              disabled={minTick === 0 || props.loading}
-            >
-              <ChevronBarLeft />
-            </Button>
-          </span>
-        </OverlayTrigger>
-        <OverlayTrigger
-          key={`prevFrameButton-overlay`}
-          placement="top"
-          overlay={<Tooltip id="prevFrameButton">{prevFrameTime}</Tooltip>}
-        >
-          <span>
-            <Button
-              className="slider-button"
-              onClick={prevFrame}
-              disabled={minTick === 0 || props.loading}
-            >
-              <ChevronDoubleLeft />
-            </Button>
-          </span>
-        </OverlayTrigger>
-        <Button
-          className="slider-button"
+        <TimeSliderButton
+          tooltipText={firstFrameTime}
+          onClick={firstFrame}
+          disabled={minTick === 0 || props.loading}
+          icon={<ChevronBarLeft />}
+        />
+        <TimeSliderButton
+          tooltipText={prevFrameTime}
+          onClick={prevFrame}
+          disabled={minTick === 0 || props.loading}
+          icon={<ChevronDoubleLeft />}
+        />
+        <TimeSliderButton
+          tooltipText={prevTime}
           onClick={prevValue}
           disabled={selectedIndex === 0 || props.loading}
-        >
-          <ChevronLeft />
-        </Button>
+          icon={<ChevronLeft />}
+        />
       </div>
       <div className="slider-container">
         {sliderRail}
         {props.loading ? null : ticks}
       </div>
       <div className="button-container">
-        <Button
-          className="slider-button"
+        <TimeSliderButton
+          tooltipText={nextTime}
           onClick={nextValue}
           disabled={
             selectedIndex === props.timestamps.length - 1 || props.loading
           }
-        >
-          <ChevronRight />
-        </Button>
-        <OverlayTrigger
-          key={`nextFrameButton-overlay`}
-          placement="top"
-          overlay={<Tooltip id="nextFrameButton">{nextFrameTime}</Tooltip>}
-        >
-          <span>
-            <Button
-              className="slider-button"
-              onClick={nextFrame}
-              disabled={maxTick === props.timestamps.length || props.loading}
-            >
-              <ChevronDoubleRight />
-            </Button>
-          </span>
-        </OverlayTrigger>
-        <OverlayTrigger
-          key={`lastFrameButton-overlay`}
-          placement="top"
-          overlay={<Tooltip id="lastFrameButton">{lastFrameTime}</Tooltip>}
-        >
-          <span>
-            <Button
-              className="slider-button"
-              onClick={lastFrame}
-              disabled={maxTick === props.timestamps.length || props.loading}
-            >
-              <ChevronBarRight />
-            </Button>
-          </span>
-        </OverlayTrigger>
+          icon={<ChevronRight />}
+        />
+        <TimeSliderButton
+          tooltipText={nextFrameTime}
+          onClick={nextFrame}
+          disabled={maxTick === props.timestamps.length || props.loading}
+          icon={<ChevronDoubleRight />}
+        />
+        <TimeSliderButton
+          tooltipText={lastFrameTime}
+          onClick={lastFrame}
+          disabled={maxTick === props.timestamps.length || props.loading}
+          icon={<ChevronBarRight />}
+        />
       </div>
     </div>
   );

--- a/oceannavigator/frontend/src/components/TimeSliderButton.jsx
+++ b/oceannavigator/frontend/src/components/TimeSliderButton.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Button from "react-bootstrap/Button";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Tooltip from "react-bootstrap/Tooltip";
+
+function TimeSliderButton(props) {
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip>{props.tooltipText}</Tooltip>}
+    >
+      <span>
+        <Button
+          className="slider-button"
+          onClick={props.onClick}
+          disabled={props.disabled}
+        >
+          {props.icon}
+        </Button>
+      </span>
+    </OverlayTrigger>
+  );
+}
+
+export default TimeSliderButton;

--- a/oceannavigator/frontend/src/stylesheets/components/_TimeSlider.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_TimeSlider.scss
@@ -88,6 +88,7 @@
   height: 36px;
   width: 36px;
   border-radius: 50%;
+  pointer-events: "none";
 }
 
 .slider-button:hover {


### PR DESCRIPTION
## Background
Additional buttons are added to allow users to quickly jump to the beginning and end of the time slider. In addition to this functionality tooltips have been added to provide feedback on what dates are available outside of the currently displayed time range. 

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/bd83ae9a-7b9b-4e03-8b63-010ade3ed6c4)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

