### PR TITLE
Get all timestamps from dataset dbs

### DIFF
--- a/data/netcdf_data.py
+++ b/data/netcdf_data.py
@@ -1111,7 +1111,7 @@ class NetCDFData(Data):
         # to the same time units as the requested dataset. Otherwise
         # this won't work.
         if nearest_timestamp:
-            all_timestamps = db.get_timestamps(variable)
+            all_timestamps = db.get_variable_timestamps(variable)
 
             start = data.utils.find_le(all_timestamps, timestamp)
             if not endtime:
@@ -1127,7 +1127,7 @@ class NetCDFData(Data):
             return timestamp
 
         if timestamp < 0 and endtime is None:
-            all_timestamps = db.get_timestamps(variable)
+            all_timestamps = db.get_variable_timestamps(variable)
             return [all_timestamps[timestamp]]
 
         if timestamp > 0 and endtime > 0:
@@ -1136,7 +1136,7 @@ class NetCDFData(Data):
             return db.get_timestamp_range(timestamp, endtime, variable)
 
         # Otherwise assume negative values are indices into timestamp list
-        all_timestamps = db.get_timestamps(variable)
+        all_timestamps = db.get_variable_timestamps(variable)
         len_timestamps = len(all_timestamps)
         if timestamp < 0 and endtime > 0:
             idx = data.utils.roll_time(timestamp, len_timestamps)

--- a/data/sqlite_database.py
+++ b/data/sqlite_database.py
@@ -148,7 +148,18 @@ class SQLiteDatabase:
 
         return result[0] if result else ""
 
-    def get_timestamps(self, variable: str) -> List[int]:
+    def get_all_timestamps(self) -> List[int]:
+        """Retrieves all timestamps from the open database sorted in ascending order.
+
+        Returns:
+            * [list] -- List of all raw netCDF timestamps for this database.
+        """
+
+        self.c.execute("SELECT DISTINCT timestamp FROM Timestamps;")
+
+        return self.__flatten_list(self.c.fetchall())
+
+    def get_variable_timestamps(self, variable: str) -> List[int]:
         """Retrieves all timestamps for a given variable from the open database sorted in ascending order.
 
         Arguments:

--- a/routes/api_v2_0.py
+++ b/routes/api_v2_0.py
@@ -265,9 +265,9 @@ def timestamps(
                     config.calculated_variables[variable]["equation"],
                     [v.key for v in db.get_data_variables()],
                 )
-                vals = db.get_timestamps(data_vars[0])
+                vals = db.get_variable_timestamps(data_vars[0])
             else:
-                vals = db.get_timestamps(variable)
+                vals = db.get_variable_timestamps(variable)
             time_dim_units = config.time_dim_units
     else:
         with open_dataset(config, variable=variable) as ds:

--- a/tests/test_sqlite_database.py
+++ b/tests/test_sqlite_database.py
@@ -20,11 +20,11 @@ class TestSqliteDatabase(TestCase):
             ]
         )
 
-    def test_get_timestamps_returns_correct_timestamps_for_historical(self):
+    def test_get_variable_timestamps_returns_correct_timestamps_for_historical(self):
 
         with SQLiteDatabase(self.historical_db) as db:
 
-            timestamps = db.get_timestamps("vo")
+            timestamps = db.get_variable_timestamps("vo")
 
             self.assertTrue(self.historical_timestamps == timestamps)
 
@@ -121,7 +121,7 @@ class TestSqliteDatabase(TestCase):
         with SQLiteDatabase(self.historical_db) as db:
 
             ncfiles = db.get_netcdf_files(self.historical_timestamps, "fake_variable")
-            timestamps = db.get_timestamps("fake_variable")
+            timestamps = db.get_variable_timestamps("fake_variable")
             dims = db.get_variable_dims("fake_variable")
             units = db.get_variable_units("fake_variable")
 


### PR DESCRIPTION
## Background
Added a function to get all dataset timestamps from the dataset's sqlite3 database. This will be useful in upcoming features where we'll need to filter datasets by available datetimes. 

## Why did you take this approach?
Quickest way to get the available timestamps. We tried filtering using a variable key but the joins made the feature too slow to be practical. 

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.