### PR TITLE
Pan main map to dataset location on change

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -190,6 +190,17 @@ class DatasetConfig:
         return cache
 
     @property
+    def default_location(self) -> list:
+        """
+        Returns the default map location of the specified dataset. Used to pan the map
+        to dataset location. Format [lon, lat, zoom].
+        """
+
+        dataset_default_location = self._get_attribute("default_location")
+
+        return dataset_default_location
+
+    @property
     def variables(self) -> list:
         """
         Returns a list of the variables for the specified dataset

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -147,6 +147,7 @@ function DatasetSelector(props) {
                   variable_scale: newVariableScale,
                   variable_range: variable_range,
                   quiverVariable: "None",
+                  default_location: currentDataset.default_location
                 });
                 setDatasetVariables(variableResult.data);
                 setDatasetTimestamps(timeData);

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -309,7 +309,29 @@ const MainMap = forwardRef((props, ref) => {
   }, [props.compareDatasets]);
 
   useEffect(() => {
-    if (props.dataset0.time > 0) {
+    if (props.dataset0.default_location) {
+      const newMapView = new View({
+        center: olProj.transform(
+          [
+            props.dataset0.default_location[0],
+            props.dataset0.default_location[1],
+          ],
+          "EPSG:4326",
+          "EPSG:3857"
+        ),
+        projection: "EPSG:3857",
+        zoom: props.dataset0.default_location[2],
+        maxZoom: MAX_ZOOM["EPSG:3857"],
+        minZoom: MIN_ZOOM["EPSG:3857"],
+      });
+      map0.setView(newMapView);
+      setMapView(newMapView);
+      props.updateMapSettings("projection", "EPSG:3857")
+    }
+  }, [props.dataset0.id]);
+
+  useEffect(() => {
+    if (props.dataset0.time >= 0) {
       layerData0.setSource(new XYZ(getDataSource(props.dataset0)));
     }
   }, [
@@ -321,7 +343,7 @@ const MainMap = forwardRef((props, ref) => {
   ]);
 
   useEffect(() => {
-    if (props.dataset1.time > 0) {
+    if (props.dataset1.time >= 0) {
       layerData1.setSource(new XYZ(getDataSource(props.dataset1)));
     }
   }, [
@@ -1508,10 +1530,16 @@ const MainMap = forwardRef((props, ref) => {
     if (map === map0) {
       setLayerBasemap(newLayerBasemap);
     }
+
+    let center = DEF_CENTER[props.mapSettings.projection]
+    if (props.dataset0.default_location){
+      center = props.dataset0.default_location
+    }
+    
     const newMapView = new View({
       projection: props.mapSettings.projection,
       center: olProj.transform(
-        DEF_CENTER[props.mapSettings.projection],
+        center,
         "EPSG:4326",
         props.mapSettings.projection
       ),

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -173,13 +173,7 @@ const MainMap = forwardRef((props, ref) => {
     });
 
     let projection = props.mapSettings.projection;
-    const newMapView = new View({
-      center: olProj.transform(DEF_CENTER[projection], "EPSG:4326", projection),
-      projection: projection,
-      zoom: 4,
-      maxZoom: MAX_ZOOM[projection],
-      minZoom: MIN_ZOOM[projection],
-    });
+    const newMapView = createMapView(center, projection, zoom);
 
     let newVectorSource = new VectorSource({
       features: [],
@@ -315,9 +309,11 @@ const MainMap = forwardRef((props, ref) => {
         props.dataset0.default_location[1],
       ];
       const newZoom = props.dataset0.default_location[2];
-      updateMapView(map0, newCenter, newZoom, "EPSG:3857");
-      if (props.compareDatasets){
-        updateMapView(map1, newCenter, newZoom, "EPSG:3857");
+      const newMapView = createMapView(newCenter, newZoom, "EPSG:3857");
+      map0.setView(newMapView);
+      props.updateMapSettings("projection", "EPSG:3857");
+      if (props.compareDatasets) {
+        map1.setView(newMapView);
       }
     }
   }, [props.dataset0.id]);
@@ -329,8 +325,10 @@ const MainMap = forwardRef((props, ref) => {
         props.dataset1.default_location[1],
       ];
       const newZoom = props.dataset1.default_location[2];
-      updateMapView(map0, newCenter, newZoom, "EPSG:3857");
-      updateMapView(map1, newCenter, newZoom, "EPSG:3857");
+      const newMapView = createMapView(newCenter, newZoom, "EPSG:3857");
+      map0.setView(newMapView);
+      map1.setView(newMapView);
+      props.updateMapSettings("projection", "EPSG:3857");
     }
   }, [props.dataset1.id]);
 
@@ -445,6 +443,18 @@ const MainMap = forwardRef((props, ref) => {
     props.mapSettings.bathyContour,
     props.mapSettings.topoShadedRelief,
   ]);
+
+  const createMapView = (center, zoom, projection) => {
+    const newMapView = new View({
+      center: olProj.transform(center, "EPSG:4326", projection),
+      projection: projection,
+      zoom: zoom,
+      maxZoom: MAX_ZOOM[projection],
+      minZoom: MIN_ZOOM[projection],
+    });
+
+    return newMapView;
+  };
 
   const createMap = (
     overlay,
@@ -1508,19 +1518,6 @@ const MainMap = forwardRef((props, ref) => {
         });
       },
     });
-  };
-
-  const updateMapView = (map, center, zoom, projection) => {
-    const newMapView = new View({
-      center: olProj.transform(center, "EPSG:4326", projection),
-      projection: projection,
-      zoom: zoom,
-      maxZoom: MAX_ZOOM[projection],
-      minZoom: MIN_ZOOM[projection],
-    });
-    map.setView(newMapView);
-    setMapView(newMapView);
-    props.updateMapSettings("projection", projection);
   };
 
   const updateProjection = (map, dataset) => {

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -310,25 +310,29 @@ const MainMap = forwardRef((props, ref) => {
 
   useEffect(() => {
     if (props.dataset0.default_location) {
-      const newMapView = new View({
-        center: olProj.transform(
-          [
-            props.dataset0.default_location[0],
-            props.dataset0.default_location[1],
-          ],
-          "EPSG:4326",
-          "EPSG:3857"
-        ),
-        projection: "EPSG:3857",
-        zoom: props.dataset0.default_location[2],
-        maxZoom: MAX_ZOOM["EPSG:3857"],
-        minZoom: MIN_ZOOM["EPSG:3857"],
-      });
-      map0.setView(newMapView);
-      setMapView(newMapView);
-      props.updateMapSettings("projection", "EPSG:3857")
+      const newCenter = [
+        props.dataset0.default_location[0],
+        props.dataset0.default_location[1],
+      ];
+      const newZoom = props.dataset0.default_location[2];
+      updateMapView(map0, newCenter, newZoom, "EPSG:3857");
+      if (props.compareDatasets){
+        updateMapView(map1, newCenter, newZoom, "EPSG:3857");
+      }
     }
   }, [props.dataset0.id]);
+
+  useEffect(() => {
+    if (props.dataset1.default_location) {
+      const newCenter = [
+        props.dataset1.default_location[0],
+        props.dataset1.default_location[1],
+      ];
+      const newZoom = props.dataset1.default_location[2];
+      updateMapView(map0, newCenter, newZoom, "EPSG:3857");
+      updateMapView(map1, newCenter, newZoom, "EPSG:3857");
+    }
+  }, [props.dataset1.id]);
 
   useEffect(() => {
     if (props.dataset0.time >= 0) {
@@ -1506,6 +1510,19 @@ const MainMap = forwardRef((props, ref) => {
     });
   };
 
+  const updateMapView = (map, center, zoom, projection) => {
+    const newMapView = new View({
+      center: olProj.transform(center, "EPSG:4326", projection),
+      projection: projection,
+      zoom: zoom,
+      maxZoom: MAX_ZOOM[projection],
+      minZoom: MIN_ZOOM[projection],
+    });
+    map.setView(newMapView);
+    setMapView(newMapView);
+    props.updateMapSettings("projection", projection);
+  };
+
   const updateProjection = (map, dataset) => {
     resetMap();
 
@@ -1531,11 +1548,11 @@ const MainMap = forwardRef((props, ref) => {
       setLayerBasemap(newLayerBasemap);
     }
 
-    let center = DEF_CENTER[props.mapSettings.projection]
-    if (props.dataset0.default_location){
-      center = props.dataset0.default_location
+    let center = DEF_CENTER[props.mapSettings.projection];
+    if (props.dataset0.default_location) {
+      center = props.dataset0.default_location;
     }
-    
+
     const newMapView = new View({
       projection: props.mapSettings.projection,
       center: olProj.transform(

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -173,7 +173,7 @@ const MainMap = forwardRef((props, ref) => {
     });
 
     let projection = props.mapSettings.projection;
-    const newMapView = createMapView(center, projection, zoom);
+    const newMapView = createMapView(DEF_CENTER[projection], projection, 4);
 
     let newVectorSource = new VectorSource({
       features: [],
@@ -309,7 +309,7 @@ const MainMap = forwardRef((props, ref) => {
         props.dataset0.default_location[1],
       ];
       const newZoom = props.dataset0.default_location[2];
-      const newMapView = createMapView(newCenter, newZoom, "EPSG:3857");
+      const newMapView = createMapView(newCenter, "EPSG:3857", newZoom);
       map0.setView(newMapView);
       props.updateMapSettings("projection", "EPSG:3857");
       if (props.compareDatasets) {
@@ -325,7 +325,7 @@ const MainMap = forwardRef((props, ref) => {
         props.dataset1.default_location[1],
       ];
       const newZoom = props.dataset1.default_location[2];
-      const newMapView = createMapView(newCenter, newZoom, "EPSG:3857");
+      const newMapView = createMapView(newCenter, "EPSG:3857", newZoom);
       map0.setView(newMapView);
       map1.setView(newMapView);
       props.updateMapSettings("projection", "EPSG:3857");
@@ -444,7 +444,7 @@ const MainMap = forwardRef((props, ref) => {
     props.mapSettings.topoShadedRelief,
   ]);
 
-  const createMapView = (center, zoom, projection) => {
+  const createMapView = (center, projection, zoom) => {
     const newMapView = new View({
       center: olProj.transform(center, "EPSG:4326", projection),
       projection: projection,

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -141,6 +141,7 @@ def datasets():
                 "group": config.group,
                 "subgroup": config.subgroup,
                 "time_dim_units": config.time_dim_units,
+                "default_location": config.default_location,
             }
         )
     return data
@@ -458,7 +459,6 @@ async def data(
     config = DatasetConfig(dataset)
 
     with open_dataset(config, variable=variable, timestamp=time) as ds:
-
         lat_var, lon_var = ds.nc_data.latlon_variables
 
         stride = config.vector_arrow_stride
@@ -588,7 +588,6 @@ def subset_query(
     time: str = Query(..., description="", example="2283984000,2283984000"),
     should_zip: str = Query("1", description="", example="1"),
 ):
-
     working_dir = None
     subset_filename = None
 

--- a/tests/test_api_v_2_0.py
+++ b/tests/test_api_v_2_0.py
@@ -292,9 +292,9 @@ class TestAPIv2:
 
         # response for each type of query
         response = []
-        response.append(self.client.get("/api/v2.0/kml/points"))
-        response.append(self.client.get("/api/v2.0/kml/lines"))
-        response.append(self.client.get("/api/v2.0/kml/areas"))
+        response.append(self.client.get("/api/v2.0/kml/point"))
+        response.append(self.client.get("/api/v2.0/kml/line"))
+        response.append(self.client.get("/api/v2.0/kml/area"))
         for resp in response:
             assert resp.status_code == 200
 
@@ -305,21 +305,21 @@ class TestAPIv2:
         # points
         response.append(
             self.client.get(
-                "/api/v2.0/kml/points/AZMP_Stations?projection=EPSG:3857"
+                "/api/v2.0/kml/point/AZMP_Stations?projection=EPSG:3857"
                 "&view_bounds=-15936951,1567587,4805001,12398409"
             )
         )
         # lines
         response.append(
             self.client.get(
-                "/api/v2.0/kml/lines/AZMP%20Transects?projection=EPSG:3857"
+                "/api/v2.0/kml/line/AZMP%20Transects?projection=EPSG:3857"
                 "&view_bounds=-15936951,1567587,4805001,12398409"
             )
         )
         # areas
         response.append(
             self.client.get(
-                "/api/v2.0/kml/areas/AZMP_NL_Region_Analysis_Areas?projection=EPSG:3857"
+                "/api/v2.0/kml/area/AZMP_NL_Region_Analysis_Areas?projection=EPSG:3857"
                 "&resolution=9784&view_bounds=-15936951,1567587,4805001,12398409"
             )
         )


### PR DESCRIPTION
## Background
This work allows the navigator to pan to a specific location and zoom level when the dataset is changed. To do so a `default_location` variable specifying the coordinates and zoom level needs to be added to the dataset entry in the datasetconfig.json file. This variable should be in the format `[lon, lat, zoom]`. This data is included in the `/datasets` API response and appended to the dataset object created by the DatasetSelector component. When the user selects a new dataset and clicks go an effect in the `MainMap` component checks the dataset object for the `default_location` variable. If present, a new OpenLayers view object is created with these coordinates and zoom level which causes the map to pan to the location. If this variable is not defined in the dataset config the map's center and zoom level are not changed. If the map is currently using an antarctic or arctic projection the map will be updated to the default EPSG:3857 projection to ensure that the data is viewable.

## Why did you take this approach?
Because these coordinates are specific to each dataset it makes sense to add them to the datasetconfig.json file. Once added to the dataset object in the front end a UseEffect hook in the MainMap component can easily check to see if the dataset has a `default_location` entry and update the map's view to change the location and zoom. 

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.
