### PR TITLE
Add scale selector to AreaWindow

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -14,6 +14,7 @@ import SubsetPanel from "./SubsetPanel.jsx";
 import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
+import { formToJSON } from "axios";
 
 class AreaWindow extends React.Component {
   constructor(props) {
@@ -24,8 +25,8 @@ class AreaWindow extends React.Component {
 
     this.state = {
       currentTab: 1, // Currently selected tab
-      scale: props.dataset_0.variable_scale,
-      scale_1: props.dataset_1.variable_scale_1,
+      scale: props.dataset_0.variable_scale[0] + "," +props.dataset_0.variable_scale[1] + ",auto",
+      scale_1: props.dataset_1.scale_1 + ",auto",
       scale_diff: "-10,10,auto",
       leftColormap: "default",
       rightColormap: "default",
@@ -191,6 +192,14 @@ class AreaWindow extends React.Component {
             {_("Swap Views")}
           </Button>
 
+          <ColormapRange
+            auto
+            key="scale"
+            id="scale"
+            state={this.state.scale}
+            onUpdate={this.onLocalUpdate}
+          />
+
           <div
             style={{
               display:
@@ -200,17 +209,7 @@ class AreaWindow extends React.Component {
                   : "none",
             }}
           >
-            <ColormapRange
-              //auto
-              min={this.state.scale[0]}
-              max={this.state.scale[1]}
-              key="scale_diff"
-              id="scale_diff"
-              state={this.state.scale_diff}
-              def={""}
-              onUpdate={this.onLocalUpdate}
-              title={_("Diff. Variable Range")}
-            />
+            
             <ComboBox
               key="colormap_diff"
               id="colormap_diff"
@@ -296,7 +295,6 @@ class AreaWindow extends React.Component {
             onUpdate={this.props.updateDataset0}
             showQuiverSelector={false}
             showVariableRange={false}
-            showAxisRange={true}
             mapSettings={this.props.mapSettings}
             mountedDataset={this.props.dataset_0}
           />

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -25,7 +25,7 @@ class AreaWindow extends React.Component {
 
     this.state = {
       currentTab: 1, // Currently selected tab
-      scale: props.dataset_0.variable_scale[0] + "," +props.dataset_0.variable_scale[1] + ",auto",
+      scale: props.dataset_0.variable_scale + ",auto",
       scale_1: props.dataset_1.scale_1 + ",auto",
       scale_diff: "-10,10,auto",
       leftColormap: "default",
@@ -116,6 +116,16 @@ class AreaWindow extends React.Component {
         return;
       }
 
+      if (key === "scale") {
+        if (value.constructor === Array){
+          value = value[0] + ',' + value[1]
+        }
+        this.setState((prevState) => ({
+          scale: value
+        }));
+        return;
+      }
+
       let newState = {};
       if (typeof key === "string") {
         newState[key] = value;
@@ -196,7 +206,7 @@ class AreaWindow extends React.Component {
             auto
             key="scale"
             id="scale"
-            state={this.state.scale}
+            state={this.state.scale.split(',')}
             onUpdate={this.onLocalUpdate}
           />
 

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -24,8 +24,8 @@ class AreaWindow extends React.Component {
 
     this.state = {
       currentTab: 1, // Currently selected tab
-      scale: props.dataset_0.scale + ",auto",
-      scale_1: props.dataset_1.scale_1 + ",auto",
+      scale: props.dataset_0.variable_scale,
+      scale_1: props.dataset_1.variable_scale_1,
       scale_diff: "-10,10,auto",
       leftColormap: "default",
       rightColormap: "default",
@@ -201,7 +201,9 @@ class AreaWindow extends React.Component {
             }}
           >
             <ColormapRange
-              auto
+              //auto
+              min={this.state.scale[0]}
+              max={this.state.scale[1]}
               key="scale_diff"
               id="scale_diff"
               state={this.state.scale_diff}
@@ -294,6 +296,7 @@ class AreaWindow extends React.Component {
             onUpdate={this.props.updateDataset0}
             showQuiverSelector={false}
             showVariableRange={false}
+            showAxisRange={true}
             mapSettings={this.props.mapSettings}
             mountedDataset={this.props.dataset_0}
           />

--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -87,6 +87,12 @@ class AreaWindow extends React.Component {
     this._mounted = false;
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.dataset_0.variable !== prevProps.dataset_0.variable) {
+      this.setState({ scale: this.props.dataset_0.variable_scale + ",auto", })
+    }
+  }
+
   //Updates Plot with User Specified Title
   updatePlotTitle(title) {
     if (title !== this.state.plotTitle) {
@@ -117,12 +123,10 @@ class AreaWindow extends React.Component {
       }
 
       if (key === "scale") {
-        if (value.constructor === Array){
+        if (value.constructor === Array) {
           value = value[0] + ',' + value[1]
         }
-        this.setState((prevState) => ({
-          scale: value
-        }));
+        this.setState({ scale: value });
         return;
       }
 
@@ -136,6 +140,12 @@ class AreaWindow extends React.Component {
       }
       this.setState(newState);
     }
+  }
+
+  compareChanged(checked) {
+    let newScale = checked ? "-10,10,auto" : this.props.dataset_0.variable_scale + ",auto"
+    this.setState({ scale: newScale });
+    this.props.setCompareDatasets(checked)
   }
 
   onTabChange(index) {
@@ -188,7 +198,7 @@ class AreaWindow extends React.Component {
             id="dataset_compare"
             key="dataset_compare"
             checked={this.props.dataset_compare}
-            onUpdate={(_, checked) => this.props.setCompareDatasets(checked)}
+            onUpdate={(_, checked) => this.compareChanged(checked)}
             title={_("Compare Datasets")}
           />
 
@@ -214,12 +224,12 @@ class AreaWindow extends React.Component {
             style={{
               display:
                 this.props.dataset_compare &&
-                this.state.dataset_0.variable == this.props.dataset_1.variable
+                  this.state.dataset_0.variable == this.props.dataset_1.variable
                   ? "block"
                   : "none",
             }}
           >
-            
+
             <ComboBox
               key="colormap_diff"
               id="colormap_diff"
@@ -406,7 +416,7 @@ class AreaWindow extends React.Component {
         plot_query.neighbours = this.props.mapSettings.interpNeighbours;
         plot_query.plotTitle = this.state.plotTitle;
         if (this.props.dataset_compare) {
-          plot_query.compare_to = {...this.props.dataset_1};
+          plot_query.compare_to = { ...this.props.dataset_1 };
           plot_query.compare_to.dataset = this.props.dataset_1.id;
           plot_query.compare_to.scale = this.state.scale_1;
           plot_query.compare_to.scale_diff = this.state.scale_diff;

--- a/oceannavigator/frontend/src/components/ColormapRange.jsx
+++ b/oceannavigator/frontend/src/components/ColormapRange.jsx
@@ -12,6 +12,11 @@ function ColormapRange(props) {
   const [max, setMax] = useState(parseFloat(props.state[1]).toFixed(4));
 
   useEffect(() => {
+    setMin(parseFloat(props.state[0]).toFixed(4));
+    setMax(parseFloat(props.state[1]).toFixed(4));
+  }, [props])
+
+  useEffect(() => {
     let newMin = parseFloat(min).toFixed(4);
     let newMax = parseFloat(max).toFixed(4);
     let prevMin = parseFloat(props.state[0]).toFixed(4);

--- a/oceannavigator/frontend/src/components/ColormapRange.jsx
+++ b/oceannavigator/frontend/src/components/ColormapRange.jsx
@@ -103,7 +103,7 @@ function ColormapRange(props) {
   }
 
   return (
-    <div className="ColormapRange">
+    <div className="ColormapRange" style={{ margin : props.auto ? '0px 0px' : '0px 5px'}}>
       <h1>{props.title}</h1>
       {props.auto ? autoCheck : null}
       <table style={{ display: useAuto ? "none" : "table" }}>
@@ -113,7 +113,7 @@ function ColormapRange(props) {
               <label htmlFor={props.id + "_min"}>{"Min:"}</label>
             </td>
             <td>
-              <input
+              <input 
                 type="number"
                 className="range-input"
                 value={min}

--- a/oceannavigator/frontend/src/stylesheets/components/_ColormapRange.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_ColormapRange.scss
@@ -1,5 +1,4 @@
 div.ColormapRange {
-  margin: 0px 5px;
   .range-input {
     max-width: 100px;  
   }


### PR DESCRIPTION
## Background
#1135 

## Why did you take this approach?
I decided to use the existing ColormapRange component to avoid redundancy. 

## Anything in particular that should be highlighted?
I'm not sure why the check box isn't in line with the other ones in the area settings card.

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/3c633d78-6c1d-4309-97b4-bf601bb8c1bd)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
