### PR TITLE
Add Hide Data Layer button to MapInputs panel

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -4,6 +4,8 @@ import Slider from "rc-slider";
 import { Modal, ProgressBar, Button, Form } from "react-bootstrap";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 import AxisRange from "./AxisRange.jsx";
 import DatasetDropdown from "./DatasetDropdown.jsx";
@@ -570,6 +572,17 @@ function DatasetSelector(props) {
     />
   ) : null;
 
+  const hideDataSwitch = props.showCompare ? (
+    <Button
+      className="new-tab-button"
+      onClick={() => {
+        props.updateMapSettings("hideDataLayer", !props.mapSettings.hideDataLayer)
+      }}
+    >
+      <FontAwesomeIcon icon={faEyeSlash} />
+    </Button>
+  ) : null;
+
   return (
     <>
       <div
@@ -589,6 +602,7 @@ function DatasetSelector(props) {
         {props.horizontalLayout ? null : timeSelector}
         {props.horizontalLayout ? goButton : null}
         {props.showCompare ? compareSwitch : null}
+        {props.showCompare ? hideDataSwitch : null}
       </div>
       {props.horizontalLayout ? timeSelector : null}
       {props.horizontalLayout ? null : goButton}

--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -4,8 +4,6 @@ import Slider from "rc-slider";
 import { Modal, ProgressBar, Button, Form } from "react-bootstrap";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 import AxisRange from "./AxisRange.jsx";
 import DatasetDropdown from "./DatasetDropdown.jsx";
@@ -572,17 +570,6 @@ function DatasetSelector(props) {
     />
   ) : null;
 
-  const hideDataSwitch = props.showCompare ? (
-    <Button
-      className="new-tab-button"
-      onClick={() => {
-        props.updateMapSettings("hideDataLayer", !props.mapSettings.hideDataLayer)
-      }}
-    >
-      <FontAwesomeIcon icon={faEyeSlash} />
-    </Button>
-  ) : null;
-
   return (
     <>
       <div
@@ -602,7 +589,6 @@ function DatasetSelector(props) {
         {props.horizontalLayout ? null : timeSelector}
         {props.horizontalLayout ? goButton : null}
         {props.showCompare ? compareSwitch : null}
-        {props.showCompare ? hideDataSwitch : null}
       </div>
       {props.horizontalLayout ? timeSelector : null}
       {props.horizontalLayout ? null : goButton}

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -1711,6 +1711,9 @@ const MainMap = forwardRef((props, ref) => {
     }
   }
 
+  layerData0.setVisible(!props.mapSettings.hideDataLayer)
+  layerData1.setVisible(!props.mapSettings.hideDataLayer)
+
   return (
     <div className="map-container">
       <div className="title ol-popup" ref={popupElement0} />

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -36,6 +36,7 @@ function MapInputs(props) {
             id="dataset_0"
             onUpdate={props.updateDataset0}
             mapSettings={props.mapSettings}
+            updateMapSettings={props.updateMapSettings}
             action={props.action}
             horizontalLayout={true}
             showTimeSlider={!props.compareDatasets}

--- a/oceannavigator/frontend/src/components/MapInputs.jsx
+++ b/oceannavigator/frontend/src/components/MapInputs.jsx
@@ -1,8 +1,15 @@
 import React from "react";
+import Button from "react-bootstrap/Button";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Tooltip from "react-bootstrap/Tooltip";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 
 import DatasetSelector from "./DatasetSelector.jsx";
 import DrawingTools from "./DrawingTools.jsx";
 import ObservationTools from "./ObservationTools.jsx";
+
+import { withTranslation } from "react-i18next";
 
 function MapInputs(props) {
 
@@ -24,6 +31,21 @@ function MapInputs(props) {
     />
   ) : null;
 
+  const hideDataSwitch = props.showCompare ? (
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip id="tooltip">{__("Hide Data Layer")}</Tooltip>}
+    >
+      <Button
+        className={`hide-data-button ${props.compareDatasets ? "hide-data-button-compare" : ""}`}
+        onClick={() => {
+          props.updateMapSettings("hideDataLayer", !props.mapSettings.hideDataLayer)
+        }}
+      >
+        <FontAwesomeIcon icon={faEyeSlash} size="2xs" />
+      </Button>
+    </OverlayTrigger>
+  ) : null;
 
   return (
     <div className="map-inputs-container">
@@ -36,13 +58,13 @@ function MapInputs(props) {
             id="dataset_0"
             onUpdate={props.updateDataset0}
             mapSettings={props.mapSettings}
-            updateMapSettings={props.updateMapSettings}
             action={props.action}
             horizontalLayout={true}
             showTimeSlider={!props.compareDatasets}
             showCompare={props.showCompare}
             compareDatasets={props.compareDatasets}
           />
+          {props.showCompare ? hideDataSwitch : null}
         </div>
         {props.compareDatasets ? (
           <div
@@ -64,4 +86,4 @@ function MapInputs(props) {
   );
 }
 
-export default MapInputs;
+export default withTranslation()(MapInputs);

--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -49,6 +49,7 @@ function OceanNavigator(props) {
     projection: "EPSG:3857", // Map projection
     basemap: "topo",
     extent: [],
+    hideDataLayer: false,
     ...MAP_DEFAULTS,
   });
   const [uiSettings, setUiSettings] = useState({
@@ -474,6 +475,7 @@ function OceanNavigator(props) {
         dataset0={dataset0}
         dataset1={dataset1}
         mapSettings={mapSettings}
+        updateMapSettings={updateMapSettings}
         updateDataset0={updateDataset0}
         updateDataset1={updateDataset1}
         uiSettings={uiSettings}

--- a/oceannavigator/frontend/src/stylesheets/components/_MapInputs.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_MapInputs.scss
@@ -25,3 +25,17 @@
   flex-direction: column;
   justify-content: flex-start;
 }
+
+.hide-data-button {
+  position: absolute;
+  top: 0px;
+  right: calc(5%);
+  height: 20px;
+  width: 20px;
+  justify-content: center;
+  display: flex;
+}
+
+.hide-data-button-compare {
+  right: calc(50.5%) !important;
+}

--- a/oceannavigator/translations/fr.json
+++ b/oceannavigator/translations/fr.json
@@ -106,6 +106,7 @@
     "Greyscale": "Greyscale",
     "Height:": "Hauteur:",
     "Help": "Aide",
+    "Hide Data Layer": "Masquer la Couche de Données",
     "Hovmöller Diagram": "Diagramme Hovmöller",
     "Hovmöller Diagram(s) for:\n%s": "Hovmöller Diagramme(s) pour:\n%s",
     "IMEI": "IMEI",


### PR DESCRIPTION
## Background
We received a request to provide a way to hide the data layer so that users can view the bathymetry below. A practical solution was to add a _Hide Data Layer_ button to the MapInputs panel which toggles the data layer's visibility in the MainMap component via the `mapSettings` prop.

## Why did you take this approach?
This is a intuitive way to allow users to hide the data layer and was straightforward to implement. 

## Anything in particular that should be highlighted?
The button currently only toggles the data layer. Other layers, such as drawing layers, quivers, and observations, can easily be added to this functionality if requested.  

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/37c69a26-b569-4931-ad68-abe960d2f00c)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.