### PR TITLE
Changes fixed for 'Go' button in plot windows, is now displaying correct.

### DIFF
--- a/oceannavigator/frontend/src/stylesheets/components/_AreaWindow.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_AreaWindow.scss
@@ -11,4 +11,11 @@
     display: flex;
     justify-content: center;
   }
+
+  .global-settings-card {
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 }

--- a/oceannavigator/frontend/src/stylesheets/components/_DatasetSelector.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_DatasetSelector.scss
@@ -36,7 +36,7 @@ div.quiver-options {
 
 .go-button {
   margin: 5px;
-  display: flex;
+
 }
 
 .go-button:hover {


### PR DESCRIPTION

## Background
"GO" button in all plot windows was not properly aligned. Now it is displaying evenly in all plot windows.

## Why did you take this approach?
Changes made in css.

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
