### PR TITLE
'Dataset Dropdown covers Variable Selector for some datasets' fix

### DIFF
--- a/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
@@ -16,8 +16,7 @@
 
   .dd-toggle {
     display: flex;
-    flex: 1;
-    width: 100%;
+    width: 300px;
     font-size: 10pt;
     font-weight: 400;
     line-height: 1.5;
@@ -54,6 +53,8 @@
     background-color: #fff;
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23333' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
     background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    background-size: 16px 12px;
     margin-left: 5px;
   }
 

--- a/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
@@ -16,6 +16,7 @@
 
   .dd-toggle {
     display: flex;
+    flex: 1;
     width: 100%;
     font-size: 10pt;
     font-weight: 400;
@@ -53,8 +54,6 @@
     background-color: #fff;
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23333' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
     background-repeat: no-repeat;
-    background-position: right 0.5rem center;
-    background-size: 16px 12px;
     margin-left: 5px;
   }
 


### PR DESCRIPTION


## Background
#1123 

## Why did you take this approach?
Added 'flex: 1' so that the dataset dropdown div covered the area of it's child components. However this caused the dropdown icon to overlap so I adjusted the 'dd-toggle-caret' style as well.

## Anything in particular that should be highlighted?
Not sure if the edits to 'dd-toggle-caret' look bad elsewhere but couldn't find any issues myself

## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
