### PR TITLE
dataset selector window dimesion fixed.

### DIFF
--- a/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
+++ b/oceannavigator/frontend/src/stylesheets/components/_DatasetDropdown.scss
@@ -6,7 +6,8 @@
 
   .row {
     margin: 0;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    align-items: center;
   }
 
   .dd-label {
@@ -15,8 +16,12 @@
   }
 
   .dd-toggle {
-    display: flex;
-    width: 300px;
+    position: relative;
+    display: inline-flex;
+    flex-wrap: wrap;
+    width: auto;
+    max-width: 100%;
+    white-space: normal; 
     font-size: 10pt;
     font-weight: 400;
     line-height: 1.5;
@@ -29,10 +34,10 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    max-width: 250px;
     padding: 0;
     margin: 5px !important;
     flex-direction: row;
+    padding-right: 1.5em;
     align-items: center;
   }
 
@@ -48,6 +53,10 @@
   }
 
   .dd-toggle-caret {
+    position: absolute;
+    top:35%;
+    right: 0.01rem;
+    transform: translate(-50%);
     width: 24px;
     height: 12px;
     background-color: #fff;


### PR DESCRIPTION
##1197
## Background
Dataset selector CSS in plot windows: Dropdown too wide, title misalignment fixed.
## Why did you take this approach?

## Checks
- [x] I ran unit tests.
- [x] I've tested the relevant changes from a user POV.
- [x] I've formatted my Python code using `black .`.

_Hint_ To run all python unit tests run the following command from the root repository directory:
```sh
bash run_python_tests.sh
```
