### PR TITLE
area plot crash fix

### DIFF
--- a/oceannavigator/frontend/src/components/ComboBox.jsx
+++ b/oceannavigator/frontend/src/components/ComboBox.jsx
@@ -175,7 +175,8 @@ class ComboBox extends React.Component {
                     if (
                       d.hasOwnProperty(key) &&
                       key != "id" &&
-                      key != "value"
+                      key != "value" &&
+                      d[key] != null
                     ) {
                       this.props.onUpdate(this.props.id + "_" + key, d[key]);
                     }
@@ -201,7 +202,7 @@ class ComboBox extends React.Component {
           const d = props.data[i];
           if (d.id == value) {
             for (var key in d) {
-              if (d.hasOwnProperty(key) && key != "id" && key != "value") {
+              if (d.hasOwnProperty(key) && key != "id" && key != "value" && d[key] != null) {
                 props.onUpdate(props.id + "_" + key, d[key]);
               }
             }


### PR DESCRIPTION
## Background
Issue #1105 . While dataset is loading the values are set to null which causes a crash on update.

## Why did you take this approach?
I edited the ComboBox.js file to skip the update if the values from 'dataset0' are null. This will skip the updates that happen while the dataset is loading. 

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
