### PR TITLE
Fixed Dataset dropdown overlaps “variables” label

### DIFF
--- a/oceannavigator/frontend/src/stylesheets/components/_SelectBox.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_SelectBox.scss
@@ -23,6 +23,7 @@
   margin: 0;
   padding: 5;
   font-weight: bold;
+  margin-left: 6%;
 }
 
 .col {


### PR DESCRIPTION
## Background
Fixed Dataset dropdown overlaps “variables” label on dataset selector for some datasets. Now it is not overlapping for any of the dataset dropdown

## Why did you take this approach?
Since dataset dropdown was overlapping on “variables” label, I did some changes in CSS styling to fix it. 

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
