### PR TITLE
Prevent Hourly Timepicker Calendar from Removing Hour from Timestamps 

### DIFF
--- a/oceannavigator/frontend/src/components/calendars/DailyCalendar.jsx
+++ b/oceannavigator/frontend/src/components/calendars/DailyCalendar.jsx
@@ -48,7 +48,10 @@ const DailyCalendar = React.forwardRef((props, ref) => {
     const [prevMonth, prevMonthYear] = getPreviousMonth(month, year);
     const [nextMonth, nextMonthYear] = getNextMonth(month, year);
 
-    let newDatesEnabled = props.availableDates.filter((date) => {
+    let availableDates = JSON.parse(JSON.stringify(props.availableDates));
+    availableDates = availableDates.map((date) => new Date(date))
+
+    let newDatesEnabled = availableDates.filter((date) => {
       let dateMonth = date.getMonth();
       let dateYear = date.getFullYear();
 
@@ -69,8 +72,8 @@ const DailyCalendar = React.forwardRef((props, ref) => {
         ? 29
         : 28
       : months30.includes(month)
-      ? 30
-      : 31;
+        ? 30
+        : 31;
   };
 
   const getPreviousMonth = (month, year) => {
@@ -181,7 +184,7 @@ const DailyCalendar = React.forwardRef((props, ref) => {
   let prevDisabled = true;
   if (
     (earliestDate.getUTCMonth() < month &&
-    earliestDate.getUTCFullYear() === year) ||
+      earliestDate.getUTCFullYear() === year) ||
     earliestDate.getUTCFullYear() < year
   ) {
     prevDisabled = false;
@@ -190,9 +193,9 @@ const DailyCalendar = React.forwardRef((props, ref) => {
   let nextDisabled = true;
   if (
     (latestDate.getUTCMonth() > month &&
-    latestDate.getUTCFullYear() ===
-        year) ||
-        latestDate.getUTCFullYear() > year
+      latestDate.getUTCFullYear() ===
+      year) ||
+    latestDate.getUTCFullYear() > year
   ) {
     nextDisabled = false;
   }


### PR DESCRIPTION
## Background
The hours listed in the hourly timepicker dropdown were getting repalced by "00:00" whenever the date was changed via the calendar or the prev/next buttons. This was because the `DailyCalendar` component was erasing the time data when generating the date buttons for the calendar drop down. To resolve this issue a deep copy of the timestamps was created within this component to prevent the original timestamp data from getting modified. 

## Why did you take this approach?
Keeps the functionality without modifying the original data. 

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/76a28036-4a11-4d3f-8087-316f0bb373fa)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/86a0aae1-1a8f-4863-b2e8-fa0edfb40cad)

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
