### PR TITLE
Fix NetCDF3 NC Subsetting

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -442,7 +442,7 @@ class NetCDFData(Data):
 
                 # Perform regridding using nearest neighbour weighting
                 regridded = pyresample.kd_tree.resample_nearest(
-                    input_def, data, output_def, 50000, fill_value=None, nprocs=8
+                    input_def, data, output_def, 50000, fill_value=None
                 )
                 # Move merged axis back to front
                 regridded = np.moveaxis(regridded, -1, 0)


### PR DESCRIPTION
## Background
Norm notified us of an issue encountered when subsetting an area with NetCDF3 NC format. The subset request fails and returns  a "daemonic processes are not allowed to have children" error message from the multiprocessing library. The cause of this error appears to be the _nprocs_ argument passed to the `pyresample.kd_tree.resample_nearest` function triggering the use of multiprocessing to handle the resampling operation which raises the error. Removing this argument fixes the issue but may lead to a performance hit on large resampling operations though this has not been an noticeable during testing. 

## Why did you take this approach?
Async operations cannot spawn child operations so removing the _nprocs_ argument is the most direct way to fix this issue.

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.
