### PR TITLE
Transect plot y-axis scale behaviour update

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -49,7 +49,7 @@ class AreaWindow extends React.Component {
       syncLocalToGlobalState: false,
       showarea: true,
       surfacevariable: "none",
-      linearthresh: 200,
+      linearthresh: 0,
       bathymetry: true, // Show bathymetry on map
       plotTitle: undefined,
       quiver: {

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -225,15 +225,14 @@ class LineWindow extends React.Component {
             {_("surfacevariable_help")}
           </ComboBox>
 
-          <NumberBox
+          <DepthLimit
             key="linearthresh"
             id="linearthresh"
             state={this.state.linearthresh}
             onUpdate={this.onLocalUpdate}
-            title={_("Linear Threshold")}
           >
             {_("linearthresh_help")}
-          </NumberBox>
+          </DepthLimit>
 
           <DepthLimit
             key="depth_limit"

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -30,7 +30,7 @@ class LineWindow extends React.Component {
       colormap_diff: "default", // Colourmap for difference plot
       showmap: true,
       surfacevariable: "none",
-      linearthresh: 200,
+      linearthresh: 0,
       size: "10x7",
       dpi: 144,
       depth_limit: false,

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -6,7 +6,7 @@ import Range from "./ColormapRange.jsx";
 import CheckBox from "./lib/CheckBox.jsx";
 import NumberBox from "./NumberBox.jsx";
 import ImageSize from "./ImageSize.jsx";
-import DepthLimit from "./DepthLimit.jsx";
+import TransectLimiter from "./TransectLimiter.jsx";
 import DatasetSelector from "./DatasetSelector.jsx";
 import PropTypes from "prop-types";
 import CustomPlotLabels from "./CustomPlotLabels.jsx";
@@ -225,20 +225,22 @@ class LineWindow extends React.Component {
             {_("surfacevariable_help")}
           </ComboBox>
 
-          <DepthLimit
+          <TransectLimiter
             key="linearthresh"
             id="linearthresh"
             state={this.state.linearthresh}
             onUpdate={this.onLocalUpdate}
+            title="Linear Threshold"
           >
             {_("linearthresh_help")}
-          </DepthLimit>
+          </TransectLimiter>
 
-          <DepthLimit
+          <TransectLimiter
             key="depth_limit"
             id="depth_limit"
             state={this.state.depth_limit}
             onUpdate={this.onLocalUpdate}
+            title="Limit Depth"
           />
 
           <div

--- a/oceannavigator/frontend/src/components/LineWindow.jsx
+++ b/oceannavigator/frontend/src/components/LineWindow.jsx
@@ -230,7 +230,8 @@ class LineWindow extends React.Component {
             id="linearthresh"
             state={this.state.linearthresh}
             onUpdate={this.onLocalUpdate}
-            title="Linear Threshold"
+            title="Exponential Plot"
+            parameter="Linear Threshold"
           >
             {_("linearthresh_help")}
           </TransectLimiter>
@@ -241,6 +242,7 @@ class LineWindow extends React.Component {
             state={this.state.depth_limit}
             onUpdate={this.onLocalUpdate}
             title="Limit Depth"
+            parameter="Depth"
           />
 
           <div

--- a/oceannavigator/frontend/src/components/NumberBox.jsx
+++ b/oceannavigator/frontend/src/components/NumberBox.jsx
@@ -97,11 +97,6 @@ class NumberBox extends React.Component {
           <tbody>
             <tr>
               <td>
-                <label className="table-label" htmlFor={this.props.id}>
-                  {_("Value:")}
-                </label>
-              </td>
-              <td>
                 <input
                   className="table-input"
                   type="number"

--- a/oceannavigator/frontend/src/components/TransectLimiter.jsx
+++ b/oceannavigator/frontend/src/components/TransectLimiter.jsx
@@ -63,6 +63,7 @@ class TransectLimiter extends React.Component {
             id="depth"
             state={this.state.value}
             onUpdate={this.onUpdate}
+            title={this.props.parameter}
           />
         </div>
       </div>

--- a/oceannavigator/frontend/src/components/TransectLimiter.jsx
+++ b/oceannavigator/frontend/src/components/TransectLimiter.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 
 import { withTranslation } from "react-i18next";
 
-class DepthLimit extends React.Component {
+class TransectLimiter extends React.Component {
   constructor(props) {
     super(props);
 
@@ -46,17 +46,15 @@ class DepthLimit extends React.Component {
   }
 
   render() {
-    _("Depth Limit");
-    _("Limit Depth");
     return (
-      <div className="DepthLimit">
-        <h1 className="depthlimit-title">{_("Depth Limit")}</h1>
+      <div className="TransectLimiter">
+        
 
         <Form.Check
           type="checkbox"
           checked={this.state.limit}
           onChange={this.enableChecked}
-          label={_("Limit Depth")}
+          label={this.props.title}
         />
 
         <div style={{ display: this.state.limit ? "block" : "none" }}>
@@ -65,7 +63,6 @@ class DepthLimit extends React.Component {
             id="depth"
             state={this.state.value}
             onUpdate={this.onUpdate}
-            title={_("Depth Limit")}
           />
         </div>
       </div>
@@ -74,10 +71,10 @@ class DepthLimit extends React.Component {
 }
 
 //***********************************************************************
-DepthLimit.propTypes = {
+TransectLimiter.propTypes = {
   onUpdate: PropTypes.func,
   id: PropTypes.string,
   state: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
 };
 
-export default withTranslation()(DepthLimit);
+export default withTranslation()(TransectLimiter);

--- a/oceannavigator/frontend/src/stylesheets/components/_NumberBox.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_NumberBox.scss
@@ -7,6 +7,7 @@ div.NumberBox {
     justify-content: space-between;
     font-size: small;
     font-weight: bold;
+    margin-bottom: 5px;
 
     .help-button {
       border: 1px solid;

--- a/oceannavigator/frontend/src/stylesheets/components/_TransectLimiter.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_TransectLimiter.scss
@@ -1,6 +1,6 @@
-div.DepthLimit{
+div.TransectLimiter{
 
-    .depthlimit-title {
+    .TransectLimiter-title {
       font-size: small;
       font-weight: bold;
     }

--- a/oceannavigator/frontend/src/stylesheets/components/_all.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_all.scss
@@ -9,7 +9,7 @@
 @import "DailyCalendar";
 @import "DatasetDropdown";
 @import "DatasetSelector";
-@import "DepthLimit";
+@import "TransectLimiter";
 @import "DrawingTools";
 @import "EnterCoordinatesWindow";
 @import "MainMap";

--- a/oceannavigator/translations/en/LC_MESSAGES/messages.po
+++ b/oceannavigator/translations/en/LC_MESSAGES/messages.po
@@ -456,14 +456,14 @@ msgstr "Apply"
 msgid "Time (UTC)"
 msgstr ""
 
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:49
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:53
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:64
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:49
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:53
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:64
 msgid "Depth Limit"
 msgstr ""
 
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:50
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:56
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:50
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:56
 msgid "Limit Depth"
 msgstr ""
 

--- a/oceannavigator/translations/fr/LC_MESSAGES/messages.po
+++ b/oceannavigator/translations/fr/LC_MESSAGES/messages.po
@@ -452,14 +452,14 @@ msgstr "Appliqué"
 msgid "Time (UTC)"
 msgstr "L'Heure (UTC)"
 
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:49
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:53
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:64
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:49
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:53
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:64
 msgid "Depth Limit"
 msgstr "Limite de Profondeur"
 
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:50
-#: oceannavigator/frontend/src/components/DepthLimit.jsx:56
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:50
+#: oceannavigator/frontend/src/components/TransectLimiter.jsx:56
 msgid "Limit Depth"
 msgstr "Limiter la Profondeur"
 

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -188,8 +188,8 @@ class Plotter(metaclass=ABCMeta):
         if linearthresh is None or linearthresh == "":
             linearthresh = 200
         linearthresh = float(linearthresh)
-        if not linearthresh > 0:
-            linearthresh = 1
+        if linearthresh < 0:
+            linearthresh = 0
 
         return linearthresh
 

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -185,11 +185,9 @@ class Plotter(metaclass=ABCMeta):
 
     def __get_linear_threshold(self, linearthresh: str):
 
-        if linearthresh is None or linearthresh == "":
-            linearthresh = 200
-        linearthresh = float(linearthresh)
-        if linearthresh < 0:
+        if linearthresh is None or linearthresh == "" or linearthresh < 0:
             linearthresh = 0
+        linearthresh = float(linearthresh)
 
         return linearthresh
 

--- a/plotting/transect.py
+++ b/plotting/transect.py
@@ -958,10 +958,14 @@ class TransectPlotter(LinePlotter):
         ax = plt.gca()
         ax.set_title(plotTitle, fontsize=14)  # Set title of subplot
         ax.invert_yaxis()
-        if self.depth_limit is None or (
+
+        if self.linearthresh == 0:
+            plt.yscale("linear")
+        elif self.depth_limit is None or (
             self.depth_limit is not None and self.linearthresh < self.depth_limit
         ):
             plt.yscale("symlog", linthresh=self.linearthresh)
+
 
         ax.yaxis.set_major_formatter(ScalarFormatter())
 


### PR DESCRIPTION
## Background
Currently, a transect plot would have an exponential y-axis with an adjustable linear threshold by default. These changes change the default to a linear y-axis with a checkbox which enables the original (exponential with linear threshold) behaviour.

## Why did you take this approach?
I retooled the DepthLimit component into a more general TransectLimiter component so that it could be used for both it's original purpose as well as the exponential toggle.

## Anything in particular that should be highlighted?


## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/136633941/22afc511-7920-47c2-bd8c-8112168e8a22)


## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
