### PR TITLE
Fix Area Plot Depth Selector

### DIFF
--- a/oceannavigator/frontend/src/components/AreaWindow.jsx
+++ b/oceannavigator/frontend/src/components/AreaWindow.jsx
@@ -401,7 +401,7 @@ class AreaWindow extends React.Component {
         plot_query.colormap = this.state.leftColormap;
         plot_query.time = this.props.dataset_0.time;
         plot_query.area = area;
-        plot_query.depth = this.state.dataset_0.depth;
+        plot_query.depth = this.props.dataset_0.depth;
         plot_query.bathymetry = this.state.bathymetry;
         plot_query.quiver = this.state.quiver;
         plot_query.contour = this.state.contour;


### PR DESCRIPTION
## Background
The area plot depth selector was not updating the plot displayed in the window. This was because the `plot_query` referenced the copy of `dataset_0` in state and not props. To fix this problem we updated the reference so that the plot chances when a new depth is selected. 

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
