### PR TITLE
pyinstrument middleware added

### DIFF
--- a/oceannavigator/settings.py
+++ b/oceannavigator/settings.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     log_level: str = "DEBUG"
     observation_agg_url: str = ""
     overlay_kml_dir: str = ""
+    profilng: bool = False
     sentry_env: str = ""
     sentry_traces_rate: int = 0
     shape_file_dir: str = ""


### PR DESCRIPTION
## Background
Allows for profiling api requests for a breakdown of time resources used

## Why did you take this approach?
https://pyinstrument.readthedocs.io/en/latest/guide.html#profile-a-web-request-in-fastapi

## Anything in particular that should be highlighted?
To invoke, make any request with the GET parameter 'profile=1' and it will print the HTML result from pyinstrument.

example: http://localhost:8443/api/v2.0/tiles/giops_day/votemper/2337379200/0/4/9/3?projection=EPSG:3857&scale=-5,30&interp=gaussian&radius=25&neighbours=10&profile=1

## Screenshot(s)
![unnamed](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/c0575bae-1129-46e9-8452-39007101e0fd)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
