### PR TITLE
Make prints in scripts python3 compatible

### DIFF
--- a/data/mercator.py
+++ b/data/mercator.py
@@ -246,9 +246,9 @@ class Mercator(Model):
                     np.zeros(d.shape[1:]), mask=True, dtype=self.depths.dtype
                 )
 
-                depth_values[
-                    np.unravel_index(indices, depth_values.shape)
-                ] = self.depths[depths]
+                depth_values[np.unravel_index(indices, depth_values.shape)] = (
+                    self.depths[depths]
+                )
 
         else:
             if len(var.shape) == 4:

--- a/data/nemo.py
+++ b/data/nemo.py
@@ -274,9 +274,9 @@ class Nemo(Model):
                     np.zeros(d.shape[1:]), mask=True, dtype=self.depths.dtype
                 )
 
-                depth_values[
-                    np.unravel_index(indices, depth_values.shape)
-                ] = self.depths[depths]
+                depth_values[np.unravel_index(indices, depth_values.shape)] = (
+                    self.depths[depths]
+                )
 
                 dep = self.__resample(
                     latvar[miny:maxy, minx:maxx],

--- a/oceannavigator/__init__.py
+++ b/oceannavigator/__init__.py
@@ -80,7 +80,7 @@ def configure_pyinstrument(app: FastAPI, output_dir: str) -> None:
                 + f"{int(time.time())}"
                 + ".json"
             )
-            with open(fname, 'w') as f:
+            with open(fname, "w") as f:
                 f.write(profiler.output(renderer=SpeedscopeRenderer()))
             return response
         else:

--- a/plotting/class4.py
+++ b/plotting/class4.py
@@ -4,7 +4,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
 
-#from flask_babel import gettext
+# from flask_babel import gettext
 from netCDF4 import Dataset, chartostring
 
 import plotting.utils as utils
@@ -183,7 +183,9 @@ class Class4Plotter(Plotter):
 
                 if self.error in ["climatology", "observation"]:
                     if self.error == "climatology":
-                        plot_label = "Error wrt Climatology" # gettext("Error wrt Climatology")
+                        plot_label = (
+                            "Error wrt Climatology"  # gettext("Error wrt Climatology")
+                        )
                         handles.append(
                             plt.plot(
                                 self.observed_data[i, idx, :]
@@ -192,11 +194,15 @@ class Class4Plotter(Plotter):
                                 form,
                             )
                         )
-                        legend.append(f"{id_label} {'Observed'}") # {gettext('Observed')}")
+                        legend.append(
+                            f"{id_label} {'Observed'}"
+                        )  # {gettext('Observed')}")
 
                         data = self.climatology_data
                     else:
-                        plot_label = "Error wrt Observation" # gettext("Error wrt Observation")
+                        plot_label = (
+                            "Error wrt Observation"  # gettext("Error wrt Observation")
+                        )
 
                         data = self.observed_data
 
@@ -229,14 +235,18 @@ class Class4Plotter(Plotter):
                                 form,
                             )
                         )
-                        legend.append(f"{id_label} {'Climatology'}") # {gettext('Climatology')}")
+                        legend.append(
+                            f"{id_label} {'Climatology'}"
+                        )  # {gettext('Climatology')}")
                     lim = np.abs(plt.xlim()).max()
                     plt.xlim([-lim, lim])
                 else:
                     handles.append(
                         plt.plot(self.observed_data[i, idx, :], self.depths[i], form)
                     )
-                    legend.append("%s %s" % (id_label, "Observed")) # gettext("Observed")))
+                    legend.append(
+                        "%s %s" % (id_label, "Observed")
+                    )  # gettext("Observed")))
                     handles.append(
                         plt.plot(self.forecast_data[i, idx, :], self.depths[i], form)
                     )
@@ -257,7 +267,9 @@ class Class4Plotter(Plotter):
                                 self.climatology_data[i, idx, :], self.depths[i], form
                             )
                         )
-                        legend.append(f"{id_label} {'Climatology'}") # {gettext('Climatology')}")
+                        legend.append(
+                            f"{id_label} {'Climatology'}"
+                        )  # {gettext('Climatology')}")
 
             plt.xlim([np.floor(plt.xlim()[0]), np.ceil(plt.xlim()[1])])
 
@@ -266,7 +278,8 @@ class Class4Plotter(Plotter):
             plt.xlabel(f"{v} ({utils.mathtext(self.variable_units[idx])})", fontsize=14)
             plt.gca().invert_yaxis()
             plt.ylabel(
-                f"Depth ({utils.mathtext(self.depth_unit)})", fontsize=14 # gettext(f"Depth ({utils.mathtext(self.depth_unit)})"), fontsize=14
+                f"Depth ({utils.mathtext(self.depth_unit)})",
+                fontsize=14,  # gettext(f"Depth ({utils.mathtext(self.depth_unit)})"), fontsize=14
             )
             plt.grid(True)
 

--- a/plotting/hovmoller.py
+++ b/plotting/hovmoller.py
@@ -3,7 +3,8 @@ import re
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
-#from flask_babel import gettext
+
+# from flask_babel import gettext
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 # Silence a FutureWarning
@@ -193,15 +194,17 @@ class HovmollerPlotter(LinePlotter):
             gs,
             [0, 1],
             [0, 0],
-            self.variable_name, # gettext(self.variable_name),
+            self.variable_name,  # gettext(self.variable_name),
             vmin,
             vmax,
             self.data,
             self.iso_timestamps,
             self.cmap,
             self.variable_unit,
-            self.variable_name # gettext(self.variable_name)
-            + get_depth_label(self.depth_value, self.depth_unit), # gettext(get_depth_label(self.depth_value, self.depth_unit)),
+            self.variable_name  # gettext(self.variable_name)
+            + get_depth_label(
+                self.depth_value, self.depth_unit
+            ),  # gettext(get_depth_label(self.depth_value, self.depth_unit)),
         )
 
         # If in compare mode
@@ -229,14 +232,16 @@ class HovmollerPlotter(LinePlotter):
                 gs,
                 [1, 1],
                 [1, 0],
-                self.compare["variable_name"], # gettext(self.compare["variable_name"]),
+                self.compare[
+                    "variable_name"
+                ],  # gettext(self.compare["variable_name"]),
                 vmin,
                 vmax,
                 self.compare["data"],
                 self.compare["times"],
                 self.compare["colormap"],
                 self.compare["variable_unit"],
-                self.compare["variable_name"] # gettext(self.compare["variable_name"])
+                self.compare["variable_name"]  # gettext(self.compare["variable_name"])
                 + get_depth_label(self.compare["depth"], self.compare["depth_unit"]),
                 #  gettext(
                 #     get_depth_label(self.compare["depth"], self.compare["depth_unit"])
@@ -254,16 +259,22 @@ class HovmollerPlotter(LinePlotter):
                     gs,
                     [2, 1],
                     [2, 0],
-                    self.compare["variable_name"], # gettext(self.compare["variable_name"]),
+                    self.compare[
+                        "variable_name"
+                    ],  # gettext(self.compare["variable_name"]),
                     vmin,
                     vmax,
                     data_difference,
                     self.compare["times"],
                     colormap.find_colormap("anomaly"),
                     self.compare["variable_unit"],
-                    self.compare["variable_name"] # gettext(self.compare["variable_name"])
-                    + " Difference" # + gettext(" Difference")
-                    + get_depth_label(self.compare["depth"], self.compare["depth_unit"]),
+                    self.compare[
+                        "variable_name"
+                    ]  # gettext(self.compare["variable_name"])
+                    + " Difference"  # + gettext(" Difference")
+                    + get_depth_label(
+                        self.compare["depth"], self.compare["depth_unit"]
+                    ),
                     # + gettext(
                     #     get_depth_label(
                     #         self.compare["depth"], self.compare["depth_unit"]
@@ -274,7 +285,8 @@ class HovmollerPlotter(LinePlotter):
         # Image title
         if self.plotTitle:
             fig.suptitle(
-                "Hovm\xf6ller Diagram(s) for:\n%s" % (self.name), fontsize=15 # gettext("Hovm\xf6ller Diagram(s) for:\n%s") % (self.name), fontsize=15
+                "Hovm\xf6ller Diagram(s) for:\n%s" % (self.name),
+                fontsize=15,  # gettext("Hovm\xf6ller Diagram(s) for:\n%s") % (self.name), fontsize=15
             )
         else:
             fig.suptitle(self.plotTitle, fontsize=15)
@@ -350,7 +362,7 @@ class HovmollerPlotter(LinePlotter):
             transform=ax.transAxes,
         )
 
-        plt.xlabel("Distance (km)") # plt.xlabel(gettext("Distance (km)"))
+        plt.xlabel("Distance (km)")  # plt.xlabel(gettext("Distance (km)"))
         plt.xlim([self.distance[0], self.distance[-1]])
 
         divider = make_axes_locatable(plt.gca())

--- a/plotting/line.py
+++ b/plotting/line.py
@@ -23,11 +23,14 @@ class LinePlotter(Plotter):
         if name is None or name == "":
             p0 = geopy.Point(points[0])
             p1 = geopy.Point(points[-1])
-            name = "(%0.4f N, %0.4f W) to (%0.4f N, %0.4f W)" % ( # gettext("(%0.4f N, %0.4f W) to (%0.4f N, %0.4f W)") % (
-                p0.latitude,
-                p0.longitude,
-                p1.latitude,
-                p1.longitude,
+            name = (
+                "(%0.4f N, %0.4f W) to (%0.4f N, %0.4f W)"
+                % (  # gettext("(%0.4f N, %0.4f W) to (%0.4f N, %0.4f W)") % (
+                    p0.latitude,
+                    p0.longitude,
+                    p1.latitude,
+                    p1.longitude,
+                )
             )
 
         self.name = name

--- a/plotting/sound.py
+++ b/plotting/sound.py
@@ -80,8 +80,12 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
                 np.amax(self.sspeed) + (maxspeed - minspeed) * 0.1,
             ]
         )
-        ax.set_xlabel("Sound Speed (m/s)", fontsize=14) # ax.set_xlabel(gettext("Sound Speed (m/s)"), fontsize=14)
-        ax.set_ylabel("Depth (m)", fontsize=14) # ax.set_ylabel(gettext("Depth (m)"), fontsize=14)
+        ax.set_xlabel(
+            "Sound Speed (m/s)", fontsize=14
+        )  # ax.set_xlabel(gettext("Sound Speed (m/s)"), fontsize=14)
+        ax.set_ylabel(
+            "Depth (m)", fontsize=14
+        )  # ax.set_ylabel(gettext("Depth (m)"), fontsize=14)
         ax.invert_yaxis()
         ax.xaxis.set_ticks_position("top")
         ax.xaxis.set_label_position("top")
@@ -90,7 +94,7 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
 
         if not self.plotTitle:
             ax.set_title(
-                "Sound Speed Profile for (%s)\n%s" # gettext("Sound Speed Profile for (%s)\n%s")
+                "Sound Speed Profile for (%s)\n%s"  # gettext("Sound Speed Profile for (%s)\n%s")
                 % (", ".join(self.names), self.date_formatter(self.iso_timestamp)),
                 fontsize=15,
             )
@@ -108,7 +112,9 @@ class SoundSpeedPlotter(TemperatureSalinityPlotter):
         ax2 = ax.twinx()
         ureg = pint.UnitRegistry()
         ax2.set_ylim((ylim * ureg.meters).to(ureg.feet).magnitude)
-        ax2.set_ylabel("Depth (ft)", fontsize=14) # ax2.set_ylabel(gettext("Depth (ft)"), fontsize=14)
+        ax2.set_ylabel(
+            "Depth (ft)", fontsize=14
+        )  # ax2.set_ylabel(gettext("Depth (ft)"), fontsize=14)
 
         ax.text(
             0,

--- a/plotting/stats.py
+++ b/plotting/stats.py
@@ -46,9 +46,9 @@ class Stats:
                     self.inner_area.area_query[idx]["polygons"][0][idx2][
                         1
                     ] = divide_lon_line
-                    self.outter_area.area_query[idx]["polygons"][0][idx2][
-                        1
-                    ] = convert_to_bounded_lon(lon)
+                    self.outter_area.area_query[idx]["polygons"][0][idx2][1] = (
+                        convert_to_bounded_lon(lon)
+                    )
                 elif abs(lon) < abs(divide_lon_line):
                     self.outter_area.area_query[idx]["polygons"][0][idx2][
                         1

--- a/plotting/stick.py
+++ b/plotting/stick.py
@@ -2,6 +2,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 # from flask_babel import gettext
 from matplotlib.dates import date2num
 

--- a/plotting/transect.py
+++ b/plotting/transect.py
@@ -992,9 +992,9 @@ class TransectPlotter(LinePlotter):
         self.plotTitle = (
             "Transect Data for:\n%s" % (self.name)
             + "\nProfile: "
-            + format(self.destination.latitude, '.4f')
+            + format(self.destination.latitude, ".4f")
             + " "
-            + format(self.destination.longitude, '.4f')
+            + format(self.destination.longitude, ".4f")
         )
 
     def _transect_plot(

--- a/plotting/ts.py
+++ b/plotting/ts.py
@@ -127,8 +127,12 @@ class TemperatureSalinityPlotter(PointPlotter):
         for idx, _ in enumerate(self.temperature):
             plt.plot(self.salinity[idx], self.temperature[idx], "-")
 
-        plt.xlabel("Salinity (PSU)", fontsize=14) # plt.xlabel(gettext("Salinity (PSU)"), fontsize=14)
-        plt.ylabel("Temperature (Celsius)", fontsize=14) # plt.ylabel(gettext("Temperature (Celsius)"), fontsize=14)
+        plt.xlabel(
+            "Salinity (PSU)", fontsize=14
+        )  # plt.xlabel(gettext("Salinity (PSU)"), fontsize=14)
+        plt.ylabel(
+            "Temperature (Celsius)", fontsize=14
+        )  # plt.ylabel(gettext("Temperature (Celsius)"), fontsize=14)
 
         if len(self.points) == 1:
             labels = []
@@ -153,7 +157,7 @@ class TemperatureSalinityPlotter(PointPlotter):
 
         if not self.plotTitle:
             plt.title(
-                "T/S Diagram for (%s)\n%s" # gettext("T/S Diagram for (%s)\n%s")
+                "T/S Diagram for (%s)\n%s"  # gettext("T/S Diagram for (%s)\n%s")
                 % (", ".join(self.names), self.date_formatter(self.iso_timestamp)),
                 fontsize=15,
             )

--- a/scripts/apply_mask.py
+++ b/scripts/apply_mask.py
@@ -9,7 +9,7 @@ import numpy as np
 from netCDF4 import Dataset
 
 if len(sys.argv) < 4:
-    print "Usage: " + sys.argv[0] + " inputfile maskedfile outputfile"
+    print("Usage: " + sys.argv[0] + " inputfile maskedfile outputfile")
     exit(1)
 
 infile = sys.argv[1]
@@ -27,7 +27,7 @@ with Dataset(infile, 'r') as src, \
         )
 
     for name, variable in src.variables.items():
-        print name
+        print(name)
         dst.createVariable(name, variable.datatype, variable.dimensions)
         addMask = False
         for attrname in variable.ncattrs():
@@ -47,7 +47,7 @@ with Dataset(infile, 'r') as src, \
             addMask = True
 
         if addMask:
-            print "Adding mask to %s" % name
+            print("Adding mask to %s" % name)
             result = np.ma.masked_array(variable[:])
             result.mask = masked.variables[name][0, :].mask
             dst.variables[name][:] = result

--- a/scripts/drifter_process.py
+++ b/scripts/drifter_process.py
@@ -175,7 +175,7 @@ for buoy_id, files in buoy_files.items():
 
         if len(si) > 0:
             dataframe.drop(points.index[si[0]], inplace=True)
-            print "\tDropping point with speed=%0.1f knots" % speed[si[0]]
+            print("\tDropping point with speed=%0.1f knots" % speed[si[0]])
         else:
             changed = False
 
@@ -212,8 +212,8 @@ for buoy_id, files in buoy_files.items():
     )
 
     if (vt.size<= 2 or vx.size <=2 or vy.size <=2 ):
-	    print "vt,vx,or vy are to small to use, must nbe greater than 1 (the drifter should have more than 1 point)"
-	    continue
+        print("vt,vx,or vy are to small to use, must nbe greater than 1 (the drifter should have more than 1 point)")
+        continue
     fx = interpolate.interp1d(vt, vx, bounds_error=False, kind='linear')
     fy = interpolate.interp1d(vt, vy, bounds_error=False, kind='linear')
 

--- a/scripts/get_drifters.py
+++ b/scripts/get_drifters.py
@@ -16,7 +16,7 @@ import requests
 
 def download_file_from_google_drive(id, destination):
     def get_confirm_token(response):
-        print "confirming token"
+        print("confirming token")
         for key, value in response.cookies.items():
             if key.startswith('download_warning'):
                 return value
@@ -24,7 +24,7 @@ def download_file_from_google_drive(id, destination):
         return None
 
     def save_response_content(response, destination):
-        print "saving chunck"
+        print("saving chunck")
         CHUNK_SIZE = 32768
 
         with open(destination, "wb") as f:
@@ -49,7 +49,7 @@ def download_file_from_google_drive(id, destination):
 if __name__ == "__main__":
     import sys
     if len(sys.argv) is not 3:
-        print "Usage: python google_drive.py drive_file_id destination_file_path"
+        print("Usage: python google_drive.py drive_file_id destination_file_path")
     else:
         # TAKE ID FROM SHAREABLE LINK
         file_id = sys.argv[1]

--- a/scripts/readNovaFloat_SN472.py
+++ b/scripts/readNovaFloat_SN472.py
@@ -58,24 +58,24 @@ def makeMapnewArctic(lonStart,lonEnd,latStart,latEnd,lat1,lon1,foutPath,ax):
 #    lons = etopo1.variables["x"][:]
 #    lats = etopo1.variables["y"][:]
 
-    print "lons:", max(lons),min(lons)
-    print lons
+    print("lons:", max(lons),min(lons))
+    print(lons)
 
-    print "lats:", max(lats),min(lats)
-    print lats
+    print("lats:", max(lats),min(lats))
+    print(lats)
 
 
-    print "lon,lat,start, end:",lonStart,lonEnd,latStart,latEnd
-    print " lat lon start end:", latStart-2,latEnd+5,lonStart-5,lonEnd+5
+    print("lon,lat,start, end:",lonStart,lonEnd,latStart,latEnd)
+    print(" lat lon start end:", latStart-2,latEnd+5,lonStart-5,lonEnd+5)
 
     res = findSubsetIndices(latStart-1,latEnd+1,lonStart-1,lonEnd+1,lats,lons)
 
-    print "res:::",res
+    print("res:::",res)
 
     lon,lat=np.meshgrid(lons[res[0]:res[1]],lats[res[2]:res[3]])
 
-    print "shape of lon:",np.shape(lon)
-    print "shape of lat:",np.shape(lat)
+    print("shape of lon:",np.shape(lon))
+    print("shape of lat:",np.shape(lat))
 #    exit(1)
 
 #    print "Extracted data for area %s : (%s,%s) to (%s,%s)"%(name,lon.min(),lat.min(),lon.max(),lat.max())
@@ -101,7 +101,7 @@ def makeMapnewArctic(lonStart,lonEnd,latStart,latEnd,lat1,lon1,foutPath,ax):
     else:
         lon_0=(abs(lonEnd)+abs(lonStart))/2.0
 
-    print 'Center longitude ',lon_0
+    print('Center longitude ',lon_0)
 
     map = Basemap(llcrnrlat=latStart,urcrnrlat=latEnd,\
             llcrnrlon=lonStart,urcrnrlon=lonEnd,\
@@ -157,7 +157,7 @@ def makeMapnewArctic(lonStart,lonEnd,latStart,latEnd,lat1,lon1,foutPath,ax):
     cb.set_label('Depth (m)',fontsize=10)
 
 #    map.plot(lon1,lat1,'r*', markersize=6,latlon='true')
-    print type(lon1),type(lat1),np.shape(lon1)
+    print(type(lon1), type(lat1), np.shape(lon1))
     
 #    for lon2,lat2 in zip(lon1,lat1):
 #        print lon2,lat2 
@@ -282,7 +282,7 @@ def makeMapnewArctic(lonStart,lonEnd,latStart,latEnd,lat1,lon1,foutPath,ax):
     return map
     
 def readDay(fctd,fHK):
-    print fctd, fHK
+    print(fctd, fHK)
     
 #    with open(fctd,'rb') as ctdCsvfile:
     cFlag = True
@@ -292,14 +292,14 @@ def readDay(fctd,fHK):
 #        print totalLine 
         ctdCsvfile.seek(0)
         if totalLine < 3:
-            print "there is no data in file:", fctd
+            print("there is no data in file:", fctd)
             novaFloat=defaultdict()
             
             cFlag = False 
         else:
-            print ctdCsvfile
+            print(ctdCsvfile)
             reader =csv.reader(ctdCsvfile)
-            print reader
+            print(reader)
             row0 = reader.next()
             
             fieldName=[]
@@ -314,14 +314,14 @@ def readDay(fctd,fHK):
             fields.append(row0[2])
             
             headerInfo = zip(fieldName,fields)
-            print headerInfo
+            print(headerInfo)
             
             novaFloat = dict(headerInfo)
             novaFloat = defaultdict(list,novaFloat)
             
             row1 = reader.next()
             row2 = reader.next()
-            print row1,row2
+            print(row1, row2)
             
             varName=[]
             for itemi,fitemi in zip(row1,row2):
@@ -367,14 +367,14 @@ def novafloatReader(fdataPath,dayi,novaFloatSN):
     folderName = str(yeari)+'-'+str(monthi).rjust(2,'0')+'-'+str(dayi).rjust(2,'0')
     
     
-    print "folderName:",folderName
+    print(f"folderName: {folderName}")
     fpathc = fdataPath+'/'+folderName+'/'
     
     novaFloatDeployment=[]
     for dirname,dirnames,filenames  in os.walk(fpathc):
 #        print len(filenames)
         if len(filenames) > 0:
-            print filenames
+            print(filenames)
             
 #            exit(1)
             ctdFilename = []
@@ -397,7 +397,7 @@ def novafloatReader(fdataPath,dayi,novaFloatSN):
                 
             if len(ctdFilename)> 1:
 #                pass
-                print ctdFilename
+                print(ctdFilename)
                 for filei in ctdFilename:
                     if folderName in filei:
 #                        currentDay = filei
@@ -415,9 +415,9 @@ def novafloatReader(fdataPath,dayi,novaFloatSN):
                         substr= "ASCENT_"
                         lenSubStr = len(substr)
                         indx = filei.find(substr)
-                        print filei
-                        print indx, filei[indx:indx+lenSubStr]
-                        print filei[indx+lenSubStr:indx+lenSubStr+10]
+                        print(filei)
+                        print(indx, filei[indx:indx+lenSubStr])
+                        print(filei[indx+lenSubStr:indx+lenSubStr+10])
                         
 
                         if "PARTIAL" in filei:
@@ -477,10 +477,10 @@ if __name__=="__main__":
 
     
     year1,month1,day1 = startDate.split('-')
-    print year1,month1,day1
+    print(year1, month1, day1)
     
     year2,month2,day2 = endDate.split('-')
-    print year2,month2,day2    
+    print(year2, month2, day2)
 
 #    MJD0 = jdcal.jcal2jd(year1,refMonth,refDay)[1]
     
@@ -516,7 +516,7 @@ if __name__=="__main__":
         
 #        if len(novaFloatDeployment) > 1:
         for floati in novaFloatDeployment:
-            print floati 
+            print(floati)
             datenum.append(floati["time"])
 
             latTmp = float(floati["GPSLAT"])
@@ -530,7 +530,7 @@ if __name__=="__main__":
             if latTmp > 180 or lonTmp > 180:
                 latTmp = float(floati["IRIDLAT"])
                 lonTmp = float(floati["IRIDLON"])
-                print latTmp,lonTmp, type(latTmp),type(lonTmp)
+                print(latTmp,lonTmp, type(latTmp),type(lonTmp))
                 
                 
 #            if False:
@@ -587,8 +587,8 @@ if __name__=="__main__":
          pickle.dump((salinity,temperature,pressure,lat,lon,datenum),f)
     
 #    exit(1)
-    print type(lat)
-    print len(salt),len(temp),len(pres)
+    print(type(lat))
+    print(len(salt), len(temp), len(pres))
     
 #    import matplotlib.pyplot as plt
     

--- a/scripts/usingFloat2extracCls4.py
+++ b/scripts/usingFloat2extracCls4.py
@@ -8,11 +8,8 @@ and
 @author: xuj
 """
 
-import errno
-
 #dt0= datetime.strptime(timeStr, "%Y-%m-%d %H:%M")
 import os
-import sys
 from datetime import datetime
 
 import cPickle as pickle
@@ -21,7 +18,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from netCDF4 import Dataset
 from novaFloatGiopsIce import novafloatIce
-from scipy import interpolate
 
 global novaId 
 
@@ -35,7 +31,7 @@ def readfromCls4file(fname,dayStr):
     foutPath = getOutPath()
     
     DEVELOPING=False 
-    print fname 
+    print(fname)
     figName = (fname.split('/')[-1])[:-3]
 
 #    print figName 
@@ -115,7 +111,7 @@ def readfromCls4file(fname,dayStr):
             try:
                 persistence = np.squeeze(cfile.variables["persistence"][novaIdx,:,:,:])
             except KeyError:
-                print "There is no persistence variable in this file:", fname
+                print(f"There is no persistence variable in this file: {fname}")
                 persistence=np.empty_like(forecast)*np.NaN
     
             cfile.close()
@@ -177,7 +173,7 @@ def readfromCls4file(fname,dayStr):
         #        plt.show()
                 
                 figName = foutPath+figName+'.png'
-                print figName 
+                print(figName)
                 plt.savefig(figName)
                 plt.close()            
 
@@ -212,7 +208,7 @@ def getFname(fCls4path,dayStr,modelStr):
         else :
             fileExist =False 
             
-            print "file missing on this day:" ,modelStr,dayStr
+            print("file missing on this day:" ,modelStr,dayStr)
     
         
     elif "FOAM" in modelStr:
@@ -222,7 +218,7 @@ def getFname(fCls4path,dayStr,modelStr):
             fname = fCls4path+foamFileName
             
         else:
-            print "file missing on this day:" ,modelStr, dayStr
+            print("file missing on this day:" ,modelStr, dayStr)
             fileExist =False 
                     
         
@@ -231,7 +227,7 @@ def getFname(fCls4path,dayStr,modelStr):
         if os.path.isfile(fCls4path+psy4Filename):
             fname = fCls4path+psy4Filename    
         else:
-            print "file missing on this day:", modelStr, dayStr
+            print("file missing on this day:", modelStr, dayStr)
             fileExist =False 
                         
     elif "HYCOM" in modelStr:        
@@ -239,16 +235,16 @@ def getFname(fCls4path,dayStr,modelStr):
         if os.path.isfile(fCls4path+psy4Filename):
             fname = fCls4path+psy4Filename    
         else:
-            print "file missing on this day:", modelStr, dayStr
+            print("file missing on this day:", modelStr, dayStr)
             fileExist =False 
 
 
     elif "NERSC" in modelStr:        
-        psy4Filename = "class4_"+dayStr+"_NERSC_ARCMFC_v3_profile.nc" 
+        psy4Filename = f"class4_{dayStr}_NERSC_ARCMFC_v3_profile.nc" 
         if os.path.isfile(fCls4path+psy4Filename):
             fname = fCls4path+psy4Filename    
         else:
-            print "file missing on this day:", modelStr, dayStr
+            print("file missing on this day:", modelStr, dayStr)
             fileExist =False 
 
     elif "BLK" in modelStr:        
@@ -256,7 +252,7 @@ def getFname(fCls4path,dayStr,modelStr):
         if os.path.isfile(fCls4path+psy4Filename):
             fname = fCls4path+psy4Filename    
         else:
-            print "file missing on this day:", modelStr, dayStr
+            print("file missing on this day:", modelStr, dayStr)
             fileExist =False 
 
         
@@ -266,7 +262,7 @@ def getFname(fCls4path,dayStr,modelStr):
 def readGiopsIce(lat,lon,datenum):
     di = 0            
     for datei in datenum:
-        print datei 
+        print(datei)
         dt0= datetime.strptime(datei, "%Y-%m-%d %H:%M:%S")
         dt1 = mdates.date2num(dt0)
 #        dt2 = mdates.num2date(dt1)
@@ -287,7 +283,7 @@ def readGiopsIce(lat,lon,datenum):
         
     
 
-    return giopsIce
+    return aice # was giopsIce but its not defined 
 
     
 if __name__=="__main__":
@@ -317,8 +313,8 @@ if __name__=="__main__":
         with open(floatIceData,'w') as f: 
             pickle.dump((aice,datenumAice),f)
 
-    print np.shape(aice)
-    print np.shape(datenumAice)
+    print(np.shape(aice))
+    print(np.shape(datenumAice))
     
     aice = np.squeeze(np.array(aice))
     TEMPERATURE =[]
@@ -377,7 +373,7 @@ if __name__=="__main__":
 
         di = 0            
         for datei in datenum:
-            print datei 
+            print(datei)
             dt0= datetime.strptime(datei, "%Y-%m-%d %H:%M:%S")
             dt1 = mdates.date2num(dt0)
             dt2 = mdates.num2date(dt1)
@@ -386,7 +382,7 @@ if __name__=="__main__":
             taxis.append(dt1)        
             
             dayStr = str(dt0.year)+str(dt0.month).rjust(2,'0')+str(dt0.day).rjust(2,'0')
-            print dayStr
+            print(dayStr)
             
     
             
@@ -395,10 +391,10 @@ if __name__=="__main__":
             if fileExist:
                 novaIn,climatology,persistence,forecast,bestEstimate,dayObs,depth = readfromCls4file(fname,dayStr)
                 
-                print type(dayObs),np.shape(dayObs)
-                print np.shape(depth)
-                print np.shape(forecast)
-                print np.shape(bestEstimate)
+                print(type(dayObs), np.shape(dayObs))
+                print(np.shape(depth))
+                print(np.shape(forecast))
+                print(np.shape(bestEstimate))
                 
                 
 #                unmaskedDayObs = np.ma.masked_equal(dayObs,True)
@@ -412,9 +408,9 @@ if __name__=="__main__":
                 
 #                exit(1)
                 if novaIn:
-                    print np.shape(climatology)
-                    print np.shape(depth)
-                    print np.shape(persistence)
+                    print(np.shape(climatology))
+                    print(np.shape(depth))
+                    print(np.shape(persistence))
     
                     errorClimate = climatology - dayObs
     
@@ -430,12 +426,12 @@ if __name__=="__main__":
                     
                     errorBest    = bestEstimate - dayObs
                     
-                    print np.shape(errorClimate),np.shape(errorPersist)
-                    print np.shape(errorForcast),np.shape(errorBest)
+                    print(np.shape(errorClimate), np.shape(errorPersist))
+                    print(np.shape(errorForcast), np.shape(errorBest))
                     
                     rmsClimat = np.sqrt(np.mean(errorClimate**2,axis=1))
                     biasClimat = np.mean(errorClimate,axis=1)
-                    print np.shape(rmsClimat)
+                    print(np.shape(rmsClimat))
                     
                     rmsPersist = np.sqrt(np.mean(errorPersist**2,axis=2))
                     rmsCast    = np.sqrt(np.mean(errorForcast**2,axis=2))
@@ -478,8 +474,8 @@ if __name__=="__main__":
                         DEPTH.extend(depth[dataIdx])                        
                         
                     else:
-                        print "now", di
-                        print tempSize, saliSize
+                        print("now", di)
+                        print(tempSize, saliSize)
 #                        print dayObs
 #                        exit(1)                        
                     
@@ -507,9 +503,9 @@ if __name__=="__main__":
                             
                             CLIMATOLOGY = np.hstack((CLIMATOLOGY,climatology[:,dataIdx]))
                             temp =forecast[:,:,dataIdx]
-                            print np.shape(temp),np.shape(FORECAST)
+                            print(np.shape(temp),np.shape(FORECAST))
                             FORECAST= np.dstack((FORECAST,forecast[:,:,dataIdx]))
-                            print np.shape(temp),np.shape(FORECAST)
+                            print(np.shape(temp),np.shape(FORECAST))
                         
                         
 #                        np.append(BESTESTIMATION,bestEstimate[1,dataIdx],1)
@@ -564,7 +560,7 @@ if __name__=="__main__":
                         plt.close()
     #                plt.subplot(122)
                     
-                    print np.shape(rmsClimat),rmsClimat
+                    print(np.shape(rmsClimat),rmsClimat)
                     
     #                if hasattrdayObs, 'mask'):
     #                    dayObs.mask[np.where(qc==badDataFlag)]=True
@@ -576,12 +572,12 @@ if __name__=="__main__":
     #                exit(1)
                     
                 else:
-                    print "There is no Nova float data for this Day:", dayStr
+                    print(f"There is no Nova float data for this Day:{dayStr}")
             
     
                 
-            print np.shape(dateNum)           
-            print np.shape(rmsError120Z)
+            print(np.shape(dateNum))      
+            print(np.shape(rmsError120Z))
         
         with open(modelFile,'w') as f:        
             pickle.dump((rmsError120Z,rmsBest,rmsClimatology,biasError120Z,biasBest,biasClimatology,dateNum),f)
@@ -649,8 +645,8 @@ if __name__=="__main__":
     
     
     
-    print np.shape(taxis)
-    print np.shape(salt)
-    print np.shape(temp)
-    print np.shape(pres)
+    print(np.shape(taxis))
+    print(np.shape(salt))
+    print(np.shape(temp))
+    print(np.shape(pres))
     

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,5 +1,5 @@
-"""Unit tests for plotting.colormap module.
-"""
+"""Unit tests for plotting.colormap module."""
+
 import unittest
 
 import plotting.colormap

--- a/tests/test_data_class4.py
+++ b/tests/test_data_class4.py
@@ -1,5 +1,5 @@
-"""Unit tests for data.class4 module.
-"""
+"""Unit tests for data.class4 module."""
+
 import shutil
 from pathlib import Path
 

--- a/tests/test_netcdf_data.py
+++ b/tests/test_netcdf_data.py
@@ -1,5 +1,5 @@
-"""Unit tests for data.netcdf_data.
-"""
+"""Unit tests for data.netcdf_data."""
+
 import datetime
 import json
 import os

--- a/tests/test_scriptGen.py
+++ b/tests/test_scriptGen.py
@@ -68,9 +68,9 @@ class TestScriptGenerator:
 
         plotQuery = (
             '{"area":[{"innerrings":[],"name":"","polygons":[[[57.45537472457255,'
-            '-53.32611083984376],[54.96545403664038,-35.91699909988563],['
-            '37.492919230762624,-40.57520222488561],[39.21584183791197,'
-            '-60.08692097488562],[57.45537472457255,-53.32611083984376]]]}],'
+            "-53.32611083984376],[54.96545403664038,-35.91699909988563],["
+            "37.492919230762624,-40.57520222488561],[39.21584183791197,"
+            "-60.08692097488562],[57.45537472457255,-53.32611083984376]]]}],"
             '"bathymetry":true,"colormap":"default","contour":{"colormap":"default"'
             ',"hatch":false,"legend":true,"levels":"auto","variable":"none"},'
             '"dataset":"giops_day","depth":0,"interp":"gaussian","neighbours":10,'
@@ -96,16 +96,16 @@ class TestScriptGenerator:
 
         plotQuery = (
             '{"area":[{"innerrings":[],"name":"","polygons":[[[57.45537472457255,'
-            '-53.32611083984376],[54.96545403664038,-35.91699909988563],['
-            '37.492919230762624,-40.57520222488561],[39.21584183791197,'
-            '-60.08692097488562],[57.45537472457255,-53.32611083984376]]]}],'
+            "-53.32611083984376],[54.96545403664038,-35.91699909988563],["
+            "37.492919230762624,-40.57520222488561],[39.21584183791197,"
+            "-60.08692097488562],[57.45537472457255,-53.32611083984376]]]}],"
             '"bathymetry":true,"colormap":"default","contour":{"colormap":"default"'
             ',"hatch":false,"legend":true,"levels":"auto","variable":"none"},'
             '"dataset":"giops_day","depth":0,"interp":"gaussian","neighbours":10,'
             '"projection":"EPSG:3857","quiver":{"colormap":"default","magnitude":'
             '"length","variable":"none"},"radius":25,"scale":"-5,30,auto",'
             '"showarea":true,"time":862,"type":"map","variable":"votemper"}&save'
-            '&format=csv&size=10x7&dpi=144'
+            "&format=csv&size=10x7&dpi=144"
         )
         data = generateR(plotQuery)
         newData = data.read()
@@ -128,7 +128,7 @@ class TestScriptGenerator:
             '-60.08692097488562","output_format":"NETCDF4","should_zip":0,"time":'
             '"857,862","user_grid":0,"variables":"vice,votemper,vozocrtx,vomecrty"}'
         )
-        data = generateR(plotQuery, None, 'subset')
+        data = generateR(plotQuery, None, "subset")
         newData = data.read()
         m = hashlib.md5()
         m.update(newData)


### PR DESCRIPTION
## Background
I wanted to look at some of the scripts but I did not want to install python2.  Then I ran `black .` and that changed other files.

## Why did you take this approach?
This was the least invasive approach.  converting more of these strings to f-strings would be better but I am not sure what the code style is for this repo.

The changes outside of scripts were auto formats by black.

## Checks
I went to run the unit tests and I got this far down the dependencies before giving up.

`pip install xarray ply fastapi metpy flask dask sentry_sdk gsw pyinstrument geopy pyresample pydantic_settings babel views` 

Do you have a requirements file? 

- [ ] I ran unit tests.
- [ ] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.