### PR TITLE
Add ONav Lite link to landing page

### DIFF
--- a/oceannavigator/frontend/index.html
+++ b/oceannavigator/frontend/index.html
@@ -127,8 +127,8 @@
               <a class="nav-link js-scroll-trigger" href="#about">About</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link js-scroll-trigger" href="/public"
-                >Open Ocean Navigator</a
+              <a class="nav-link js-scroll-trigger" href="https://lite.oceannavigator.ca/"
+                >Ocean Navigator Lite</a
               >
             </li>
             <li class="nav-item">


### PR DESCRIPTION
## Background
Adds a link to the Ocean Navigator Lite (https://lite.oceannavigator.ca) to the landing page for quick access. Removed the `Open Ocean Navigator` link to minimize redundancy and clutter. 

![image](https://github.com/user-attachments/assets/69bd1ef2-32f1-43c3-b87f-a2b2380f2694)

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.

