### PR TITLE
Seawater to gsw

### DIFF
--- a/config/conda/environment.yml
+++ b/config/conda/environment.yml
@@ -97,6 +97,7 @@ dependencies:
   - greenlet=3.0.2=py312h30efb56_0
   - gst-plugins-base=1.22.7=h8e1006c_1
   - gstreamer=1.22.7=h98fc4e7_1
+  - gsw=3.6.17=py312hc7c0aa3_1
   - h11=0.14.0=pyhd8ed1ab_0
   - h2=4.1.0=pyhd8ed1ab_0
   - harfbuzz=8.3.0=h3d44ed6_0
@@ -382,7 +383,7 @@ dependencies:
   - zlib-ng=2.0.7=h0b41bf4_0
   - zstd=1.5.5=hfc55251_0
   - pip:
-    - pydantic-settings==2.1.0
-    - python-dotenv==1.0.0
-    - visvalingamwyatt==0.2.0
-prefix: /home/ubuntu/onav-cloud/tools/miniconda/envs/navigator
+      - pydantic-settings==2.1.0
+      - python-dotenv==1.0.0
+      - visvalingamwyatt==0.2.0
+prefix: /home/ubuntu/onav-cloud/tools/miniconda/3/amd64/envs/navigator

--- a/config/conda/environment.yml
+++ b/config/conda/environment.yml
@@ -312,7 +312,6 @@ dependencies:
   - s2n=1.4.0=h06160fa_0
   - scikit-image=0.22.0=py312hfb8ada1_2
   - scipy=1.11.4=py312heda63a1_0
-  - seawater=3.3.4=py_1
   - sentry-sdk=1.39.0=pyhd8ed1ab_0
   - setuptools=68.2.2=pyhd8ed1ab_0
   - shapely=2.0.2=py312h9e6bd2c_1

--- a/config/conda/navigator-spec-file.txt
+++ b/config/conda/navigator-spec-file.txt
@@ -344,7 +344,6 @@ https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.2-pyhd8ed1ab_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/pykdtree-1.3.10-py312hc7c0aa3_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.4.1-py312hc7c0aa3_1.conda
 https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py312heda63a1_0.conda
-https://conda.anaconda.org/conda-forge/noarch/seawater-3.3.4-py_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py312h9e6bd2c_1.conda
 https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-h967ea9e_4.conda
 https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.2-pyhd8ed1ab_0.conda

--- a/config/conda/navigator-spec-file.txt
+++ b/config/conda/navigator-spec-file.txt
@@ -327,6 +327,7 @@ https://conda.anaconda.org/conda-forge/noarch/colorspacious-1.1.2-pyh24bf2e0_0.t
 https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py312h8572e83_0.conda
 https://conda.anaconda.org/conda-forge/noarch/dask-core-2023.12.0-pyhd8ed1ab_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.7-h8e1006c_1.conda
+https://conda.anaconda.org/conda-forge/linux-64/gsw-3.6.17-py312hc7c0aa3_1.conda
 https://conda.anaconda.org/conda-forge/noarch/httpx-0.26.0-pyhd8ed1ab_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/hypercorn-0.14.3-py312h7900ff3_2.conda
 https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2023.9.18-py312ha6884dc_2.conda

--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -120,15 +120,14 @@ def unstaggered_speed(u_vel, v_vel):
 def __calc_pressure(depth, latitude):
     pressure = []
     try:
-        pressure = [gsw.conversions.p_from_z(d,latitude) for d in depth]
+        pressure = [gsw.conversions.p_from_z(d, latitude) for d in depth]
     except TypeError:
-        pressure = gsw.conversions.p_from_z(depth,latitude)
+        pressure = gsw.conversions.p_from_z(depth, latitude)
 
     return np.array(pressure)
 
 
 def __validate_depth_lat_temp_sal(depth, latitude, temperature, salinity):
-
     if type(depth) is not np.ndarray:
         depth = np.array(depth)
 
@@ -145,7 +144,6 @@ def __validate_depth_lat_temp_sal(depth, latitude, temperature, salinity):
 
 
 def __find_depth_index_of_min_value(data: np.ndarray, depth_axis=0) -> np.ndarray:
-
     if not np.ma.is_masked(data):
         # Mask out NaN values to prevent an exception blow-up.
         masked = np.ma.masked_array(data, np.isnan(data))
@@ -157,7 +155,6 @@ def __find_depth_index_of_min_value(data: np.ndarray, depth_axis=0) -> np.ndarra
 
 
 def __find_depth_index_of_max_value(data: np.ndarray, depth_axis=0) -> np.ndarray:
-
     if not np.ma.is_masked(data):
         # Mask out NaN values to prevent an exception blow-up.
         masked = np.ma.masked_array(data, np.isnan(data))
@@ -178,7 +175,7 @@ def oxygensaturation(temperature: np.ndarray, salinity: np.ndarray) -> np.ndarra
     * temperature: temperature values in Celsius.
     * salinity: salinity values.
     """
-    
+
     return gsw.O2sol_SP_pt(salinity, temperature)
 
 
@@ -203,7 +200,7 @@ def nitrogensaturation(temperature: np.ndarray, salinity: np.ndarray) -> np.ndar
         transposed = True
     x = salinity
     T0 = 273.15
-    y = np.log((298.15 - temperature)/(T0 + temperature))
+    y = np.log((298.15 - temperature) / (T0 + temperature))
     # The coefficents below are from Table 4 of Hamme and Emerson (2004)
     a0 = 6.42931
     a1 = 2.92704
@@ -213,7 +210,7 @@ def nitrogensaturation(temperature: np.ndarray, salinity: np.ndarray) -> np.ndar
     b1 = -8.02566e-3
     b2 = -1.46775e-2
 
-    N2sol = np.exp(a0 + y*(a1 + y*(a2 + a3*y)) + x*(b0 + y*(b1 + b2*y)))
+    N2sol = np.exp(a0 + y * (a1 + y * (a2 + a3 * y)) + x * (b0 + y * (b1 + b2 * y)))
 
     if transposed:
         N2sol = np.transpose(N2sol)
@@ -329,7 +326,6 @@ def __get_soniclayerdepth_mask(
 def __soniclayerdepth_from_sound_speed(
     soundspeed: np.ndarray, depth: np.ndarray
 ) -> np.ndarray:
-
     min_indices = __find_depth_index_of_min_value(soundspeed)
 
     mask = __get_soniclayerdepth_mask(soundspeed, min_indices)

--- a/plotting/sound.py
+++ b/plotting/sound.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as tkr
 import numpy as np
 import pint
-import seawater
+import gsw
 
 import plotting.utils as utils
 from plotting.ts import TemperatureSalinityPlotter
@@ -19,7 +19,7 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
         super(SoundSpeedPlotter, self).load_data()
 
         self.pressure = [
-            seawater.pres(self.temperature_depths[idx], ll[0])
+            gsw.conversions.p_from_z(self.temperature_depths[idx], ll[0])
             for idx, ll in enumerate(self.points)
         ]
 
@@ -39,7 +39,7 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
         else:
             temperature_c = self.temperature
 
-        self.sspeed = seawater.svel(self.salinity, temperature_c, self.pressure)
+        self.sspeed = gsw.sound_speed(self.salinity, temperature_c, self.pressure)
 
     def plot(self):
         # Create base figure

--- a/plotting/ts.py
+++ b/plotting/ts.py
@@ -3,7 +3,7 @@ import re
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
-import seawater
+import gsw
 
 import plotting.utils as utils
 from data import open_dataset
@@ -117,7 +117,7 @@ class TemperatureSalinityPlotter(PointPlotter):
 
         for j in range(0, int(ydim)):
             for i in range(0, int(xdim)):
-                dens[j, i] = seawater.dens(si[i], ti[j], 0)
+                dens[j, i] = gsw.density.rho(si[i], ti[j], 0)
 
         dens -= 1000
 

--- a/scripts/data_importers/argo.py
+++ b/scripts/data_importers/argo.py
@@ -5,7 +5,7 @@ import os
 
 import defopt
 import pandas as pd
-import seawater
+import gsw
 import xarray as xr
 
 import data.observational
@@ -84,7 +84,7 @@ def main(uri: str, filename: str):
                 # We need to commit the station here so that it'll have an id
                 session.commit()
 
-                depth = seawater.dpth(
+                depth = gsw.conversions.z_from_p(
                     ds.PRES[prof].dropna("N_LEVELS").values, ds.LATITUDE.values[prof]
                 )
 

--- a/scripts/data_importers/glider.py
+++ b/scripts/data_importers/glider.py
@@ -4,7 +4,7 @@ import glob
 import os
 
 import defopt
-import seawater
+import gsw
 import xarray as xr
 
 import data.observational
@@ -39,7 +39,7 @@ def main(uri: str, filename: str):
                 .dropna()
             )
 
-            df["DEPTH"] = seawater.dpth(df.PRES, df.LATITUDE)
+            df["DEPTH"] = gsw.conversions.z_from_p(df.PRES, df.LATITUDE)
 
             for variable in variables:
                 if variable not in datatype_map:

--- a/scripts/data_importers/nafc_ctd.py
+++ b/scripts/data_importers/nafc_ctd.py
@@ -5,7 +5,7 @@ import os
 
 import defopt
 import pandas as pd
-import seawater
+import gsw
 import xarray as xr
 
 import data.observational
@@ -72,7 +72,7 @@ def main(uri: str, filename: str):
             p.stations.append(s)
             data.observational.db.session.commit()
 
-            ds["level"] = seawater.dpth(ds.level.values, ds.latitude[0].values)
+            ds["level"] = gsw.conversions.z_from_p(ds.level.values, ds.latitude[0].values)
 
             # Generate the samples
             for var, dt in datatype_map.items():

--- a/scripts/data_importers/seal.py
+++ b/scripts/data_importers/seal.py
@@ -6,7 +6,7 @@ import os
 import defopt
 import numpy as np
 import pandas as pd
-import seawater
+import gsw
 import xarray as xr
 
 import data.observational
@@ -63,7 +63,7 @@ def main(uri: str, filename: str):
         with xr.open_dataset(fname) as ds:
             ds["TIME"] = ds.JULD.to_index().to_datetimeindex()
             ds["TIME"] = ds.TIME.swap_dims({"TIME": "N_PROF"})
-            depth = seawater.dpth(
+            depth = gsw.conversions.z_from_p(
                 ds.PRES_ADJUSTED,
                 np.tile(ds.LATITUDE, (ds.PRES.shape[1], 1)).transpose(),
             )

--- a/scripts/pfile.py
+++ b/scripts/pfile.py
@@ -7,7 +7,7 @@ or to use the file as a Pandas Dataframe.
 import dateutil
 import numpy as np
 import pandas as pd
-import seawater
+import gsw
 
 SHIP_NUMBERS = {
     "00": "Unknown",
@@ -192,7 +192,7 @@ class PFile:
         )
 
         if "pres" in self.dataframe.columns.values:
-            self.dataframe["depth"] = seawater.eos80.dpth(
+            self.dataframe["depth"] = gsw.conversions.z_from_p(
                 self.dataframe["pres"], self.meta["latitude"]
             )
 


### PR DESCRIPTION
## Background
seawater package is deprecated. Replaced with gsw

## Why did you take this approach?
gsw uses the TEOS-10 instead of the EOS-80 used by 'seawater' which is now considered obsolete

## Anything in particular that should be highlighted?
tempgradient() function now returns result in K/Pa rather than C/db. This change needs to be reflected in configs branch

## Screenshot(s)


## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
