### PR TITLE
Area plot clean up

### DIFF
--- a/oceannavigator/dataset_config.py
+++ b/oceannavigator/dataset_config.py
@@ -39,18 +39,14 @@ class DatasetConfig:
                 f"Loaded dataset config file from: {settings.dataset_config_file}"
             )
 
-        for name in config: 
+        for name in config:
             stub_file = f"{settings.dataset_config_stub_path}{name}.json"
 
-            with open(stub_file, "r") as f: 
+            with open(stub_file, "r") as f:
                 config[name] = json.load(f)[name]
-                log().debug(
-                    f"Loaded stub dataset config file from: {stub_file}"
-                )
+                log().debug(f"Loaded stub dataset config file from: {stub_file}")
 
         return config
-
-
 
     def _get_attribute(self, key: str) -> Union[str, dict]:
         return self._config.get(key) if not None else ""
@@ -369,14 +365,14 @@ class VariableConfig:
             return [self._variable.valid_min, self._variable.valid_max]
         else:
             return [0, 100]
-        
+
     @property
     def data_categories(self) -> list | None:
         """
         Returns ordered category labels for discrete/categorical variables.
         """
         try:
-            return self.__get_attribute('data_categories')
+            return self.__get_attribute("data_categories")
         except KeyError:
             return None
 

--- a/oceannavigator/frontend/src/components/data-selectors/TimeSlider.jsx
+++ b/oceannavigator/frontend/src/components/data-selectors/TimeSlider.jsx
@@ -409,8 +409,6 @@ function TimeSlider({ id, dataset, timestamps, selected, onChange }) {
     />
   ));
 
-  console.log(dataset.id, timestamps.length, thumbLeft, selectedIndex);
-
   return (
     <div
       className="time-slider"

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -275,14 +275,10 @@ class MapPlotter(Plotter):
                 ]
             )
 
-        elif abs(self.centroid[1] - self.bounds[1]) > 90:
-
-            if abs(self.bounds[3] - self.bounds[1]) > 360:
-                raise ClientError(("You have requested an area that exceeds the width \
-                        of the world. Thinking big is good but plots need to \
-                        be less than 360 deg wide."))  # gettext(
-            self.plot_projection = ccrs.Mercator(central_longitude=self.centroid[1])
-
+        elif abs(self.bounds[3] - self.bounds[1]) > 360:
+            raise ClientError(("You have requested an area that exceeds the width \
+                of the world. Thinking big is good but plots need to \
+                be less than 360 deg wide."))  # gettext()
         else:
             self.plot_projection = ccrs.Mercator(
                 central_longitude=self.centroid[1],

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -6,18 +6,19 @@ import pickle
 import threading
 import tempfile
 from textwrap import wrap
-from typing import Union
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import cartopy.img_transform as cimg_transform
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.axes import Axes
 from matplotlib.colors import FuncNorm
+from matplotlib.figure import Figure
 from matplotlib.patches import Patch, PathPatch, Polygon
 from matplotlib.path import Path
 from osgeo import gdal, osr
-from shapely.geometry import box, LinearRing, MultiPolygon, Point, Polygon as Poly
+from shapely.geometry import LinearRing, MultiPolygon, Point, Polygon as Poly
 from shapely.ops import unary_union
 
 import plotting.colormap as colormap
@@ -30,7 +31,6 @@ from utils.errors import ClientError
 from utils.misc import list_areas
 
 from oceannavigator.settings import get_settings
-
 
 settings = get_settings()
 
@@ -47,10 +47,8 @@ class MapPlotter(Plotter):
         super().parse_query(query)
 
         if len(self.variables) > 1:
-            raise ClientError(
-                f"MapPlotter only supports 1 variable. \
-                    Received multiple: {self.variables}"
-            )
+            raise ClientError(f"MapPlotter only supports 1 variable. \
+                    Received multiple: {self.variables}")
 
         self.projection = query.get("projection")
 
@@ -143,28 +141,34 @@ class MapPlotter(Plotter):
     def get_land_geoms(self, extent: tuple) -> list:
         # Returns a list of land shape geometries that intersect the plot extent
         scaler = cfeature.AdaptiveScaler("110m", (("50m", 50), ("10m", 15)))
-        land_shp = cfeature.NaturalEarthFeature(
-            "physical", "land", scale=scaler.scale_from_extent(extent)
-        )
+        scale = scaler.scale_from_extent(extent)
+
+        land_feats = cfeature.NaturalEarthFeature("physical", "land", scale=scale)
+        lake_feats = cfeature.NaturalEarthFeature("physical", "lakes", scale=scale)
 
         lon_min, lon_max, lat_min, lat_max = extent
 
-        geometries = []
+        exts = []
         if lon_min <= lon_max:
-            bbox = box(lon_min, lat_min, lon_max, lat_max)
-            for geom in land_shp.geometries():
-                inter = geom.intersection(bbox)
-                if not inter.is_empty:
-                    geometries.append(inter)
+            exts.append(extent)
         else:
-            # plot wraps longitudes
-            west_box = box(lon_min, lat_min, 180, lat_max)
-            east_box = box(-180, lat_min, lon_max, lat_max)
-            for geom in land_shp.geometries():
-                for bb in (west_box, east_box):
-                    inter = geom.intersection(bb)
-                    if not inter.is_empty:
-                        geometries.append(inter)
+            # plot wraps longitudes - process each side separately
+            west_ext = (lon_min, lat_min, 180, lat_max)
+            east_ext = (-180, lat_min, lon_max, lat_max)
+            exts.extend([west_ext, east_ext])
+
+        geometries = []
+        for ext in exts:
+            land_geoms = land_feats.intersecting_geometries(ext)
+            land_geoms = unary_union(list(land_geoms))
+
+            if land_geoms.is_empty:
+                continue
+
+            lake_geoms = lake_feats.intersecting_geometries(ext)
+            lake_geoms = unary_union(list(lake_geoms))
+
+            geometries.append(land_geoms.difference(lake_geoms))
 
         return geometries
 
@@ -173,7 +177,7 @@ class MapPlotter(Plotter):
         extent: list,
         figuresize: list,
         dpi: int,
-    ) -> Union[plt.figure, plt.axes]:
+    ) -> Figure | Axes:
 
         CACHE_DIR = settings.cache_dir
         filename = self._get_filename(self.plot_projection.proj4_params["proj"], extent)
@@ -289,13 +293,9 @@ class MapPlotter(Plotter):
         elif abs(self.centroid[1] - self.bounds[1]) > 90:
 
             if abs(self.bounds[3] - self.bounds[1]) > 360:
-                raise ClientError(
-                    (  # gettext(
-                        "You have requested an area that exceeds the width \
+                raise ClientError(("You have requested an area that exceeds the width \
                         of the world. Thinking big is good but plots need to \
-                        be less than 360 deg wide."
-                    )
-                )
+                        be less than 360 deg wide."))  # gettext(
             self.plot_projection = ccrs.Mercator(central_longitude=self.centroid[1])
 
         else:
@@ -816,7 +816,9 @@ class MapPlotter(Plotter):
                 self.data, self.dataset_config.variable[f"{self.variables[0]}"]
             )
 
-        data_categories = self.dataset_config.variable[self.variables[0]].data_categories
+        data_categories = self.dataset_config.variable[
+            self.variables[0]
+        ].data_categories
         c = ax.imshow(
             self.data,
             vmin=vmin,

--- a/plotting/map.py
+++ b/plotting/map.py
@@ -12,9 +12,7 @@ import cartopy.feature as cfeature
 import cartopy.img_transform as cimg_transform
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.axes import Axes
 from matplotlib.colors import FuncNorm
-from matplotlib.figure import Figure
 from matplotlib.patches import Patch, PathPatch, Polygon
 from matplotlib.path import Path
 from osgeo import gdal, osr
@@ -144,28 +142,15 @@ class MapPlotter(Plotter):
         scale = scaler.scale_from_extent(extent)
 
         land_feats = cfeature.NaturalEarthFeature("physical", "land", scale=scale)
-        lake_feats = cfeature.NaturalEarthFeature("physical", "lakes", scale=scale)
 
-        lon_min, lon_max, lat_min, lat_max = extent
-
-        exts = []
-        if lon_min <= lon_max:
-            exts.append(extent)
-        else:
-            # plot wraps longitudes - process each side separately
-            west_ext = (lon_min, lat_min, 180, lat_max)
-            east_ext = (-180, lat_min, lon_max, lat_max)
-            exts.extend([west_ext, east_ext])
+        land_geoms = land_feats.intersecting_geometries(extent)
+        land_geoms = unary_union(list(land_geoms))
 
         geometries = []
-        for ext in exts:
-            land_geoms = land_feats.intersecting_geometries(ext)
-            land_geoms = unary_union(list(land_geoms))
+        if not land_geoms.is_empty:
+            lake_feats = cfeature.NaturalEarthFeature("physical", "lakes", scale=scale)
 
-            if land_geoms.is_empty:
-                continue
-
-            lake_geoms = lake_feats.intersecting_geometries(ext)
+            lake_geoms = lake_feats.intersecting_geometries(extent)
             lake_geoms = unary_union(list(lake_geoms))
 
             geometries.append(land_geoms.difference(lake_geoms))
@@ -177,7 +162,7 @@ class MapPlotter(Plotter):
         extent: list,
         figuresize: list,
         dpi: int,
-    ) -> Figure | Axes:
+    ) -> tuple:
 
         CACHE_DIR = settings.cache_dir
         filename = self._get_filename(self.plot_projection.proj4_params["proj"], extent)
@@ -916,6 +901,7 @@ class MapPlotter(Plotter):
                 self.longitude,
                 self.latitude,
                 self.bathymetry,
+                transform_first=True,
                 linewidths=0.5,
                 norm=FuncNorm(
                     (lambda x: np.log10(x), lambda x: 10**x), vmin=1, vmax=6000


### PR DESCRIPTION
## Background
This address three bugs in the area plotter and cleans up some inefficient code:
- Correctly removes lakes from the basemap layer so that inland datasets (e.g. WCPS) are visible in the plot.
- Correctly wraps bathymetry contours at edges of projection
- Fix plot size bounding logic to prevent edge case errors

## Why did you take this approach?
The geometry splitting approach used previous doesn't seem to fix issues at the projection bounds and adds a lot of unnecessary code.

## Anything in particular that should be highlighted?
There are still some edge cases where the orientation of area polygons crossing the dateline in all projections can get reversed. To prevent this it might be best to get the centroid from the feature in the UI map component and include it with the plot query.

## Checks
- [X] I ran unit tests.
- [X] I've tested the relevant changes from a user POV.
- [X] I've formatted my Python code using `black .`.
