### PR TITLE
Limit points in timeseries plot

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -996,6 +996,10 @@ class NetCDFData(Data):
                 raise RuntimeError("Error finding timestamp(s) in database.")
 
             file_list = db.get_netcdf_files(timestamp, variables_to_load)
+            if len(file_list) > 50:
+                file_list = np.array(file_list)
+                idx = np.linspace(0, file_list.size - 1, 50, dtype=int)
+                file_list = file_list[idx].tolist()
             if not file_list:
                 raise RuntimeError("NetCDF file list is empty.")
 


### PR DESCRIPTION
## Background
VM/Timeseries plot requests covering more than ~50 timestamps have historically taken longer than the 5 minute response time limit allotted to Navigator queries. In the past we have limited the timepicker components so that users cannot select timespans greater than 50 timestamps but this was dropped when the UI was refactored last year. Instead of taking a similar approach I opted to subsample the timestamps so than users can request timeseries plots over any length of time but the result plot will only have a maximum of 50 points.    

## Why did you take this approach?
Unlike the previous approach described above, this allows users to plot any length of timeseries.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.