### PR TITLE
Fix Density variable calculation

### DIFF
--- a/data/calculated_parser/functions.py
+++ b/data/calculated_parser/functions.py
@@ -268,6 +268,14 @@ def density(depth, latitude, temperature, salinity) -> np.ndarray:
 
     press = __calc_pressure(depth, latitude)
 
+    if salinity.shape != press.shape:
+        # Need to pad press so it can broadcast against temperature and salinity.
+        # eg. if using GIOPS and salinity has shape (3, 50, 3, 12) then press has
+        # shape (50, 3). This logic pads press to give shape (1, 50, 3, 1).
+        for ax, val in enumerate(salinity.shape):
+            if ax > press.ndim - 1 or press.shape[ax] != val:
+                press = np.expand_dims(press, axis=ax)
+
     density = gsw.density.rho(salinity, temperature, press)
     return np.array(density)
 


### PR DESCRIPTION
## Background
Received a request to add a Water Density variable to the Navigator (see [Issue #1147](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/issues/1147)). A density function has already been implemented in `data/calculated_parser/functions.py` but the pressure values needed to be padded so that they could be broadcast against salinity and temperature to calculate the sea water density. For this I used the same approach as other calculated variables such as sound speed. 

## Why did you take this approach?
Same approach has been used in other calculated variable functions and has been shown to work.

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/783929ab-8018-40c2-a2e0-68962a644c61)

![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/3c2e5876-7cbd-410b-8f43-af612bdebc60)



## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
