### PR TITLE
Add NetCDF option to Profile and Virtual Morning Save Image menu

### DIFF
--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -9,9 +9,9 @@ from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import Mount
 from fastapi.staticfiles import StaticFiles
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from pyinstrument import Profiler
 from pyinstrument.renderers import SpeedscopeRenderer
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from oceannavigator.dataset_config import DatasetConfig
 
@@ -78,7 +78,8 @@ def configure_pyinstrument(app: FastAPI, output_dir: str) -> None:
                 f"{output_dir}"
                 + f"{api_path.replace("/api/v2.0/", "").replace("/", "_")}_"
                 + f"{int(time.time())}"
-                + ".json")
+                + ".json"
+            )
             with open(fname, 'w') as f:
                 f.write(profiler.output(renderer=SpeedscopeRenderer()))
             return response

--- a/oceannavigator/frontend/src/components/PlotImage.jsx
+++ b/oceannavigator/frontend/src/components/PlotImage.jsx
@@ -393,7 +393,7 @@ class PlotImage extends React.PureComponent {
             >
               <Icon icon="file-image-o" /> GeoTIFF
             </Dropdown.Item>
-            <Dropdown.Divider/>
+            <Dropdown.Divider />
             <Dropdown.Item
               eventKey="csv"
               disabled={this.props.query.type == "hovmoller"}
@@ -412,6 +412,15 @@ class PlotImage extends React.PureComponent {
               }
             >
               <Icon icon="file-text-o" /> {_("ODV")}
+            </Dropdown.Item>
+            <Dropdown.Item
+              eventKey="nc"
+              disabled={
+                !this.props.query.type.includes("profile") &&
+                !this.props.query.type.includes("timeseries")
+              }
+            >
+              <Icon icon="file-image-o" /> NetCDF
             </Dropdown.Item>
             <Dropdown.Item
               eventKey="stats"

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -347,10 +347,14 @@ class Plotter(metaclass=ABCMeta):
             return (buf.getvalue(), self.mime, self.filename)
 
     def netcdf(self, dataset):
+        if self.query.get("time"):
+            time = self.query.get("time")
+        else:
+            time = f"{self.query.get("starttime")}_{self.query.get("endtime")}"
         filename = (
             self.query["dataset"]
             + "_%dN%dW" % (self.query["station"][0][0], self.query["station"][0][1])
-            + f"_{self.query["time"]}_NETCDF4.nc"
+            + f"_{time}_NETCDF4.nc"
         )
 
         path = Path("/tmp/subset")

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -2,10 +2,12 @@ import contextlib
 import datetime
 from abc import ABCMeta, abstractmethod
 from io import BytesIO, StringIO
+from pathlib import Path
 from typing import List
 
 import matplotlib.pyplot as plt
 import numpy as np
+import xarray as xr
 from babel.dates import format_date, format_datetime
 
 import plotting.colormap as colormap
@@ -58,6 +60,8 @@ class Plotter(metaclass=ABCMeta):
             return self.odv_ascii()
         elif self.filetype == "stats":
             return self.stats_csv()
+        elif self.filetype == "nc":
+            return self.netcdf()
         else:
             return self.plot()
 
@@ -341,6 +345,15 @@ class Plotter(metaclass=ABCMeta):
                     buf.write("\n")
 
             return (buf.getvalue(), self.mime, self.filename)
+
+    def netcdf(self, dataset):
+
+        path = Path("/tmp/subset")
+        path.mkdir(parents=True, exist_ok=True)
+        working_dir = "/tmp/subset/" + self.filename
+        dataset.to_netcdf(working_dir)
+
+        return working_dir, self.mime, self.filename
 
     def get_variable_names(self, dataset, variables: List[str]) -> List[str]:
         """Returns a list of names for the variables.

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -347,13 +347,18 @@ class Plotter(metaclass=ABCMeta):
             return (buf.getvalue(), self.mime, self.filename)
 
     def netcdf(self, dataset):
+        filename = (
+            self.query["dataset"]
+            + "_%dN%dW" % (self.query["station"][0][0], self.query["station"][0][1])
+            + f"_{self.query["time"]}_NETCDF4.nc"
+        )
 
         path = Path("/tmp/subset")
         path.mkdir(parents=True, exist_ok=True)
-        working_dir = "/tmp/subset/" + self.filename
+        working_dir = "/tmp/subset/" + filename
         dataset.to_netcdf(working_dir)
 
-        return working_dir, self.mime, self.filename
+        return working_dir, self.mime, filename
 
     def get_variable_names(self, dataset, variables: List[str]) -> List[str]:
         """Returns a list of names for the variables.

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -1,6 +1,7 @@
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
+import xarray as xr
 
 import plotting.utils as utils
 from data import open_dataset
@@ -212,3 +213,30 @@ class ProfilePlotter(PointPlotter):
         fig.subplots_adjust(top=(0.8))
 
         return super(ProfilePlotter, self).plot(fig)
+
+    def netcdf(self):
+        pts = np.array(self.points)
+        dims = ["time", "depth", "latitude", "longitude"]
+        data_vars = {}
+        for idx, variable in enumerate(self.variables):
+            data = np.nan * np.ones((1, self.depths.shape[-1], len(pts), len(pts)))
+            data[:, :, idx, idx] = self.data[idx].filled(np.nan) 
+            data_vars[variable] = (
+                dims,
+                data,
+                {
+                    "units": self.dataset_config.variable[variable].unit,
+                    "name": self.dataset_config.variable[variable].name,
+                },
+            )
+
+        coords = {
+            "time": (["time"], [self.time]),
+            "depth": (["depth"], np.unique(self.depths)),
+            "latitude": (["latitude"], pts[:, 0]),
+            "longitude": (["longitude"], pts[:, 1]),
+        }
+        ds = xr.Dataset(data_vars=data_vars, coords=coords)
+        ds["time"].attrs = {"units": self.dataset_config.time_dim_units}
+
+        return super(ProfilePlotter, self).netcdf(ds)

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -116,6 +116,33 @@ class ProfilePlotter(PointPlotter):
 
         return super(ProfilePlotter, self).csv(header, columns, data)
 
+    def netcdf(self):
+        pts = np.array(self.points)
+        dims = ["time", "depth", "latitude", "longitude"]
+        data_vars = {}
+        for idx, variable in enumerate(self.variables):
+            data = np.nan * np.ones((1, self.depths.shape[-1], len(pts), len(pts)))
+            data[:, :, idx, idx] = self.data[idx].filled(np.nan)
+            data_vars[variable] = (
+                dims,
+                data,
+                {
+                    "units": self.dataset_config.variable[variable].unit,
+                    "name": self.dataset_config.variable[variable].name,
+                },
+            )
+
+        coords = {
+            "time": (["time"], [self.time]),
+            "depth": (["depth"], np.unique(self.depths)),
+            "latitude": (["latitude"], pts[:, 0]),
+            "longitude": (["longitude"], pts[:, 1]),
+        }
+        ds = xr.Dataset(data_vars=data_vars, coords=coords)
+        ds["time"].attrs = {"units": self.dataset_config.time_dim_units}
+
+        return super(ProfilePlotter, self).netcdf(ds)
+
     def plot(self):
         # Create base figure
         fig = plt.figure(figsize=self.figuresize, dpi=self.dpi)
@@ -213,30 +240,3 @@ class ProfilePlotter(PointPlotter):
         fig.subplots_adjust(top=(0.8))
 
         return super(ProfilePlotter, self).plot(fig)
-
-    def netcdf(self):
-        pts = np.array(self.points)
-        dims = ["time", "depth", "latitude", "longitude"]
-        data_vars = {}
-        for idx, variable in enumerate(self.variables):
-            data = np.nan * np.ones((1, self.depths.shape[-1], len(pts), len(pts)))
-            data[:, :, idx, idx] = self.data[idx].filled(np.nan)
-            data_vars[variable] = (
-                dims,
-                data,
-                {
-                    "units": self.dataset_config.variable[variable].unit,
-                    "name": self.dataset_config.variable[variable].name,
-                },
-            )
-
-        coords = {
-            "time": (["time"], [self.time]),
-            "depth": (["depth"], np.unique(self.depths)),
-            "latitude": (["latitude"], pts[:, 0]),
-            "longitude": (["longitude"], pts[:, 1]),
-        }
-        ds = xr.Dataset(data_vars=data_vars, coords=coords)
-        ds["time"].attrs = {"units": self.dataset_config.time_dim_units}
-
-        return super(ProfilePlotter, self).netcdf(ds)

--- a/plotting/profile.py
+++ b/plotting/profile.py
@@ -220,7 +220,7 @@ class ProfilePlotter(PointPlotter):
         data_vars = {}
         for idx, variable in enumerate(self.variables):
             data = np.nan * np.ones((1, self.depths.shape[-1], len(pts), len(pts)))
-            data[:, :, idx, idx] = self.data[idx].filled(np.nan) 
+            data[:, :, idx, idx] = self.data[idx].filled(np.nan)
             data_vars[variable] = (
                 dims,
                 data,

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -47,6 +47,8 @@ def get_mimetype(filetype: str):
         filetype = "txt"
     elif filetype == "stats":
         mime = "text/csv"
+    elif filetype == "nc":
+        mime = "application/postscript"
     else:
         filetype = "png"
         mime = "image/png"

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -601,6 +601,18 @@ async def plot(
                 headers={"Cache-Control": "max-age=300"},
             )
 
+    elif format == "nc":
+
+        def make_response(data, mime):
+            return FileResponse(
+                pathlib.Path(data),
+                media_type=mime,
+                headers={
+                    "Cache-Control": "max-age=300",
+                    "Content-Disposition": f'attachment; filename="{data}"',
+                },
+            )
+
     else:
 
         def make_response(data, mime):
@@ -648,7 +660,6 @@ async def plot(
 
     if img:
         response = make_response(img, mime)
-
     else:
         raise FAILURE
 


### PR DESCRIPTION
## Background
We received a request to add a NetCDF file output option to the point plotters (see issue #1150). A _NetCDF_ button was added to the save image menu and related functionality added to the profiler and timeseries plotters. This feature should produce NetCDF files for any profile or VM plot regardless of the number of variables, points, and depths present in the current plot and the output will always contain the standard time, depth, lat, lon dimensions. 

## Why did you take this approach?
Rather than recreate the subset window from the area plotter we decided that this should be a quick to use feature that allows users to quickly download the data visible in the current plot. 

## Screenshot(s)
![image](https://github.com/DFO-Ocean-Navigator/Ocean-Data-Map-Project/assets/79917349/5f95d87f-3add-427b-bb74-72940b0a5618)

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
