### PR TITLE
Fix obs point, track, and plot endpoint issues

### DIFF
--- a/data/observational/orm/station.py
+++ b/data/observational/orm/station.py
@@ -31,8 +31,8 @@ class Station(Base):
         if self.latitude > 90 or self.latitude < -90:
             raise ValueError(f"Latitude {self.latitude} out of range (-90,90)")
 
-        if self.longitude > 360 or self.longitude < -360:
-            raise ValueError(f"Longitude {self.longitude} out of range (-180,180)")
+        if self.longitude > 540 or self.longitude < -540:
+            raise ValueError(f"Longitude {self.longitude} out of range (-540,540)")
 
     def __repr__(self):
         return (

--- a/oceannavigator/frontend/src/components/ObservationSelector.jsx
+++ b/oceannavigator/frontend/src/components/ObservationSelector.jsx
@@ -172,7 +172,7 @@ function ObservationSelector(props) {
       .map(function (key) {
         return `${key}=${selection[key]}`;
       })
-      .join(",");
+      .join("&");
     if (type == "track") {
       props.action("show", "observation_tracks", result);
     } else {

--- a/oceannavigator/frontend/src/components/ObservationSelector.jsx
+++ b/oceannavigator/frontend/src/components/ObservationSelector.jsx
@@ -172,7 +172,7 @@ function ObservationSelector(props) {
       .map(function (key) {
         return `${key}=${selection[key]}`;
       })
-      .join(";");
+      .join(",");
     if (type == "track") {
       props.action("show", "observation_tracks", result);
     } else {

--- a/oceannavigator/frontend/src/components/TrackWindow.jsx
+++ b/oceannavigator/frontend/src/components/TrackWindow.jsx
@@ -42,7 +42,7 @@ class TrackWindow extends React.Component {
     };
 
     if (this.props.obs_query) {
-      let pairs = this.props.obs_query.split(',').map(x => x.split('='));
+      let pairs = this.props.obs_query.split('&').map(x => x.split('='));
       let dict = pairs.reduce(function (d, p) { d[p[0]] = p[1]; return d }, {});
       this.state['starttime'] = new Date(dict.start_date);
       this.state['endtime'] = new Date(dict.end_date);

--- a/oceannavigator/frontend/src/components/TrackWindow.jsx
+++ b/oceannavigator/frontend/src/components/TrackWindow.jsx
@@ -42,7 +42,7 @@ class TrackWindow extends React.Component {
     };
 
     if (this.props.obs_query) {
-      let pairs = this.props.obs_query.split(';').map(x => x.split('='));
+      let pairs = this.props.obs_query.split(',').map(x => x.split('='));
       let dict = pairs.reduce(function (d, p) { d[p[0]] = p[1]; return d }, {});
       this.state['starttime'] = new Date(dict.start_date);
       this.state['endtime'] = new Date(dict.end_date);

--- a/plotting/track.py
+++ b/plotting/track.py
@@ -50,6 +50,8 @@ class TrackPlotter(Plotter):
         trackvariable = query.get("trackvariable")
         if isinstance(trackvariable, str):
             trackvariables = trackvariable.split(",")
+        elif not isinstance(trackvariable, list):
+            trackvariables = [trackvariable]
         else:
             trackvariables = trackvariable
 

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -1181,7 +1181,7 @@ def observation_tracktime(
 @router.get("/observation/track/{query}.json")
 def observation_track(
     query: str = Path(
-        title="List of key=value pairs, seperated by ;",
+        title="List of key=value pairs, seperated by ,",
         examples=["start_date=2019-01-01;end_date=2019-06-01;quantum=year"],
     ),
     db: Session = Depends(get_db),
@@ -1189,7 +1189,7 @@ def observation_track(
     """
     Observational query for tracks. Used in ObservationSelector.
     """
-    query_dict = {key: value for key, value in [q.split("=") for q in query.split(";")]}
+    query_dict = {key: value for key, value in [q.split("=") for q in query.split(",")]}
     data = []
     params = {}
 
@@ -1285,7 +1285,7 @@ def observation_track(
 @router.get("/observation/point/{query}.json")
 def observation_point(
     query: str = Path(
-        title="List of key=value pairs, seperated by ;",
+        title="List of key=value pairs, seperated by ,",
         examples=[
             (
                 "start_date=2019-01-01;end_date=2019-06-01;"

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -1189,7 +1189,7 @@ def observation_track(
     """
     Observational query for tracks. Used in ObservationSelector.
     """
-    query_dict = {key: value for key, value in [q.split("=") for q in query.split(",")]}
+    query_dict = {key: value for key, value in [q.split("=") for q in query.split("&")]}
     data = []
     params = {}
 
@@ -1298,7 +1298,7 @@ def observation_point(
     """
     Observational query for points. Used in ObservationSelector.
     """
-    query_dict = {key: value for key, value in [q.split("=") for q in query.split(";")]}
+    query_dict = {key: value for key, value in [q.split("=") for q in query.split("&")]}
     data = []
     params = {}
     MAPPING = {

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -1181,7 +1181,7 @@ def observation_tracktime(
 @router.get("/observation/track/{query}.json")
 def observation_track(
     query: str = Path(
-        title="List of key=value pairs, seperated by ,",
+        title="List of key=value pairs, seperated by &",
         examples=["start_date=2019-01-01&end_date=2019-06-01&quantum=year"],
     ),
     db: Session = Depends(get_db),
@@ -1285,7 +1285,7 @@ def observation_track(
 @router.get("/observation/point/{query}.json")
 def observation_point(
     query: str = Path(
-        title="List of key=value pairs, seperated by ,",
+        title="List of key=value pairs, seperated by &",
         examples=[
             (
                 "start_date=2019-01-01&end_date=2019-06-01&"

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -1182,7 +1182,7 @@ def observation_tracktime(
 def observation_track(
     query: str = Path(
         title="List of key=value pairs, seperated by ,",
-        examples=["start_date=2019-01-01;end_date=2019-06-01;quantum=year"],
+        examples=["start_date=2019-01-01&end_date=2019-06-01&quantum=year"],
     ),
     db: Session = Depends(get_db),
 ):
@@ -1288,7 +1288,7 @@ def observation_point(
         title="List of key=value pairs, seperated by ,",
         examples=[
             (
-                "start_date=2019-01-01;end_date=2019-06-01;"
+                "start_date=2019-01-01&end_date=2019-06-01&"
                 + "datatype=sea_water_temperature"
             )
         ],


### PR DESCRIPTION
## Background
This PR address a number of issues in the observation point, track, and plot endpoints:
- The ORM range of lat and lon coordinates does not account for wrapping value in a continuous line.
- The track variable value in the query may be a list or single value so logic was added to the track plotter to accommodate these datatypes.
- The query string format separated variables with `;` which prevented the query from reaching the end point. This has been replaced with `&` as commonly used to separate variables in query strings. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
