### PR TITLE
Fix Colormap Range "Auto" Function

### DIFF
--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -55,8 +55,8 @@ def get_mimetype(filetype: str):
 
 
 def normalize_scale(data, variable_config):
-    vmin = np.amin(data)
-    vmax = np.amax(data)
+    vmin = float(np.amin(data))
+    vmax = float(np.amax(data))
 
     if variable_config.is_zero_centered:
         vmax = max(abs(vmax), abs(vmin))


### PR DESCRIPTION
## Background
Since updating to Python 3.12 I noticed that the _Auto_ function on the colormap range selector was not updating the range values when clicked. The query returns error 500.  This was due to the endpoint returning numpy.float64 type values which are not compatible with json. To fix the problem the `normalize_scale` function casts the min and max values of the data array to regular python floats. 

## Why did you take this approach?
Castling This ensures that the return values are json compatible and does not affect their values. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
