### PR TITLE
Fix Linear Threshold feature

### DIFF
--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -176,7 +176,7 @@ class LineWindow extends React.Component {
             style={{
               display:
                 this.props.dataset_compare &&
-                this.props.dataset_0.variable == this.props.dataset_1.variable
+                  this.props.dataset_0.variable == this.props.dataset_1.variable
                   ? "block"
                   : "none",
             }}
@@ -246,7 +246,7 @@ class LineWindow extends React.Component {
             style={{
               display:
                 this.props.dataset_compare &&
-                this.props.dataset_0.variable == this.props.dataset_1.variable
+                  this.props.dataset_0.variable == this.props.dataset_1.variable
                   ? "block"
                   : "none",
             }}
@@ -367,7 +367,7 @@ class LineWindow extends React.Component {
         plot_query.depth_limit = this.state.depth_limit;
         plot_query.selectedPlots = this.state.selectedPlots.toString();
         if (this.props.dataset_compare) {
-          plot_query.compare_to = {...this.props.dataset_1};
+          plot_query.compare_to = { ...this.props.dataset_1 };
           plot_query.compare_to.dataset = this.props.dataset_1.id;
           plot_query.compare_to.scale = this.state.scale_1;
           plot_query.compare_to.scale_diff = this.state.scale_diff;
@@ -382,7 +382,7 @@ class LineWindow extends React.Component {
         plot_query.starttime = this.props.dataset_0.starttime;
         plot_query.depth = this.props.dataset_0.depth;
         if (this.props.dataset_compare) {
-          plot_query.compare_to = {...this.props.dataset_1};
+          plot_query.compare_to = { ...this.props.dataset_1 };
           plot_query.compare_to.dataset = this.props.dataset_1.id;
           plot_query.compare_to.scale = this.state.scale_1;
           plot_query.compare_to.scale_diff = this.state.scale_diff;

--- a/oceannavigator/frontend/src/components/NumberBox.jsx
+++ b/oceannavigator/frontend/src/components/NumberBox.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Modal, Button } from "react-bootstrap";
-// import NumericInput from "react-numeric-input";
 import Icon from "./lib/Icon.jsx";
 import PropTypes from "prop-types";
 
@@ -28,9 +27,12 @@ class NumberBox extends React.Component {
   changed(num, str) {
     clearTimeout(this.timeout);
 
-    this.setState({
-      value: num,
-    });
+    num = Number(num)
+    if (!isNaN(num)) {
+      this.setState({
+        value: num,
+      });
+    }
 
     this.timeout = setTimeout(this.updateParent, 1250);
   }
@@ -91,7 +93,7 @@ class NumberBox extends React.Component {
           </Modal.Footer>
         </Modal>
 
-        <table className="numberbox-table"> 
+        <table className="numberbox-table">
           <tbody>
             <tr>
               <td>
@@ -104,7 +106,7 @@ class NumberBox extends React.Component {
                   className="table-input"
                   type="number"
                   value={this.state.value}
-                  onChange={this.changed}
+                  onChange={(e)=>this.changed(e.target.value)}
                 />
               </td>
             </tr>


### PR DESCRIPTION
## Background
It looks like the Linear Threshold feature was broken during the UI updated (v9.0). The issues appears to lie within the _NumberBox_ component where two problems occur: the underlying `<input>`'s event was passed to the `this.changed` event handler instead of just the event value and there was no validation in place to ensure that the received value was a number. 

To restore functionality we now just pass the event's value to the input change handler and added validation to ensure that this is a number. 

## Why did you take this approach?
Following best practices for a numeric input in React.

## Anything in particular that should be highlighted?
Fixed some code formatting in _LineWindow_ and _NumberBox_ components.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.