### PR TITLE
Fix EnterCoordsWindow crash

### DIFF
--- a/oceannavigator/frontend/src/components/EnterCoordsWindow.jsx
+++ b/oceannavigator/frontend/src/components/EnterCoordsWindow.jsx
@@ -46,13 +46,8 @@ function EnterCoordsWindow(props) {
     clearTimeout(timer);
     setTimer(
       setTimeout(
-        props.action(
-          "updatePoint",
-          parseInt(e.target.id),
-          0,
-          parseFloat(e.target.value)
-        ),
-        500
+        updateCoordinate(parseInt(e.target.id), 0, parseFloat(e.target.value)),
+        1000
       )
     );
   };
@@ -61,16 +56,17 @@ function EnterCoordsWindow(props) {
     clearTimeout(timer);
     setTimer(
       setTimeout(
-        props.action(
-          "updatePoint",
-          parseInt(e.target.id),
-          1,
-          parseFloat(e.target.value)
-        ),
-        500
+        updateCoordinate(parseInt(e.target.id), 1, parseFloat(e.target.value)),
+        1000
       )
     );
   };
+
+  const updateCoordinate = (row, col, value) => {
+    if (!isNaN(value)) {
+      props.action("updatePoint", row, col, value)
+    }
+  }
 
   const handleClear = () => {
     props.action("clearPoints");


### PR DESCRIPTION
## Background
The coordinate fields in the `EnterCoordsWindow` caused the Navigator to crash when the values were deleted. To resolved we added some additional input validation before updating the `vectorCoords` prop to avoid the crash.

## Why did you take this approach?
This approach ensures that valid values are passed to the `vectorCoords` prop which is mapped to the input fields. 

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

