### PR TITLE
Allow multiple point selection with shift key

### DIFF
--- a/oceannavigator/frontend/src/components/OceanNavigator.jsx
+++ b/oceannavigator/frontend/src/components/OceanNavigator.jsx
@@ -69,6 +69,7 @@ function OceanNavigator(props) {
   const [observationArea, setObservationArea] = useState([]);
   const [subquery, setSubquery] = useState();
   const [showPermalink, setShowPermalink] = useState(false);
+  const [multiSelect, setMultiSelect] = useState(false);
 
   useEffect(() => {
     ReactGA.ga("send", "pageview");
@@ -103,7 +104,18 @@ function OceanNavigator(props) {
         console.error(err);
       }
     }
+
+    window.addEventListener("keyup", upHandler);
+    return () => {
+      window.removeEventListener("keyup", upHandler);
+    };
   }, []);
+
+  const upHandler = (e) => {
+    if (e.key === "Shift") {
+      setMultiSelect(false);
+    }
+  };
 
   const action = (name, arg, arg2, arg3) => {
     switch (name) {
@@ -213,6 +225,10 @@ function OceanNavigator(props) {
           break;
         case "names":
           setNames(value[i]);
+          break;
+        case "multiSelect":
+          setMultiSelect(value[i]);
+          break;
       }
     }
   };
@@ -454,6 +470,7 @@ function OceanNavigator(props) {
       modalTitle = __("Info/Help");
       break;
   }
+
   return (
     <div className="OceanNavigator">
       <ScaleViewer
@@ -505,20 +522,26 @@ function OceanNavigator(props) {
       <ToggleLanguage />
       <LinkButton action={action} />
       <MapTools uiSettings={uiSettings} updateUI={updateUI} action={action} />
-      <Modal
-        show={uiSettings.showModal}
-        onHide={closeModal}
-        dialogClassName="full-screen-modal"
-        size={modalSize}
-      >
-        <Modal.Header closeButton closeVariant="white" closeLabel={__("Close")}>
-          <Modal.Title>{modalTitle}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>{modalBodyContent}</Modal.Body>
-        <Modal.Footer>
-          <Button onClick={closeModal}>{__("Close")}</Button>
-        </Modal.Footer>
-      </Modal>
+      {multiSelect ? null : (
+        <Modal
+          show={uiSettings.showModal}
+          onHide={closeModal}
+          dialogClassName="full-screen-modal"
+          size={modalSize}
+        >
+          <Modal.Header
+            closeButton
+            closeVariant="white"
+            closeLabel={__("Close")}
+          >
+            <Modal.Title>{modalTitle}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{modalBodyContent}</Modal.Body>
+          <Modal.Footer>
+            <Button onClick={closeModal}>{__("Close")}</Button>
+          </Modal.Footer>
+        </Modal>
+      )}
       <Modal
         show={showPermalink}
         onHide={() => setShowPermalink(false)}

--- a/oceannavigator/frontend/src/components/map/Map.jsx
+++ b/oceannavigator/frontend/src/components/map/Map.jsx
@@ -157,48 +157,7 @@ const Map = forwardRef((props, ref) => {
       mapRef0
     );
 
-    const newSelect = new olinteraction.Select({
-      style: function (feat, res) {
-        if (feat.get("type") != "area") {
-          return new Style({
-            stroke: new Stroke({
-              color: "#0099ff",
-              width: 4,
-            }),
-            image: new Circle({
-              radius: 4,
-              fill: new Fill({
-                color: "#0099ff",
-              }),
-              stroke: new Stroke({
-                color: "#ffffff",
-                width: 1,
-              }),
-            }),
-          });
-        }
-      },
-    });
-
-    newSelect.on("select", function (e) {
-      let selectedFeatures = this.getFeatures();
-      if (
-        e.selected.length > 0 &&
-        (e.selected[0].line || e.selected[0].drifter)
-      ) {
-        selectedFeatures.clear();
-        selectedFeatures.push(e.selected[0]);
-      }
-      if (e.selected.length == 0) {
-        props.updateState("plotEnabled", true);
-        props.action("point", props.vectorCoordinates);
-      }
-      pushSelection(selectedFeatures);
-
-      if (e.selected[0].get("type") == "area") {
-        selectedFeatures.clear();
-      }
-    });
+    const newSelect = createSelect()
     newMap.addInteraction(newSelect);
 
     newMap.on("moveend", function () {
@@ -464,7 +423,6 @@ const Map = forwardRef((props, ref) => {
         selectedFeatures.push(e.selected[0]);
       }
       if (e.selected.length == 0) {
-        props.updateState("plotEnabled", true);
         props.action("point", props.vectorCoordinates);
       }
       pushSelection(selectedFeatures);

--- a/oceannavigator/frontend/src/components/map/Map.jsx
+++ b/oceannavigator/frontend/src/components/map/Map.jsx
@@ -157,7 +157,7 @@ const Map = forwardRef((props, ref) => {
       mapRef0
     );
 
-    const newSelect = createSelect()
+    const newSelect = createSelect();
     newMap.addInteraction(newSelect);
 
     newMap.on("moveend", function () {
@@ -414,7 +414,11 @@ const Map = forwardRef((props, ref) => {
     });
 
     newSelect.on("select", function (e) {
+      let shiftHeld = e.mapBrowserEvent.originalEvent.shiftKey;
       let selectedFeatures = this.getFeatures();
+      if (shiftHeld && e.selected[0].get("type") == "point") {
+        props.updateState(["multiSelect"], true);
+      }
       if (
         e.selected.length > 0 &&
         (e.selected[0].line || e.selected[0].drifter)
@@ -731,7 +735,7 @@ const Map = forwardRef((props, ref) => {
 
     props.action(actionType, content);
     props.updateUI({ modalType: t, showModal: true });
-    props.updateState("names", names);
+    props.updateState(["names"], [names]);
   };
 
   const updateSelectFilter = (select) => {

--- a/oceannavigator/frontend/src/components/map/Map.jsx
+++ b/oceannavigator/frontend/src/components/map/Map.jsx
@@ -414,8 +414,12 @@ const Map = forwardRef((props, ref) => {
     });
 
     newSelect.on("select", function (e) {
-      let shiftHeld = e.mapBrowserEvent.originalEvent.shiftKey;
       let selectedFeatures = this.getFeatures();
+      if (selectedFeatures.getLength() === 0) {
+        return;
+      }
+
+      let shiftHeld = e.mapBrowserEvent.originalEvent.shiftKey;
       if (shiftHeld && e.selected[0].get("type") == "point") {
         props.updateState(["multiSelect"], true);
       }
@@ -429,6 +433,7 @@ const Map = forwardRef((props, ref) => {
       if (e.selected.length == 0) {
         props.action("point", props.vectorCoordinates);
       }
+
       pushSelection(selectedFeatures);
 
       if (e.selected[0].get("type") == "area") {


### PR DESCRIPTION
## Background
The OpenLayers select feature inherently allows users to select multiple features by holding the shift key when clicking on them. The `Map` component however fires the signal to open the plot window immediately after a selection is made preventing users from easily selecting multiple points to plot. A shift key check is added to the select function to signal that the user is selecting multiple points prevents the window from opening via a `multiSelect` state variable. Likewise, an event listener is added to the main ocean navigator component to check that the shift key is released which modifies the `multiSelect` state and allows the plot window to open.

## Why did you take this approach?
These checks allow the navigator to track when the user is selecting multiple points and delay the opening of the plot window.

## Anything in particular that should be highlighted?
Multiple point selection is only enables when the user is selecting points to plot. 

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
