### PR TITLE
fixed slicing for netcdf subset

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -316,23 +316,35 @@ class NetCDFData(Data):
         # calculated variables.
         if not entire_globe:
             # Find closest indices in dataset corresponding to each calculated point
-            ymin_index, xmin_index, _ = find_nearest_grid_point(
+            y0_index, x0_index, _ = find_nearest_grid_point(
                 bottom_left[0],
                 bottom_left[1],
                 self.get_dataset_variable(lat_var),
                 self.get_dataset_variable(lon_var),
             )
-            ymax_index, xmax_index, _ = find_nearest_grid_point(
-                top_right[0],
-                top_right[1],
-                self.get_dataset_variable(lat_var),
-                self.get_dataset_variable(lon_var),
-            )
+            y1_index, x1_index, _ = find_nearest_grid_point(
+                            top_right[0],
+                            top_right[1],
+                            self.get_dataset_variable(lat_var),
+                            self.get_dataset_variable(lon_var),
+                        )
+            y2_index, x2_index, _ = find_nearest_grid_point(
+                            bottom_left[0],
+                            top_right[1],
+                            self.get_dataset_variable(lat_var),
+                            self.get_dataset_variable(lon_var),
+                        )
+            y3_index, x3_index, _ = find_nearest_grid_point(
+                            top_right[0],
+                            bottom_left[1],
+                            self.get_dataset_variable(lat_var),
+                            self.get_dataset_variable(lon_var),
+                        )
 
             # Compute min/max for each slice in case the values are flipped
             # the netCDF4 module does not support unordered slices
-            y_slice = slice(min(ymin_index, ymax_index), max(ymin_index, ymax_index))
-            x_slice = slice(min(xmin_index, xmax_index), max(xmin_index, xmax_index))
+            y_slice = slice(min(y0_index, y1_index, y2_index, y3_index), max(y0_index, y1_index, y2_index, y3_index))
+            x_slice = slice(min(x0_index, x1_index, x2_index, x3_index), max(x0_index, x1_index, x2_index, x3_index))
 
             # Get nicely formatted bearings
             p0 = geopy.Point(bottom_left)


### PR DESCRIPTION
## Background
#1106 

## Why did you take this approach?
Taking all 4 corners allows for proper slicing despite RIOPS' irregular grid

## Anything in particular that should be highlighted?
Depending on location, subset may have rotated orientation however the data is correct

## Screenshot(s)
Selected area:
<img width="242" alt="Screenshot 2024-02-27 100042" src="https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/a20164bd-80db-4472-a245-07af2cf12e90">

Before:
<img width="315" alt="Screenshot 2024-02-27 100016" src="https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/341c352a-954b-4883-a858-5d9eab0560bb">

After:
<img width="319" alt="Screenshot 2024-02-27 100135" src="https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/7d32e1c9-e64d-4939-8792-c0508b91e44a">



## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
