### PR TITLE
added a smooth transition at zoom level 7

### DIFF
--- a/oceannavigator/frontend/src/components/Map/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map/Map.jsx
@@ -967,7 +967,7 @@ const Map = forwardRef((props, ref) => {
     }
 
     const vectorTileGrid = new olTilegrid.createXYZ({
-      tileSize: 512,
+      tileSize: 256,
       maxZoom: MAX_ZOOM[props.mapSettings.projection],
     });
 
@@ -1045,7 +1045,7 @@ const Map = forwardRef((props, ref) => {
       mapLayers[4].setSource(null);
     } else {
       const vectorTileGrid = new olTilegrid.createXYZ({
-        tileSize: 512,
+        tileSize: 256,
         maxZoom: MAX_ZOOM[props.mapSettings.projection],
       });
 
@@ -1063,7 +1063,6 @@ const Map = forwardRef((props, ref) => {
         new VectorTile({
           format: new MVT(),
           tileGrid: vectorTileGrid,
-          tilePixelRatio: 8,
           url: `/api/v2.0/mbt/bath/{z}/{x}/{y}?projection=${props.mapSettings.projection}`,
           projection: props.mapSettings.projection,
         })

--- a/oceannavigator/frontend/src/components/Map/utils.js
+++ b/oceannavigator/frontend/src/components/Map/utils.js
@@ -86,9 +86,10 @@ export const getBasemap = (
       const shadedRelief = topoShadedRelief ? "true" : "false";
       return new TileLayer({
         preload: 1,
+        maxZoom:7-1e-10,       
         source: new XYZ({
           url: `/api/v2.0/tiles/topo/{z}/{x}/{y}?shaded_relief=${shadedRelief}&projection=${projection}`,
-          projection: projection,
+          projection: projection,           
         }),
       });
     case "ocean":
@@ -140,7 +141,7 @@ export const createMap = (
   );
 
   const vectorTileGrid = new olTilegrid.createXYZ({
-    tileSize: 512,
+    tileSize: 256,
     maxZoom: maxZoom,
   });
 
@@ -170,7 +171,7 @@ export const createMap = (
     }),
     opacity: mapSettings.mapBathymetryOpacity,
     visible: mapSettings.bathymetry,
-    preload: 1,
+     preload: 1,
   });
 
   const newLayerBathShapes = new VectorTileLayer({


### PR DESCRIPTION
#1195 
## Background
Zoom level 8 returns empty topographic basemap tiles , because of the transition from topography tiles to mbt tiles.Fixed logic for a smoother transition and no more empty tile is returned.

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
