### PR TITLE
Restore enclosed area feature selection

### DIFF
--- a/oceannavigator/frontend/src/components/Map/Map.jsx
+++ b/oceannavigator/frontend/src/components/Map/Map.jsx
@@ -158,71 +158,6 @@ const Map = forwardRef((props, ref) => {
     getLineDistance: getLineDistance,
   }));
 
-  //styles for hover select
-  const createHoverSelect = (selectInteraction, layerFeatureVector) => {
-    const hoverStyle = new Style({
-      image: new Circle({
-        radius: 4,
-        fill: new Fill({
-          color: "#00ffff",
-        }),
-        stroke: new Stroke({
-          color: "#000000",
-        }),
-      }),
-      stroke: new Stroke({
-        color: "#00ffff",
-        width: 4,
-      }),
-      fill: new Fill({
-        color: "rgba(0,255,255,0.1)",
-      }),
-    });
-
-    const selectedHoverStyle = new Style({
-      stroke: new Stroke({
-        color: "#0099ff",
-        width: 4,
-      }),
-      fill: new Fill({
-        color: "rgba(0,153,255,0.3)", 
-      }),
-      image: new Circle({
-        radius: 4,
-        fill: new Fill({
-          color: "#0099ff",
-        }),
-        stroke: new Stroke({
-          color: "#ffffff",
-          width: 1,
-        }),
-      }),
-    });
-
-    const hoverSelect = new Select({
-      condition: pointerMove,
-      style: function (feature, resolution) {
-        // Skip annotation features
-        if (feature.get("annotation")) {
-          return null;
-        }
-
-        const selectedFeatures = selectInteraction.getFeatures().getArray();
-        if (selectedFeatures.includes(feature)) {
-          return selectedHoverStyle;
-        }
-
-        return hoverStyle;
-      },
-      layers: [layerFeatureVector],
-      filter: function (feature, layer) {
-        return !feature.get("annotation");
-      },
-    });
-
-    return hoverSelect;
-  };
-
   useEffect(() => {
     let overlay = new Overlay({
       element: popupElement0.current,
@@ -342,7 +277,7 @@ const Map = forwardRef((props, ref) => {
         MAX_ZOOM[props.mapSettings.projection],
         mapRef1
       );
-      
+
       const newSelect = createSelect();
       const newHoverSelect = createHoverSelect(
         newSelect,
@@ -561,6 +496,68 @@ const Map = forwardRef((props, ref) => {
     });
 
     return newSelect;
+  };
+
+  const createHoverSelect = (selectInteraction, layerFeatureVector) => {
+    const hoverSelect = new Select({
+      condition: pointerMove,
+      style: function (feature, resolution) {
+        const selectedFeatures = selectInteraction.getFeatures().getArray();
+        let fillColor = selectedFeatures.includes(feature)
+          ? "#0099ff"
+          : "#ff0000";
+        if (feature.get("type") === "Point") {
+          return new Style({
+            stroke: new Stroke({
+              color: "#ffffff88",
+              width: 16,
+            }),
+            image: new Circle({
+              radius: 6,
+              fill: new Fill({
+                color: fillColor,
+              }),
+              stroke: new Stroke({
+                color: "#ffffffff",
+                width: 3,
+              }),
+            }),
+          });
+        }
+        return [
+          new Style({
+            stroke: new Stroke({
+              color: "#ffffff22",
+              width: 16,
+            }),
+          }),
+          new Style({
+            stroke: new Stroke({
+              color: "#ffffff88",
+              width: 12,
+            }),
+          }),
+          new Style({
+            stroke: new Stroke({
+              color: "#ffffffff",
+              width: 8,
+            }),
+          }),
+          new Style({
+            stroke: new Stroke({
+              color: fillColor,
+              width: 4,
+            }),
+          }),
+        ];
+      },
+      layers: [layerFeatureVector],
+      filter: function (feature, layer) {
+        return !feature.get("annotation");
+      },
+    });
+
+    return hoverSelect;
   };
 
   const getFeatures = () => {

--- a/oceannavigator/frontend/src/components/Map/utils.js
+++ b/oceannavigator/frontend/src/components/Map/utils.js
@@ -303,24 +303,21 @@ export const createMap = (
         popupElement.current.innerHTML = feature.get("name");
       }
 
-      if (feature.get("type") == "area") {
+      if (feature.get("type") == "Polygon") {
         mapObject.forEachFeatureAtPixel(e.pixel, function (f) {
           selected = f;
           f.setStyle([
             new Style({
               stroke: new Stroke({
                 color: "#ffffff",
-                width: 2,
-              }),
-              fill: new Fill({
-                color: "#ffffff80",
-              }),
+                width: 5,
+              })
             }),
             new Style({
               stroke: new Stroke({
-                color: "#000000",
-                width: 1,
-              }),
+                color: "#ff0000",
+                width: 3,
+              })
             }),
             new Style({
               geometry: new olgeom.Point(
@@ -541,65 +538,20 @@ export const createFeatureVectorLayer = (source, mapSettings) => {
       } else {
         switch (feat.get("type")) {
           case "Polygon":
-            const almostInvisibleFill = new Fill({
-              color: "rgba(255,255,255,0.01)",
-            });
-
-            if (feat.get("key")) {
-              return [
-                new Style({
-                  stroke: new Stroke({
-                    color: "#ffffff",
-                    width: 2,
-                  }),
-                  fill: almostInvisibleFill,
-                }),
-                new Style({
-                  stroke: new Stroke({
-                    color: "#000000",
-                    width: 1,
-                  }),
-                  fill: almostInvisibleFill,
-                }),
-                new Style({
-                  geometry: new olgeom.Point(
-                    olProj.transform(
-                      feat.get("centroid"),
-                      "EPSG:4326",
-                      mapSettings.projection
-                    )
-                  ),
-                  text: new Text({
-                    text: feat.get("name"),
-                    font: "14px sans-serif",
-                    fill: new Fill({
-                      color: "#000",
-                    }),
-                    stroke: new Stroke({
-                      color: "#ffffff",
-                      width: 2,
-                    }),
-                  }),
-                }),
-              ];
-            } else {
-              return [
-                new Style({
-                  stroke: new Stroke({
-                    color: "#ffffff",
-                    width: 5,
-                  }),
-                  fill: almostInvisibleFill,
-                }),
-                new Style({
-                  stroke: new Stroke({
-                    color: "#ff0000",
-                    width: 3,
-                  }),
-                  fill: almostInvisibleFill,
-                }),
-              ];
-            }
+            return [
+              new Style({
+                stroke: new Stroke({
+                  color: "#ffffff",
+                  width: 5,
+                })
+              }),
+              new Style({
+                stroke: new Stroke({
+                  color: "#ff0000",
+                  width: 3,
+                })
+              }),
+            ];
           case "LineString":
             return [
               new Style({


### PR DESCRIPTION
## Background
As described in #1230 users cannot selected an area feature enclosed by others due to issues with the fill added by the hover selection. To resolve this a wider stroke is used instead of completely filling the polygon.

## Why did you take this approach?
This still gives users feedback on which feature is under the mouse pointer without obstructing selection of other features. 

## Screenshots
Innermost area is selected:
<img width="493" height="492" alt="image" src="https://github.com/user-attachments/assets/ce291097-8b82-45e7-96c7-6e6dcdbebd49" />

## Checks
- [ ] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [ ] I've formatted my Python code using `black .`.
