### PR TITLE
Fix subset panel API query

### DIFF
--- a/oceannavigator/frontend/src/components/SubsetPanel.jsx
+++ b/oceannavigator/frontend/src/components/SubsetPanel.jsx
@@ -99,11 +99,11 @@ function SubsetPanel(props) {
 
     window.location.href =
       window.location.origin +
-      "/api/v2.0/generate_script/?query=" +
+      "/api/v2.0/generate_script?query=" +
       JSON.stringify(query) +
       "&lang=" +
       key +
-      "&scriptType=subset";
+      "&script_type=subset";
   };
 
   const getSubsetVariables = () => {


### PR DESCRIPTION
## Background
The subset panel API query did not match the update API query format that was introduced when the Navigator migrated to FastAPI. This updates the query to the current query format so that the API Script option is now functional.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
