### PR TITLE
Fix "combine point features" bug in Map component 

### DIFF
--- a/oceannavigator/frontend/src/components/Map/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map/Map.jsx
@@ -691,8 +691,10 @@ const Map = forwardRef((props, ref) => {
     );
     featureVectorSource.clear();
     featureVectorSource.addFeatures(features);
+    select0.getFeatures().clear()
     select0.getFeatures().push(newFeature);
     if (props.compareDatasets) {
+      select1.getFeatures().clear()
       select1.getFeatures().push(newFeature);
     }
     props.action("selectedFeatureIds", [newFeature.getId()]);


### PR DESCRIPTION
## Background
During release testing I found a bug that prevented plotting of line and area features created from combining point features. The root of the issue is that the previous selected features were not cleared from the Select interaction after they had been removed from the vector layer resulting in the Navigator adding a string of _NaNs_ to the feature coordinates. Clearing the select interaction before adding the combined point feature to it resolves the issue.

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
