### PR TITLE
Fix track wrapping at edges of map

### DIFF
--- a/data/observational/orm/station.py
+++ b/data/observational/orm/station.py
@@ -31,7 +31,7 @@ class Station(Base):
         if self.latitude > 90 or self.latitude < -90:
             raise ValueError(f"Latitude {self.latitude} out of range (-90,90)")
 
-        if self.longitude > 180 or self.longitude < -180:
+        if self.longitude > 360 or self.longitude < -360:
             raise ValueError(f"Longitude {self.longitude} out of range (-180,180)")
 
     def __repr__(self):

--- a/oceannavigator/frontend/src/components/MainMap.jsx
+++ b/oceannavigator/frontend/src/components/MainMap.jsx
@@ -41,7 +41,7 @@ import * as olLoadingstrategy from "ol/loadingstrategy";
 import * as olProj from "ol/proj";
 import * as olProj4 from "ol/proj/proj4";
 import * as olTilegrid from "ol/tilegrid";
-import {getDistance} from 'ol/sphere';
+import { getDistance } from 'ol/sphere';
 import { isMobile } from "react-device-detect";
 
 import "ol/ol.css";
@@ -197,7 +197,6 @@ const MainMap = forwardRef((props, ref) => {
       mapRef0
     );
 
-    // let newSelect = createSelect();
     const newSelect = new olinteraction.Select({
       style: function (feat, res) {
         if (feat.get("type") != "area") {
@@ -1115,10 +1114,10 @@ const MainMap = forwardRef((props, ref) => {
                 feat.set(
                   "name",
                   feat.get("name") +
-                    "<span>" +
-                    "RMS Error: " +
-                    feat.get("error").toPrecision(3) +
-                    "</span>"
+                  "<span>" +
+                  "RMS Error: " +
+                  feat.get("error").toPrecision(3) +
+                  "</span>"
                 );
               }
               if (id) {
@@ -1461,7 +1460,7 @@ const MainMap = forwardRef((props, ref) => {
           let c = feature
             .getGeometry()
             .clone()
-            .transform(props.mapSettings.projection, "EPSG:4326")
+            .transform(props.mapSettings.projection, "EPSG:3857")
             .getCoordinates();
           content.push([c[1], c[0], feature.get("id")]);
         }

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -1254,7 +1254,6 @@ def observation_track(
     if len(coordinates) > 1:
         df = pd.DataFrame(np.array(coordinates), columns=["id", "type", "lon", "lat"])
         df["id"] = df.id.astype(int)
-        df["lon"] = (df["lon"] + 360) % 360
 
         vc = df.id.value_counts()
         for p_id in vc.where(vc > 1).dropna().index:


### PR DESCRIPTION
## Background
As described in Issue #944

Observation tracks often wrap around the map when they cross the edges of the projection (-180,180 deg longitude). This happens when the track coordinates cross these boundaries leading OpenLayers to place them on opposite side of the map.  Eg if the track coordinates change from -178 to 178 degrees longitude. The solution implemented here is to allow the tracks to extend beyond the -180,180 longitude range so that they are plotted continuously. In the previous example the longitude coordinates would be updated from -178, 178 to -178, -182. Logic to handle this was added to the new CMEMS data importers and filters in the API and Stations DB model that shifted coordinates to within these bounds have been removed.

## Why did you take this approach?
Correcting the observations data on ingestion reduces the processing needed by the backend. This is a good time to make this change since we're currently in the process of migrating to CMEMS data for our observations.


## Screenshot(s)


## Checks
- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
