### PR TITLE
Fix projection in area plots

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -407,7 +407,7 @@ class AreaWindow extends React.Component {
         plot_query.contour = this.state.contour;
         plot_query.showarea = this.state.showarea;
         plot_query.variable = this.props.dataset_0.variable;
-        plot_query.projection = this.props.projection;
+        plot_query.projection = this.props.mapSettings.projection;
         plot_query.size = this.state.size;
         plot_query.dpi = this.state.dpi;
         plot_query.interp = this.props.mapSettings.interpType;


### PR DESCRIPTION
## Background
We were notified of an issue that prevented area plots below -30 degrees latitude. After some digging I found that the Lambert Conformal projection used in the area plotter for areas within (-85, 85) deg latitude does not extend beyond this range. Switching to the Mercator projection allows all plots within this range. While testing I also found that the area boundary is not properly calculated for polar plots outside of this range, especially when the area intersected the north/south pole. To resolve this I opted to re-calculate the bounds and centroid in the plots own CRS to ensure that the plot was centered on the polygon.

## Why did you take this approach?
Adopting the Mercator projection allows us to use the majority of the globe for standard plots. 

## Screenshot(s)
Comparisons of plots before/after changes:

![image](https://github.com/user-attachments/assets/262ba37e-084d-4d7d-be61-fd7dff5bf58e)
![image](https://github.com/user-attachments/assets/5c909225-5bce-450b-a3a8-3022db0b2d8d)

![image](https://github.com/user-attachments/assets/bdad02ec-4093-4701-8ef4-694b1302d912)
![image](https://github.com/user-attachments/assets/1730adea-520e-43f8-9774-fcbc88bed8e9)

![image](https://github.com/user-attachments/assets/445bc8a0-495e-44e1-a534-e4ea05160348)


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
