### PR TITLE
include quiver when updating map from mountedDataset

### DIFF
--- a/oceannavigator/frontend/src/components/DatasetSelector.jsx
+++ b/oceannavigator/frontend/src/components/DatasetSelector.jsx
@@ -80,6 +80,8 @@ function DatasetSelector(props) {
         setLoadingPercent(33);
         let newVariable = currentVariable;
         let newVariableScale = props.mountedDataset.variable_scale;
+        let newQuiver = props.mountedDataset.quiverVariable;
+        let newQuiverDensity = props.mountedDataset.quiverDensity;
         let variable_range = {};
         variable_range[newVariable] = null;
         let interpType = props.mapSettings.interpType;
@@ -142,8 +144,8 @@ function DatasetSelector(props) {
                   variable: newVariable,
                   variable_scale: newVariableScale,
                   variable_range: variable_range,
-                  quiverVariable: "None",
-                  quiverDensity: 0,
+                  quiverVariable: newQuiver,
+                  quiverDensity: newQuiverDensity,
                   default_location: currentDataset.default_location
                 });
                 setDatasetVariables(variableResult.data);


### PR DESCRIPTION
## Background
on #1116 I overlooked including quiver when updating the map from mountedDataset. Added now so that "Get Link" will include state of quiverVariable and quiverDensity

## Why did you take this approach?
Copied the process used for the other variables in moountedDataset

## Anything in particular that should be highlighted?


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
