### PR TITLE
Wrap subsets that cross 0° and set output longitude range to -180° to 180° 

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -312,11 +312,6 @@ class NetCDFData(Data):
         lon_var = find_variable("lon", list(self.dataset.variables.keys()))
 
         depth_var = find_variable("depth", list(self.dataset.variables.keys()))
-        # re-indexing longitude from -180 to 180
-        # self.dataset = self.dataset.assign_coords(
-        #     {lon_var: (((self.dataset[lon_var] + 180) % 360) - 180)}
-        # )
-        # self.dataset = self.dataset.sortby(lon_var)
 
         # self.get_dataset_variable should be used below instead of
         # self.dataset.variables[...] because self.dataset.variables[...]

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -367,7 +367,6 @@ class NetCDFData(Data):
                     )
                 ]
 
-            # self.dataset = [self.dataset.isel({y_coord: y_slice, x_coord: x_slice}) for x_slice in x_slices]
             subset_list = [
                 self.dataset.isel({y_coord: y_slice, x_coord: x_slice})
                 for x_slice in x_slices

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -317,7 +317,7 @@ class NetCDFData(Data):
         depth_var = find_variable("depth", list(self.dataset.variables.keys()))
         #re-indexing longitude from -180 to 180
         self.dataset = self.dataset.assign_coords(
-            {lon_var: (((self.dataset.longitude + 180) % 360) - 180)}
+            {lon_var: (((self.dataset[lon_var] + 180) % 360) - 180)}
         )
         self.dataset = self.dataset.sortby(lon_var)
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -426,9 +426,6 @@ class NetCDFData(Data):
                 subset = subset.assign(
                     **{
                         variable: self.get_dataset_variable(variable).isel(
-                            **{
-                                y_coord: slice(0, subset[y_coord].size),
-                                x_coord: slice(0, subset[x_coord].size),
                     **{
                         variable: self.get_dataset_variable(variable).isel(
                             **{

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -403,7 +403,6 @@ class NetCDFData(Data):
             )
 
         dataset_name = query.get("dataset")
-        y_coord, x_coord = self.yx_dimensions
         subset = self.dataset
         # Select requested time (time range if applicable)
         if apply_time_range:

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -25,9 +25,6 @@ from data.variable import Variable
 from data.variable_list import VariableList
 from oceannavigator.dataset_config import DatasetConfig
 
-import xarray as xr
-import numpy as np
-
 
 class NetCDFData(Data):
     """Handles reading of netcdf files.

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -25,6 +25,10 @@ from data.variable import Variable
 from data.variable_list import VariableList
 from oceannavigator.dataset_config import DatasetConfig
 
+import xarray as xr
+import numpy as np
+
+
 
 class NetCDFData(Data):
     """Handles reading of netcdf files.
@@ -309,6 +313,9 @@ class NetCDFData(Data):
         lon_var = find_variable("lon", list(self.dataset.variables.keys()))
 
         depth_var = find_variable("depth", list(self.dataset.variables.keys()))
+
+        self.dataset = self.dataset.assign_coords({lon_var: (((self.dataset.longitude + 180) % 360) - 180)})
+        self.dataset= self.dataset.sortby(lon_var)
 
         # self.get_dataset_variable should be used below instead of
         # self.dataset.variables[...] because self.dataset.variables[...]

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -429,7 +429,15 @@ class NetCDFData(Data):
                             **{
                                 y_coord: slice(0, subset[y_coord].size),
                                 x_coord: slice(0, subset[x_coord].size),
-                                })})
+                    **{
+                        variable: self.get_dataset_variable(variable).isel(
+                            **{
+                                y_coord: slice(0, subset[y_coord].size),
+                                x_coord: slice(0, subset[x_coord].size),
+                            }
+                        )
+                    }
+                )
             # Cast each attribute to str (allows exporting to all NC formats)
             subset[variable].attrs = {
                 key: str(value) for key, value in subset[variable].attrs.items()

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -437,7 +437,7 @@ class NetCDFData(Data):
             subset[variable].attrs = {
                 key: str(value) for key, value in subset[variable].attrs.items()
             }
-        #convering lat values to -180 to 180
+        # converting longitude values to -180 to 180
         subset = subset.assign_coords({lon_var: (((subset[lon_var] + 180) % 360) - 180)})
         subset = subset.sortby(lon_var)
 

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -426,8 +426,6 @@ class NetCDFData(Data):
                 subset = subset.assign(
                     **{
                         variable: self.get_dataset_variable(variable).isel(
-                    **{
-                        variable: self.get_dataset_variable(variable).isel(
                             **{
                                 y_coord: slice(0, subset[y_coord].size),
                                 x_coord: slice(0, subset[x_coord].size),

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -347,8 +347,8 @@ class NetCDFData(Data):
                 min(y0_index, y1_index, y2_index, y3_index),
                 max(y0_index, y1_index, y2_index, y3_index),
             )
+            # check that selected area is not wrapped around edges of NetCDF data
             if x0_index > x1_index:
-
                 x_slices = [
                     slice(
                         max(x0_index, x1_index, x2_index, x3_index),

--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -444,7 +444,7 @@ class NetCDFData(Data):
             }
         # converting longitude values to -180 to 180
         subset = subset.assign_coords({lon_var: (((subset[lon_var] + 180) % 360) - 180)})
-        subset = subset.sortby(lon_var)
+        subset = subset.sortby(x_coord)
 
         output_format = query.get("output_format")
         filename = (


### PR DESCRIPTION
## Background
Previously, the longitude values in the dataset ranged from 0° to 360°, which caused issues when selecting regions that crossed the dateline (180°). As a result, when users plotted areas near the border (e.g., across ±180°), the subsetting logic failed and returned data for the entire globe instead of just the selected region

## Why did you take this approach?
This pull request fixes those issues by:

Normalizing longitudes to -180° to 180°

Correctly identifying and slicing the region, even if it crosses the antimeridian

Ensuring the output NetCDF file reflects only the requested area


## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
